### PR TITLE
Chore: Update explorer plugin

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,8 +10,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@graphiql/plugin-explorer": "^0.1.20",
-    "@graphiql/plugin-code-exporter": "^0.1.2",
+    "@graphiql/plugin-explorer": "0.3.0",
+    "@graphiql/plugin-code-exporter": "0.3.0",
     "@monaco-editor/react": "^4.1.3",
     "@near-lake/primitives": "0.1.0",
     "@next/font": "13.1.6",

--- a/frontend/src/components/Playground/graphiql.jsx
+++ b/frontend/src/components/Playground/graphiql.jsx
@@ -1,9 +1,9 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useState, useMemo } from "react";
 import GraphiQL from "graphiql";
 import { sessionStorage } from "near-social-bridge";
 import { IndexerDetailsContext } from '../../contexts/IndexerDetailsContext';
-import { useExporterPlugin } from '@graphiql/plugin-code-exporter';
-import { useExplorerPlugin } from '@graphiql/plugin-explorer';
+import { codeExporterPlugin } from '@graphiql/plugin-code-exporter';
+import { explorerPlugin } from '@graphiql/plugin-explorer';
 import "graphiql/graphiql.min.css";
 import '@graphiql/plugin-code-exporter/dist/style.css';
 import '@graphiql/plugin-explorer/dist/style.css';
@@ -98,30 +98,20 @@ return (
   }
 };
 
+
+const explorer = explorerPlugin();
+
 export const GraphqlPlayground = () => {
   const { indexerDetails } = useContext(IndexerDetailsContext);
-  const snippets = [bosQuerySnippet(indexerDetails.accountId)];
-  const [query, setQuery] = useState("");
-
-  const explorerPlugin = useExplorerPlugin({
-    query,
-    onEdit: setQuery,
-  });
-  const exporterPlugin = useExporterPlugin({
-    query,
-    snippets,
-    codeMirrorTheme: 'graphiql',
-  });
+  const snippets = useMemo(()=>[bosQuerySnippet(indexerDetails.accountId)], [indexerDetails.accountId]);
+  const exporter = useMemo(()=> codeExporterPlugin({snippets}), [snippets])
 
   return (
     <div style={{ width: "100%", height: "75vh" }}>
       <GraphiQL
-        query={query}
-        onEditQuery={setQuery}
         fetcher={(params) => graphQLFetcher(params, indexerDetails.accountId)}
-        defaultQuery=""
         storage={sessionStorage}
-        plugins={[explorerPlugin, exporterPlugin]}
+        plugins={[exporter, explorer]}
       />
     </div>
   );


### PR DESCRIPTION
There were a [few breaking changes](https://github.com/graphql/graphiql/releases/tag/%40graphiql%2Fplugin-explorer%400.3.0) in the plugins we used. 

I have updated the version numbers to restore the functionality.

