### PR TITLE
fix: allow cors on all domains

### DIFF
--- a/block-server/handler.js
+++ b/block-server/handler.js
@@ -3,18 +3,12 @@ const AWS = require('aws-sdk');
 const S3= new AWS.S3();
 
 const NETWORK = process.env.NETWORK || 'mainnet';
-const allowedOrigins = ['https://queryapi-frontend-24ktefolwq-ew.a.run.app', 'https://queryapi-frontend-vcqilefdcq-ew.a.run.app'];
 
 module.exports.block = async (event) => {
-  // Set CORS headers 
-  const origin = event.headers.origin;
-  let headers = {};
-  if (allowedOrigins.includes(origin)) {
-    headers = {
-      "Access-Control-Allow-Origin": origin,
-      "Access-Control-Allow-Credentials": true,
-    };
-  }
+  let headers = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Credentials": true,
+  };
 
   try {
     // parse request params

--- a/block-server/serverless.yml
+++ b/block-server/serverless.yml
@@ -46,6 +46,7 @@ functions:
       - httpApi:
           path: /block/{block_height}
           method: get
+          cors: true
 
 #    Define function environment variables here
 #    environment:


### PR DESCRIPTION
To unblock us, I am allows cors on all domains at the domain. Our previous approach of whitelisting sites did not go through.    I think it has to do with how the VM acts. 

We can keep the ticket for figuring out a way to authenticate on access to this endpoint