### PR TITLE
Handling changed FunctionCall args type

### DIFF
--- a/indexer/queryapi_coordinator/src/metrics.rs
+++ b/indexer/queryapi_coordinator/src/metrics.rs
@@ -9,8 +9,11 @@ lazy_static! {
         "Height of last processed block"
     )
     .unwrap();
-    pub(crate) static ref BLOCK_COUNT: IntCounter =
-        try_create_int_counter("queryapi_coordinator_block_count", "Number of indexed blocks").unwrap();
+    pub(crate) static ref BLOCK_COUNT: IntCounter = try_create_int_counter(
+        "queryapi_coordinator_block_count",
+        "Number of indexed blocks"
+    )
+    .unwrap();
 }
 
 fn try_create_int_gauge(name: &str, help: &str) -> prometheus::Result<IntGauge> {

--- a/indexer/queryapi_coordinator/src/outcomes_reducer/indexer_reducer.rs
+++ b/indexer/queryapi_coordinator/src/outcomes_reducer/indexer_reducer.rs
@@ -65,21 +65,19 @@ fn build_registry_info(
                 } = action
                 {
                     match std::str::from_utf8(args) {
-                        Ok(args) => {
-                            Some(FunctionCallInfo {
-                                chain_id: context.chain_id.clone(),
-                                alert_rule_id: alert_rule.id,
-                                alert_name: alert_rule.name.clone(),
-                                signer_id: signer_id.to_string(),
-                                method_name: method_name.to_string(),
-                                args: args.to_string(),
-                                block_height: context.streamer_message.block.header.height,
-                            })
-                        }
+                        Ok(args) => Some(FunctionCallInfo {
+                            chain_id: context.chain_id.clone(),
+                            alert_rule_id: alert_rule.id,
+                            alert_name: alert_rule.name.clone(),
+                            signer_id: signer_id.to_string(),
+                            method_name: method_name.to_string(),
+                            args: args.to_string(),
+                            block_height: context.streamer_message.block.header.height,
+                        }),
                         Err(_) => {
                             tracing::error!("Failed to deserialize args");
                             None
-                        },
+                        }
                     }
                 } else {
                     None


### PR DESCRIPTION
Has been tested locally.

This has just the fix.
Better error handling around all the args is in PR 52.