### PR TITLE
feat: seperation of environments to support dev widgets

### DIFF
--- a/frontend/widgets/src/QueryApi.App.jsx
+++ b/frontend/widgets/src/QueryApi.App.jsx
@@ -1,0 +1,26 @@
+const GRAPHQL_ENDPOINT =
+  "https://queryapi-hasura-graphql-24ktefolwq-ew.a.run.app";
+const APP_OWNER = "dataplatform.near";
+const EXTERNAL_APP_URL = "https://queryapi-frontend-24ktefolwq-ew.a.run.app";
+const REGISTRY_CONTRACT_ID = "queryapi.dataplatform.near";
+
+const view = props.view;
+const path = props.path;
+const tab = props.tab;
+const selectedIndexerPath = props.selectedIndexerPath;
+
+return (
+  <Widget
+    src={`${APP_OWNER}/widget/QueryApi.Dashboard`}
+    props={{
+      GRAPHQL_ENDPOINT,
+      APP_OWNER,
+      EXTERNAL_APP_URL,
+      REGISTRY_CONTRACT_ID,
+      view,
+      path,
+      tab,
+      selectedIndexerPath,
+    }}
+  />
+);

--- a/frontend/widgets/src/QueryApi.Dashboard.jsx
+++ b/frontend/widgets/src/QueryApi.Dashboard.jsx
@@ -6,11 +6,16 @@ const [selected_accountId, selected_indexerName] = props.selectedIndexerPath
 const activeTab = props.view ?? "public-indexers";
 const limit = 7;
 let totalIndexers = 0;
-const registry_contract_id =
-  props.registry_contract_id || "queryapi.dataplatform.near";
-const APP_OWNER = "roshaan.near";
-const GRAPHQL_ENDPOINT =  'https://queryapi-hasura-graphql-24ktefolwq-ew.a.run.app' 
+const REGISTRY_CONTRACT_ID =
+  props.REGISTRY_CONTRACT_ID || "queryapi.dataplatform.near";
+const APP_OWNER = props.APP_OWNER || "dataplatform.near";
+const GRAPHQL_ENDPOINT =
+  props.GRAPHQL_ENDPOINT ||
+  "https://queryapi-hasura-graphql-24ktefolwq-ew.a.run.app";
+const EXTERNAL_APP_URL =
+  props.EXTERNAL_APP_URL || "https://queryapi-frontend-24ktefolwq-ew.a.run.app";
 
