### PR TITLE
refactor: Group indexer functions by account ID

### DIFF
--- a/registry/contract/src/lib.rs
+++ b/registry/contract/src/lib.rs
@@ -386,14 +386,6 @@ impl Contract {
             None => AccountOrAllIndexers::from(&self.registry),
         }
     }
-
-    // #[private]
-    // #[init(ignore_state)]
-    pub fn clean(keys: Vec<Base64VecU8>) {
-        for key in keys.iter() {
-            env::storage_remove(&key.0);
-        }
-    }
 }
 
 /*


### PR DESCRIPTION
This points to #19, I've separated it in to it's own PR to make reviewing easier. The migration from #19 has been extended to also handle migrating registry state. To make things easier both this PR and #19 should be merged/deployed/migrated together.

This PR updates the registry state structure to group indexer functions by account ID, all functions will now be stored under the account ID like so:
```
{
    AccountId("morgs.near"): {
        "test": IndexerConfig {
            code: "return block;",
            start_block_height: None,
            schema: None,
        },
        "test2": IndexerConfig {
            code: "return block2;",
            start_block_height: None,
            schema: None,
        },
    },
}
```
As opposed to concatenating account ID/function name and storing it as its own top level entry like so:
```
{
  "morgs.near/test": IndexerConfig {
        code: "return block;",
        start_block_height: None,
        schema: None,
    },
    "morgs.near/test2": IndexerConfig {
        code: "return block2;",
        start_block_height: None,
        schema: None,
    },
}
```