### PR TITLE
fix: Update coodinator published metrics names

### DIFF
--- a/indexer/queryapi_coordinator/src/metrics.rs
+++ b/indexer/queryapi_coordinator/src/metrics.rs
@@ -5,12 +5,12 @@ use tracing::info;
 
 lazy_static! {
     pub(crate) static ref LATEST_BLOCK_HEIGHT: IntGauge = try_create_int_gauge(
-        "indexer_explorer_latest_block_height",
+        "queryapi_coordinator_latest_block_height",
         "Height of last processed block"
     )
     .unwrap();
     pub(crate) static ref BLOCK_COUNT: IntCounter =
-        try_create_int_counter("indexer_explorer_block_count", "Number of indexed blocks").unwrap();
+        try_create_int_counter("queryapi_coordinator_block_count", "Number of indexed blocks").unwrap();
 }
 
 fn try_create_int_gauge(name: &str, help: &str) -> prometheus::Result<IntGauge> {


### PR DESCRIPTION
Copy/paste error from Explorer Indexer.. 😬 