### PR TITLE
[DPLT-1044] Write latest near.org post block height to Grafana

### DIFF
--- a/indexer-js-queue-handler/latest-post-metrics-writer.js
+++ b/indexer-js-queue-handler/latest-post-metrics-writer.js
@@ -1,0 +1,24 @@
+import fetch from "node-fetch";
+import AWS from "aws-sdk";
+
+import Metrics from "./metrics";
+
+export const handler = async () => {
+    const metrics = new Metrics("QueryAPI");
+
+    const response = await fetch("https://api.near.social/index", {
+        method: "POST",
+        body: JSON.stringify({
+            action: "post",
+            key: "main",
+            options: {
+                limit: 1,
+                order: "desc",
+            },
+        }),
+    });
+
+    const [{ blockHeight }] = await response.json();
+
+    await metrics.putBlockHeight("social.near", "posts", blockHeight);
+};

--- a/indexer-js-queue-handler/serverless.yml
+++ b/indexer-js-queue-handler/serverless.yml
@@ -39,6 +39,10 @@ constructs:
       timeout: 15 # 1.5 minutes as lift multiplies this value by 6 (https://github.com/getlift/lift/blob/master/docs/queue.md#retry-delay)
 
 functions:
+  latestPostMetricsWriter:
+    handler: latest-post-metrics-writer.handler
+    events:
+      - schedule: rate(1 minute)
 
 plugins:
   - serverless-lift


### PR DESCRIPTION
This PR adds creates a scheduled (every 1min) lambda which fetches the lastest post block height from `api.near.social` and writes it to CloudWatch metrics, which eventually ends up in Grafana. This will allow us to calculate the delta from the QueryAPI powered feed indexer.

`api.near.social` is currently used by `near.org` to fetch all posts which populate the main feed. I'd prefer to use the `social.near` contract directly but it doesn't seem feasible to do so. The contract stores more than just posts, and we'd essentially need to store a replica locally to parse out the pieces of information (posts) we are concerned about - exactly what the API does.
