### PR TITLE
feat: Add admin support in registry contract

### DIFF
--- a/registry/contract/src/lib.rs
+++ b/registry/contract/src/lib.rs
@@ -278,32 +278,21 @@ mod tests {
 
     #[test]
     fn list_admins() {
+        let admins = vec![
+            Admin {
+                account_id: AccountId::new_unchecked("bob.near".to_string()),
+                role: AdminRole::Owner,
+            },
+            Admin {
+                account_id: AccountId::new_unchecked("flatirons.near".to_string()),
+                role: AdminRole::Moderator,
+            },
+        ];
         let contract = Contract {
             registry: HashMap::new(),
-            admins: vec![
-                Admin {
-                    account_id: AccountId::new_unchecked("bob.near".to_string()),
-                    role: AdminRole::Owner,
-                },
-                Admin {
-                    account_id: AccountId::new_unchecked("flatirons.near".to_string()),
-                    role: AdminRole::Moderator,
-                },
-            ],
+            admins: admins.clone(),
         };
-        assert_eq!(
-            contract.list_admins(),
-            vec![
-                Admin {
-                    account_id: AccountId::new_unchecked("bob.near".to_string()),
-                    role: AdminRole::Owner,
-                },
-                Admin {
-                    account_id: AccountId::new_unchecked("flatirons.near".to_string()),
-                    role: AdminRole::Moderator,
-                },
-            ],
-        );
+        assert_eq!(contract.list_admins(), admins);
     }
 
     #[test]


### PR DESCRIPTION
This PR adds the concept of 'admins' to the registry contract, allowing us to restrict execution of certain methods to a select group. There are two types of admins:
1. `Owner` - defined within the smart contract, can execute everything
2. `Moderators` - can be invited by a `Super` admin, can execute most things

Note that there's no specific logic which says `Owner` admins can execute everything and `Moderators` can't, that's down to the restrictions set within each individual function.

As the contract state has changed I've added a private `migrate()` function which will be needed to migrate the state to the new format. This will need to be called immediately after the new contract code has been deployed.