### PR TITLE
fix: Ensure SQS visibility timeout is larger than lambda timeout

### DIFF
--- a/indexer-js-queue-handler/serverless.yml
+++ b/indexer-js-queue-handler/serverless.yml
@@ -17,10 +17,12 @@ constructs:
     type: queue
     worker:
       handler: handler.consumer
+      timeout: 60 # 6 minutes as lift multiplies this value by 6 (https://github.com/getlift/lift/blob/master/docs/queue.md#retry-delay)
   startFromBlock-runner:
     type: queue
     worker:
       handler: handler.consumer
+      timeout: 60 # 6 minutes as lift multiplies this value by 6 (https://github.com/getlift/lift/blob/master/docs/queue.md#retry-delay)
 
 functions:
 


### PR DESCRIPTION
Serverless requires the SQS visibility timeout must be larger than the lambda timeout.
