### PR TITLE
fix: Write prometheus metrics after successful processing of block

### DIFF
--- a/indexer/queryapi_coordinator/src/main.rs
+++ b/indexer/queryapi_coordinator/src/main.rs
@@ -94,10 +94,6 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!(target: INDEXER, "Starting queryapi_coordinator...",);
     let mut handlers = tokio_stream::wrappers::ReceiverStream::new(stream)
         .map(|streamer_message| {
-            metrics::BLOCK_COUNT.inc();
-            metrics::LATEST_BLOCK_HEIGHT
-                .set(streamer_message.block.header.height.try_into().unwrap());
-
             let context = QueryApiContext {
                 redis_connection_manager: &redis_connection_manager,
                 queue_url: &queue_url,
@@ -210,6 +206,17 @@ async fn handle_streamer_message(
         context.streamer_message.block.header.height,
     )
     .await?;
+
+    metrics::BLOCK_COUNT.inc();
+    metrics::LATEST_BLOCK_HEIGHT.set(
+        context
+            .streamer_message
+            .block
+            .header
+            .height
+            .try_into()
+            .unwrap(),
+    );
 
     Ok(context.streamer_message.block.header.height)
 }

--- a/indexer/storage/src/lib.rs
+++ b/indexer/storage/src/lib.rs
@@ -50,7 +50,6 @@ pub async fn get<V: FromRedisValue + std::fmt::Debug>(
     tracing::debug!(target: STORAGE, "GET: {:?}: {:?}", &key, &value,);
     Ok(value)
 }
-
 /// Sets the key `receipt_id: &str` with value `transaction_hash: &str` to the Redis storage.
 /// Increments the counter `receipts_{transaction_hash}` by one.
 /// The counter holds how many Receipts related to the Transaction are in watching list


### PR DESCRIPTION
Metrics are written before processing the block, so even if the processing fails the metrics continue to increase. This PR moves it to the end of processing so metrics aren't written if processing fails.