### PR TITLE
DPLT-1034 feat: allow to edit indexer when forking

### DIFF
--- a/frontend/src/components/Editor/Editor.js
+++ b/frontend/src/components/Editor/Editor.js
@@ -34,6 +34,7 @@ const Editor = ({
     debugMode,
     isCreateNewIndexer,
     indexerNameField,
+    setAccountId,
   } = useContext(IndexerDetailsContext);
 
   const DEBUG_LIST_STORAGE_KEY = `QueryAPI:debugList:${indexerDetails.accountId}#${indexerDetails.indexerName}`
@@ -127,10 +128,23 @@ const Editor = ({
     }
   };
 
+
+  const forkIndexer = async(indexerName) => {
+      let code = indexingCode;
+
+      setAccountId(currentUserAccountId)
+
+      let prevAccountId = indexerDetails.accountId.replaceAll(".", "_");
+      let newAccountId = currentUserAccountId.replaceAll(".", "_");
+      let prevIndexerName = indexerDetails.indexerName.replaceAll("-", "_").trim().toLowerCase();
+      let newIndexerName = indexerName.replaceAll("-", "_").trim().toLowerCase();
+      code = code.replaceAll(prevAccountId, newAccountId);
+      code = code.replaceAll(prevIndexerName, newIndexerName);
+      setIndexingCode(formatIndexingCode(code))
+  }
+
   const registerFunction = async (indexerName, indexerConfig) => {
     let formatted_schema = checkSQLSchemaFormatting();
-    let isForking = indexerDetails.accountId !== currentUserAccountId;
-
     let innerCode = indexingCode.match(/getBlock\s*\([^)]*\)\s*{([\s\S]*)}/)[1];
     indexerName = indexerName.replaceAll(" ", "_");
     if (formatted_schema == undefined) {
@@ -140,14 +154,6 @@ const Editor = ({
       );
       return;
     }
-
-    if (isForking) {
-      let prevAccountName = indexerDetails.accountId.replace(".", "_");
-      let newAccountName = currentUserAccountId.replace(".", "_");
-
-      innerCode = innerCode.replaceAll(prevAccountName, newAccountName);
-    }
-
     setError(() => undefined);
 
     request("register-function", {
@@ -170,8 +176,8 @@ const Editor = ({
   const handleReload = async () => {
     if (isCreateNewIndexer) {
       setShowResetCodeModel(false);
-      setIndexingCode(defaultCode);
-      setSchema(defaultSchema);
+      setIndexingCode((formatIndexingCode(indexerDetails.code)));
+      setSchema(formatSQL(indexerDetails.schema))
       return;
     }
 
@@ -331,7 +337,7 @@ const Editor = ({
         blockHeightError={blockHeightError}
       />
       <ForkIndexerModal
-        registerFunction={registerFunction}
+        forkIndexer={forkIndexer}
       />
 
       <div

--- a/frontend/src/components/Editor/Editor.js
+++ b/frontend/src/components/Editor/Editor.js
@@ -91,28 +91,6 @@ const Editor = ({
     localStorage.setItem(DEBUG_LIST_STORAGE_KEY, heights);
   }, [heights]);
 
-  // useEffect(() => {
-  //   if (selectedOption == "latestBlockHeight") {
-  //     setBlockHeightError(null);
-  //     return;
-  //   }
-  //
-  //   if (height - blockHeight > BLOCKHEIGHT_LIMIT) {
-  //     setBlockHeightError(
-  //       `Warning: Please enter a valid start block height. At the moment we only support historical indexing of the last ${BLOCKHEIGHT_LIMIT} blocks or ${BLOCKHEIGHT_LIMIT / 3600
-  //       } hrs. Choose a start block height between ${height - BLOCKHEIGHT_LIMIT
-  //       } - ${height}.`
-  //     );
-  //   } else if (blockHeight > height) {
-  //     setBlockHeightError(
-  //       `Warning: Start Block Hieght can not be in the future. Please choose a value between ${height - BLOCKHEIGHT_LIMIT
-  //       } - ${height}.`
-  //     );
-  //   } else {
-  //     setBlockHeightError(null);
-  //   }
-  // }, [blockHeight, height, selectedOption]);
-
   const checkSQLSchemaFormatting = () => {
     try {
       let formatted_sql = formatSQL(schema);
@@ -131,9 +109,7 @@ const Editor = ({
 
   const forkIndexer = async(indexerName) => {
       let code = indexingCode;
-
       setAccountId(currentUserAccountId)
-
       let prevAccountId = indexerDetails.accountId.replaceAll(".", "_");
       let newAccountId = currentUserAccountId.replaceAll(".", "_");
       let prevIndexerName = indexerDetails.indexerName.replaceAll("-", "_").trim().toLowerCase();

--- a/frontend/src/components/Editor/EditorButtons.jsx
+++ b/frontend/src/components/Editor/EditorButtons.jsx
@@ -72,7 +72,7 @@ const EditorButtons = ({
                 <Breadcrumb.Item className="flex align-center " href="#">
                   {accountId}
                 </Breadcrumb.Item>
-                  {!isCreateNewIndexer && (
+                  {indexerName && (
                 <Breadcrumb.Item href="#" active style={{ display: "flex" }}>
                  {indexerName}
                 </Breadcrumb.Item>
@@ -169,21 +169,33 @@ const EditorButtons = ({
                     <Justify style={{ paddingRight: "2px" }} size={24} />
                   </Button>
                 </OverlayTrigger>
-                {currentUserAccountId && (
+                {(!isUserIndexer && !isCreateNewIndexer) ? (
                   <OverlayTrigger
                     placement="bottom"
-                    overlay={<Tooltip>{getActionButtonText()}</Tooltip>}
+                    overlay={<Tooltip>Fork Indexer</Tooltip>}
+                  >
+                    <Button
+                      variant="primary"
+                      className="px-3"
+                      onClick={() => setShowForkIndexerModal(true)}
+                    >
+                      Fork Indexer
+                    </Button>
+                  </OverlayTrigger>
+                ) : (
+                  <OverlayTrigger
+                    placement="bottom"
+                    overlay={<Tooltip>Publish</Tooltip>}
                   >
                     <Button
                       variant="primary"
                       className="px-3"
                       onClick={() => setShowPublishModal(true)}
                     >
-                      {getActionButtonText()}
+                      Publish
                     </Button>
                   </OverlayTrigger>
                 )}
-
               </ButtonGroup>
             </Col>
           </Row>
@@ -208,6 +220,5 @@ const EditorButtons = ({
     </>
   );
 };
-   
 
 export default EditorButtons;

--- a/frontend/src/components/Form/IndexerConfigOptionsInputGroup.jsx
+++ b/frontend/src/components/Form/IndexerConfigOptionsInputGroup.jsx
@@ -51,7 +51,7 @@ const IndexerConfigOptions = ({ updateConfig }) => {
         <InputGroup.Text> Indexer Name  </InputGroup.Text>
         <Form.Control
           type="text"
-          placeholder="Indexer Name"
+          placeholder="indexer_name"
           aria-label="IndexerName"
           value={indexerNameField}
           disabled={!isCreateNewIndexer && showPublishModal}

--- a/frontend/src/components/Modals/ForkIndexerModal.jsx
+++ b/frontend/src/components/Modals/ForkIndexerModal.jsx
@@ -14,13 +14,8 @@ export const ForkIndexerModal = ({ registerFunction, forkIndexer }) => {
     setIndexerConfig,
     isCreateNewIndexer,
   } = useContext(IndexerDetailsContext);
-  const [indexerConfig, setIndexerConfigField] = useState({
-    filter: "social.near",
-    startBlockHeight: null,
-  });
   const [indexerName, setIndexerNameField] = useState("");
   const [error, setError] = useState(null);
-
 
   const fork = async () => {
     if (!indexerName) {
@@ -35,18 +30,13 @@ export const ForkIndexerModal = ({ registerFunction, forkIndexer }) => {
       return;
     }
 
-    if (!validateContractId(indexerConfig.filter)) {
-      setError("Please provide a valid contract name");
-      return;
-    }
     setError(null);
     setIndexerName(indexerName);
     setIsCreateNewIndexer(true);
-    forkIndexer(indexerName, indexerConfig);
+    forkIndexer(indexerName);
     setShowForkIndexerModal(false);
   };
 
-        // <IndexerConfigOptions updateConfig={updateConfig} />
   return (
     <Modal
       centered={true}

--- a/frontend/src/components/Modals/ForkIndexerModal.jsx
+++ b/frontend/src/components/Modals/ForkIndexerModal.jsx
@@ -1,47 +1,52 @@
 import React, { useContext, useState } from "react";
-import { Button, Modal, Alert } from "react-bootstrap";
+import { Button, Modal, Alert, InputGroup, Form  } from "react-bootstrap";
 import IndexerConfigOptions from "../Form/IndexerConfigOptionsInputGroup";
-import { IndexerDetailsContext } from '../../contexts/IndexerDetailsContext';
+import { IndexerDetailsContext } from "../../contexts/IndexerDetailsContext";
 import { validateContractId } from "../../utils/validators";
 
-export const ForkIndexerModal = ({
-  registerFunction,
-}) => {
+export const ForkIndexerModal = ({ registerFunction, forkIndexer }) => {
   const {
     indexerDetails,
     showForkIndexerModal,
     setShowForkIndexerModal,
+    setIsCreateNewIndexer,
+    setIndexerName,
+    setIndexerConfig,
+    isCreateNewIndexer,
   } = useContext(IndexerDetailsContext);
-  const [indexerConfig, setIndexerConfig] = useState({ filter: "social.near", startBlockHeight: null })
-  const [indexerName, setIndexerName] = useState("")
-  const [error, setError] = useState(null)
+  const [indexerConfig, setIndexerConfigField] = useState({
+    filter: "social.near",
+    startBlockHeight: null,
+  });
+  const [indexerName, setIndexerNameField] = useState("");
+  const [error, setError] = useState(null);
 
-  const updateConfig = (indexerName, filter, startBlockHeight, option) => {
-    let finalStartBlockHeight = option === "latestBlockHeight" ? null : startBlockHeight;
-    setIndexerConfig({ filter, startBlockHeight: finalStartBlockHeight })
-    setIndexerName(indexerName)
-  }
-  const register = async () => {
+
+  const fork = async () => {
     if (!indexerName) {
-      setError("Please provide an Indexer Name")
-      return
+      setError("Please provide an Indexer Name");
+      return;
     }
 
     if (indexerName === indexerDetails.indexerName) {
-      setError("Please provide a different Indexer Name than the orginal Indexer")
-      return
+      setError(
+        "Please provide a different Indexer Name than the orginal Indexer"
+      );
+      return;
     }
-
 
     if (!validateContractId(indexerConfig.filter)) {
-      setError("Please provide a valid contract name")
-      return
+      setError("Please provide a valid contract name");
+      return;
     }
-    setError(null)
-    registerFunction(indexerName, indexerConfig)
-    setShowForkIndexerModal(false)
-  }
+    setError(null);
+    setIndexerName(indexerName);
+    setIsCreateNewIndexer(true);
+    forkIndexer(indexerName, indexerConfig);
+    setShowForkIndexerModal(false);
+  };
 
+        // <IndexerConfigOptions updateConfig={updateConfig} />
   return (
     <Modal
       centered={true}
@@ -52,7 +57,16 @@ export const ForkIndexerModal = ({
         <Modal.Title> Enter Indexer Details</Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        <IndexerConfigOptions updateConfig={updateConfig} />
+        <InputGroup size="sm">
+          <InputGroup.Text> Indexer Name </InputGroup.Text>
+          <Form.Control
+            type="text"
+            placeholder="indexer_name"
+            aria-label="IndexerName"
+            value={indexerName}
+            onChange={(e) => setIndexerNameField(e.target.value.trim().toLowerCase())}
+          />
+        </InputGroup>
         {error && (
           <Alert className="px-3 mt-3" variant="danger">
             {error}
@@ -60,11 +74,14 @@ export const ForkIndexerModal = ({
         )}
       </Modal.Body>
       <Modal.Footer>
-        <Button variant="secondary" onClick={() => setShowPublishModal(false)}>
+        <Button
+          variant="secondary"
+          onClick={() => setShowForkIndexerModal(false)}
+        >
           Cancel
         </Button>
-        <Button variant="primary" onClick={() => register()}>
-          Fork Your Own Indexer
+        <Button variant="primary" onClick={() => fork()}>
+          Fork Indexer
         </Button>
       </Modal.Footer>
     </Modal>


### PR DESCRIPTION
While forking an indexer, you'll be given the chance to change the schema + indexerLogic before publishing. 

When forking,  we also update the indexer_name and account_name of the mutations and queries the new forked indexer targets.

-- What we do in this PR
Prior to this PR, the concept of forking an indexer(your own vs someone elses) or 
publishing an indexer(creating a new indexer vs publishing code to an existing indexer) were very confusing. 

With this PR, we separate the responsibilities to make it more clear. With that change, there is no concept of having an indexerConfig while forking an indexer as the only information we ask the user in the modal is about the new `indexerName` they would like to set. 

In the background, we use the `indexerConfig` of the indexer the user forked. 

