### PR TITLE
DPLT-1044 Expose context method for writing custom Grafana metrics

### DIFF
--- a/indexer-js-queue-handler/__snapshots__/metrics.test.js.snap
+++ b/indexer-js-queue-handler/__snapshots__/metrics.test.js.snap
@@ -18,6 +18,10 @@ exports[`Metrics writes the block height for an indexer function 1`] = `
             "Name": "STAGE",
             "Value": "dev",
           },
+          {
+            "Name": "HISTORICAL",
+            "Value": false,
+          },
         ],
         "MetricName": "INDEXER_FUNCTION_LATEST_BLOCK_HEIGHT",
         "Unit": "None",

--- a/indexer-js-queue-handler/indexer.js
+++ b/indexer-js-queue-handler/indexer.js
@@ -254,7 +254,16 @@ export default class Indexer {
             },
             log: async (log) => {
                 return await this.writeLog(functionName, block_height, log);
-            }
+            },
+            putMetric: (name, value) => {
+                const [accountId, fnName] = functionName.split('/');
+                return this.deps.metrics.putCustomMetric(
+                    accountId,
+                    fnName,
+                    `CUSTOM_${name}`,
+                    value
+                );
+            },
         };
     }
 

--- a/indexer-js-queue-handler/indexer.js
+++ b/indexer-js-queue-handler/indexer.js
@@ -46,7 +46,7 @@ export default class Indexer {
                 functionSubsegment.addAnnotation('indexer_function', function_name);
                 simultaneousPromises.push(this.writeLog(function_name, block_height, runningMessage));
 
-                simultaneousPromises.push(this.deps.metrics.putBlockHeight(indexerFunction.account_id, indexerFunction.function_name, block_height));
+                simultaneousPromises.push(this.deps.metrics.putBlockHeight(indexerFunction.account_id, indexerFunction.function_name, is_historical, block_height));
 
                 const hasuraRoleName = function_name.split('/')[0].replace(/[.-]/g, '_');
                 const functionNameWithoutAccount = function_name.split('/')[1].replace(/[.-]/g, '_');
@@ -74,7 +74,7 @@ export default class Indexer {
                 const vm = new VM({timeout: 3000, allowAsync: true});
                 const mutationsReturnValue = {mutations: [], variables: {}, keysValues: {}};
                 const context = options.imperative
-                    ? this.buildImperativeContextForFunction(function_name, functionNameWithoutAccount, block_height, hasuraRoleName)
+                    ? this.buildImperativeContextForFunction(function_name, functionNameWithoutAccount, block_height, hasuraRoleName, is_historical)
                     : this.buildFunctionalContextForFunction(mutationsReturnValue, function_name, block_height);
 
                 vm.freeze(blockWithHelpers, 'block');
@@ -225,7 +225,7 @@ export default class Indexer {
         };
     }
 
-    buildImperativeContextForFunction(functionName, functionNameWithoutAccount,  block_height, hasuraRoleName) {
+    buildImperativeContextForFunction(functionName, functionNameWithoutAccount,  block_height, hasuraRoleName, is_historical) {
         return {
             graphql: async (operation, variables) => {
                 try {
@@ -260,6 +260,7 @@ export default class Indexer {
                 return this.deps.metrics.putCustomMetric(
                     accountId,
                     fnName,
+                    is_historical,
                     `CUSTOM_${name}`,
                     value
                 );

--- a/indexer-js-queue-handler/indexer.test.js
+++ b/indexer-js-queue-handler/indexer.test.js
@@ -821,7 +821,7 @@ mutation _1 { set(functionName: "buildnear.testnet/test", key: "foo2", data: "in
         };
         await indexer.runFunctions(block_height, functions, false);
 
-        expect(metrics.putBlockHeight).toHaveBeenCalledWith('buildnear.testnet', 'test', block_height);
+        expect(metrics.putBlockHeight).toHaveBeenCalledWith('buildnear.testnet', 'test', false, block_height);
     });
 
     test('does not attach the hasura admin secret header when no role specified', async () => {
@@ -927,11 +927,12 @@ mutation _1 { set(functionName: "buildnear.testnet/test", key: "foo2", data: "in
         functions['buildnear.testnet/test'] = {code:`
             context.putMetric('TEST_METRIC', 1)
         `};
-        await indexer.runFunctions(block_height, functions, false, { imperative: true });
+        await indexer.runFunctions(block_height, functions, true, { imperative: true });
 
         expect(metrics.putCustomMetric).toHaveBeenCalledWith(
             'buildnear.testnet',
             'test',
+            true,
             'CUSTOM_TEST_METRIC',
             1
         );

--- a/indexer-js-queue-handler/metrics.js
+++ b/indexer-js-queue-handler/metrics.js
@@ -7,11 +7,11 @@ export default class Metrics {
         this.namespace = namespace;
     }
 
-    putBlockHeight(accountId, functionName, height) {
-        return this.putCustomMetric(accountId, functionName, "INDEXER_FUNCTION_LATEST_BLOCK_HEIGHT", height);
+    putBlockHeight(accountId, functionName, isHistorical, height) {
+        return this.putCustomMetric(accountId, functionName, isHistorical, "INDEXER_FUNCTION_LATEST_BLOCK_HEIGHT", height);
     }
 
-    putCustomMetric(accountId, functionName, metricName, value) {
+    putCustomMetric(accountId, functionName, isHistorical, metricName, value) {
         return this.cloudwatch
             .putMetricData({
                 MetricData: [
@@ -29,6 +29,10 @@ export default class Metrics {
                             {
                                 Name: "STAGE",
                                 Value: process.env.STAGE,
+                            },
+                            {
+                                Name: "HISTORICAL",
+                                Value: isHistorical,
                             },
                         ],
                         Unit: "None",

--- a/indexer-js-queue-handler/metrics.js
+++ b/indexer-js-queue-handler/metrics.js
@@ -8,11 +8,15 @@ export default class Metrics {
     }
 
     putBlockHeight(accountId, functionName, height) {
+        return this.putCustomMetric(accountId, functionName, "INDEXER_FUNCTION_LATEST_BLOCK_HEIGHT", height);
+    }
+
+    putCustomMetric(accountId, functionName, metricName, value) {
         return this.cloudwatch
             .putMetricData({
                 MetricData: [
                     {
-                        MetricName: "INDEXER_FUNCTION_LATEST_BLOCK_HEIGHT",
+                        MetricName: metricName,
                         Dimensions: [
                             {
                                 Name: "ACCOUNT_ID",
@@ -28,7 +32,7 @@ export default class Metrics {
                             },
                         ],
                         Unit: "None",
-                        Value: height,
+                        Value: value,
                     },
                 ],
                 Namespace: this.namespace,

--- a/indexer-js-queue-handler/metrics.test.js
+++ b/indexer-js-queue-handler/metrics.test.js
@@ -22,7 +22,7 @@ describe('Metrics', () => {
         };
         const metrics = new Metrics('test', cloudwatch);
 
-        await metrics.putBlockHeight('morgs.near', 'test', 2);
+        await metrics.putBlockHeight('morgs.near', 'test', false, 2);
 
         expect(cloudwatch.putMetricData).toBeCalledTimes(1);
         expect(cloudwatch.putMetricData.mock.calls[0]).toMatchSnapshot()


### PR DESCRIPTION
This PR exposes a new context method (`context.putMetric()`) to allow writing of arbitrary metrics to CloudWatch Metrics, and eventually Grafana.

The main driver for this change is to expose the 'latest post block height lag' of the Feed Indexer. This requires comparing the latest block height in Postgres/GraphQL, to the latest block height from `api.social.near`. To do this we could use a scheduled Lambda, but it would be extremely tailored to this one Indexer. This PR provides the necessary tools to do this within the Feed Indexer itself.

After merging and adding the metrics writing to the Feed Indexer, I'll remove the existing scheduled Lambda which writes an incorrect block height lag.