### PR TITLE
DPLT-1042 Enable `backend_only` mutations by default

### DIFF
--- a/indexer-js-queue-handler/__snapshots__/hasura-client.test.js.snap
+++ b/indexer-js-queue-handler/__snapshots__/hasura-client.test.js.snap
@@ -24,6 +24,7 @@ exports[`HasuraClient adds the specified permissions for the specified roles/tab
     {
       "args": {
         "permission": {
+          "backend_only": true,
           "check": {},
           "columns": "*",
           "computed_fields": [],
@@ -37,6 +38,42 @@ exports[`HasuraClient adds the specified permissions for the specified roles/tab
         },
       },
       "type": "pg_create_insert_permission",
+    },
+    {
+      "args": {
+        "permission": {
+          "backend_only": true,
+          "check": {},
+          "columns": "*",
+          "computed_fields": [],
+          "filter": {},
+        },
+        "role": "role",
+        "source": "default",
+        "table": {
+          "name": "height",
+          "schema": "schema",
+        },
+      },
+      "type": "pg_create_update_permission",
+    },
+    {
+      "args": {
+        "permission": {
+          "backend_only": true,
+          "check": {},
+          "columns": "*",
+          "computed_fields": [],
+          "filter": {},
+        },
+        "role": "role",
+        "source": "default",
+        "table": {
+          "name": "height",
+          "schema": "schema",
+        },
+      },
+      "type": "pg_create_delete_permission",
     },
     {
       "args": {
@@ -59,6 +96,7 @@ exports[`HasuraClient adds the specified permissions for the specified roles/tab
     {
       "args": {
         "permission": {
+          "backend_only": true,
           "check": {},
           "columns": "*",
           "computed_fields": [],
@@ -72,6 +110,42 @@ exports[`HasuraClient adds the specified permissions for the specified roles/tab
         },
       },
       "type": "pg_create_insert_permission",
+    },
+    {
+      "args": {
+        "permission": {
+          "backend_only": true,
+          "check": {},
+          "columns": "*",
+          "computed_fields": [],
+          "filter": {},
+        },
+        "role": "role",
+        "source": "default",
+        "table": {
+          "name": "width",
+          "schema": "schema",
+        },
+      },
+      "type": "pg_create_update_permission",
+    },
+    {
+      "args": {
+        "permission": {
+          "backend_only": true,
+          "check": {},
+          "columns": "*",
+          "computed_fields": [],
+          "filter": {},
+        },
+        "role": "role",
+        "source": "default",
+        "table": {
+          "name": "width",
+          "schema": "schema",
+        },
+      },
+      "type": "pg_create_delete_permission",
     },
   ],
   "type": "bulk",

--- a/indexer-js-queue-handler/hasura-client.js
+++ b/indexer-js-queue-handler/hasura-client.js
@@ -230,7 +230,9 @@ export default class HasuraClient {
                 check: {},
                 computed_fields: [],
                 filter: {},
-                ...(permission == 'select' && { allow_aggregations: true })
+                ...(permission === "select"
+                  ? { allow_aggregations: true }
+                  : { backend_only: true }),
               },
               source: 'default'
             },

--- a/indexer-js-queue-handler/hasura-client.test.js
+++ b/indexer-js-queue-handler/hasura-client.test.js
@@ -114,7 +114,7 @@ describe('HasuraClient', () => {
             });
         const client = new HasuraClient({ fetch })
 
-        await client.addPermissionsToTables('schema', ['height', 'width'], 'role', ['select', 'insert']);
+        await client.addPermissionsToTables('schema', ['height', 'width'], 'role', ['select', 'insert', 'update', 'delete']);
 
         expect(fetch.mock.calls[0][1].headers['X-Hasura-Admin-Secret']).toBe(HASURA_ADMIN_SECRET)
         expect(JSON.parse(fetch.mock.calls[0][1].body)).toMatchSnapshot();


### PR DESCRIPTION
This PR enables [backend_only](https://hasura.io/docs/latest/auth/authorization/permissions/backend-only/) mutations by default for `insert`, `update`, and `delete` permissions. Meaning all mutations can only be written to by those with the admin secret, i.e. the backend.

If we think necessary, I can also backfill all current roles/tables to also enable this role.