+let appPath = props.isDev ? "dev-App" : "App";
 State.init({
   activeTab: activeTab,
   my_indexers: [],
@@ -19,7 +24,7 @@ State.init({
   selected_account: undefined,
 });
 
-Near.asyncView(registry_contract_id, "list_indexer_functions").then((data) => {
+Near.asyncView(REGISTRY_CONTRACT_ID, "list_indexer_functions").then((data) => {
   const indexers = [];
   const total_indexers = 0;
   Object.keys(data.All).forEach((accountId) => {
@@ -303,9 +308,9 @@ const indexerView = (accountId, indexerName, idx, view) => {
       idx === 0) ||
     (selected_accountId === accountId && selected_indexerName === indexerName);
 
-  const editUrl = `https://near.org/#/${APP_OWNER}/widget/QueryApi.Dashboard?selectedIndexerPath=${accountId}/${indexerName}&view=editor-window`;
-  const statusUrl = `https://near.org/#/${APP_OWNER}/widget/QueryApi.Dashboard?selectedIndexerPath=${accountId}/${indexerName}&view=indexer-status`;
-  // const playgroundLink = `https://near.org/#/${APP_OWNER}/widget/QueryApi.Dashboard?selectedIndexerPath=${accountId}/${indexerName}&view=editor-window&tab=playground`;
+  const editUrl = `https://near.org/#/${APP_OWNER}/widget/QueryApi.${appPath}?selectedIndexerPath=${accountId}/${indexerName}&view=editor-window`;
+  const statusUrl = `https://near.org/#/${APP_OWNER}/widget/QueryApi.${appPath}?selectedIndexerPath=${accountId}/${indexerName}&view=indexer-status`;
+  // const playgroundLink = `https://near.org/#/${APP_OWNER}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}&view=editor-window&tab=playground`;
   const playgroundLink = `https://cloud.hasura.io/public/graphiql?endpoint=${GRAPHQL_ENDPOINT}/v1/graphql&header=x-hasura-role%3A${accountId.replaceAll(
     ".",
     "_"
@@ -314,7 +319,7 @@ const indexerView = (accountId, indexerName, idx, view) => {
   let removeIndexer = (name) => {
     const gas = 200000000000000;
     Near.call(
-      registry_contract_id,
+      REGISTRY_CONTRACT_ID,
       "remove_indexer_function",
       {
         function_name: name,
@@ -431,7 +436,7 @@ return (
     <Main>
       <Section active={state.activeTab === "indexers"}>
         <NavBarLogo
-          href={`https://alpha.near.org/#/${APP_OWNER}/widget/QueryApi.Dashboard`}
+          href={`https://near.org/#/${APP_OWNER}/widget/QueryApi.${appPath}`}
           title="QueryApi"
           onClick={() => {
             State.update({
@@ -455,7 +460,7 @@ return (
 
         <div>
           <ButtonLink
-            href={`/#/${APP_OWNER}/widget/QueryApi.Dashboard/?view=create-new-indexer`}
+            href={`/#/${APP_OWNER}/widget/QueryApi.${appPath}/?view=create-new-indexer`}
             style={{ "margin-top": "10px" }}
             onClick={() =>
               State.update({
@@ -499,6 +504,10 @@ return (
                 indexer_name:
                   selected_indexerName ?? state.indexers[0].indexerName,
                 accountId: selected_accountId ?? state.indexers[0].accountId,
+                EXTERNAL_APP_URL,
+                REGISTRY_CONTRACT_ID,
+                GRAPHQL_ENDPOINT,
+                APP_OWNER,
               }}
             />
           </div>
@@ -523,6 +532,10 @@ return (
                 accountId: selected_accountId ?? state.indexers[0].accountId,
                 path: "query-api-editor",
                 tab: props.tab,
+                EXTERNAL_APP_URL,
+                REGISTRY_CONTRACT_ID,
+                GRAPHQL_ENDPOINT,
+                APP_OWNER,
               }}
             />
           </div>
@@ -542,6 +555,10 @@ return (
                   selected_indexerName ?? state.indexers[0].indexerName,
                 accountId: selected_accountId ?? state.indexers[0].accountId,
                 path: "create-new-indexer",
+                EXTERNAL_APP_URL,
+                REGISTRY_CONTRACT_ID,
+                GRAPHQL_ENDPOINT,
+                APP_OWNER,
               }}
             />
           </div>

--- a/frontend/widgets/src/QueryApi.Editor.jsx
+++ b/frontend/widgets/src/QueryApi.Editor.jsx
@@ -1,10 +1,11 @@
 const path = props.path || "query-api-editor";
 const tab = props.tab || "";
-const registry_contract_id =
-  props.registry_contract_id || "queryapi.dataplatform.near";
+const REGISTRY_CONTRACT_ID =
+  props.REGISTRY_CONTRACT_ID || "queryapi.dataplatform.near";
 let accountId = props.accountId || context.accountId;
-
-let externalAppUrl = `https://queryapi-frontend-vcqilefdcq-ew.a.run.app/${path}?accountId=${accountId}`;
+let externalAppUrl =
+  props.EXTERNAL_APP_URL || "https://queryapi-frontend-24ktefolwq-ew.a.run.app";
+externalAppUrl += `/${path}?accountId=${accountId}`;
 // let externalAppUrl = `http://localhost:3000/${path}?accountId=${accountId}`;
 
 if (props.indexerName) {
@@ -31,7 +32,7 @@ const registerFunctionHandler = (request, response) => {
   // }
 
   Near.call(
-    registry_contract_id,
+    REGISTRY_CONTRACT_ID,
     "register_indexer_function",
     {
       function_name: indexerName,

--- a/frontend/widgets/src/QueryApi.IndexerStatus.jsx
+++ b/frontend/widgets/src/QueryApi.IndexerStatus.jsx
@@ -2,6 +2,7 @@
 const indexer_name = props.indexer_name;
 
 const GRAPHQL_ENDPOINT =
+  props.GRAPHQL_ENDPOINT ||
   "https://queryapi-hasura-graphql-24ktefolwq-ew.a.run.app";
 const LIMIT = 10;
 const accountId = props.accountId || context.accountId;
@@ -103,7 +104,7 @@ State.init({
 });
 
 function fetchGraphQL(operationsDoc, operationName, variables) {
-return asyncFetch(`${GRAPHQL_ENDPOINT}/v1/graphql`, {
+  return asyncFetch(`${GRAPHQL_ENDPOINT}/v1/graphql`, {
     method: "POST",
     body: JSON.stringify({
       query: operationsDoc,

--- a/frontend/widgets/src/QueryApi.dev-App.jsx
+++ b/frontend/widgets/src/QueryApi.dev-App.jsx
@@ -1,0 +1,25 @@
+const GRAPHQL_ENDPOINT = "https://query-api-hasura-vcqilefdcq-uc.a.run.app/";
+const APP_OWNER = "dev-queryapi.dataplatform.near";
+const EXTERNAL_APP_URL = "https://queryapi-frontend-vcqilefdcq-ew.a.run.app";
+const REGISTRY_CONTRACT_ID = "dev-queryapi.dataplatform.near";
+const view = props.view;
+const path = props.path;
+const tab = props.tab;
+const selectedIndexerPath = props.selectedIndexerPath;
+
+return (
+  <Widget
+    src={`${APP_OWNER}/widget/QueryApi.Dashboard`}
+    props={{
+      GRAPHQL_ENDPOINT,
+      APP_OWNER,
+      EXTERNAL_APP_URL,
+      REGISTRY_CONTRACT_ID,
+      view,
+      path,
+      tab,
+      selectedIndexerPath,
+      isDev: true,
+    }}
+  />
+);


### PR DESCRIPTION
This PR introduces two new widgets.    QueryApi.App and QueryApi.dev-App.

Each of them pass their own initial props depending upon their environment.

Dev App can be opened through this link: near.org/dev-queryapi.dataplatform.near/widget/QueryApi.dev-App
Or near.org/dataplatform.near/widget/QueryApi.dev-App

**Prod App can be opened through near.org/dataplatform.near/widget/QueryApi.App**