### PR TITLE
chore: Add `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @near/queryapi-core


### PR DESCRIPTION
Adds `@near/queryapi-core` team as owners of all files. Right now the team only includes me, if we are happy with this change i'll all other core devs.