### PR TITLE
DPLT-1026 provisioning flag fix

### DIFF
--- a/indexer/queryapi_coordinator/src/historical_block_processing.rs
+++ b/indexer/queryapi_coordinator/src/historical_block_processing.rs
@@ -181,7 +181,7 @@ pub(crate) async fn filter_matching_blocks_from_index_files(
     let index_files_content = match &indexer_rule.matching_rule {
         MatchingRule::ActionAny {
             affected_account_id,
-            status,
+            ..
         } => {
             if affected_account_id.contains('*') || affected_account_id.contains(',') {
                 needs_dedupe_and_sort = true;
@@ -195,11 +195,7 @@ pub(crate) async fn filter_matching_blocks_from_index_files(
             )
             .await
         }
-        MatchingRule::ActionFunctionCall {
-            affected_account_id,
-            status,
-            function,
-        } => {
+        MatchingRule::ActionFunctionCall { .. } => {
             tracing::error!(
                 target: crate::INDEXER,
                 "ActionFunctionCall matching rule not supported for historical processing"

--- a/indexer/queryapi_coordinator/src/historical_block_processing.rs
+++ b/indexer/queryapi_coordinator/src/historical_block_processing.rs
@@ -117,16 +117,17 @@ pub(crate) async fn process_historical_messages(
 
             blocks_from_index.append(&mut blocks_between_indexed_and_current_block);
 
+            let first_block_in_data = *blocks_from_index.first().unwrap_or(&start_block);
             for current_block in blocks_from_index {
                 send_execution_message(
                     block_height,
-                    start_block,
+                    first_block_in_data,
                     chain_id.clone(),
                     &queue_client,
                     queue_url.clone(),
                     &mut indexer_function,
                     current_block,
-                    None, //alert_queue_message.payload.clone(),  // future: populate with data from the Match
+                    None,
                 )
                 .await;
             }
@@ -392,7 +393,7 @@ fn normalize_block_height(block_height: BlockHeight) -> String {
 
 async fn send_execution_message(
     block_height: BlockHeight,
-    start_block: u64,
+    first_block: BlockHeight,
     chain_id: ChainId,
     queue_client: &Client,
     queue_url: String,
@@ -401,7 +402,7 @@ async fn send_execution_message(
     payload: Option<IndexerRuleMatchPayload>,
 ) {
     // only request provisioning on the first block
-    if current_block != start_block {
+    if current_block != first_block {
         indexer_function.provisioned = true;
     }
 

--- a/indexer/queryapi_coordinator/src/main.rs
+++ b/indexer/queryapi_coordinator/src/main.rs
@@ -245,7 +245,7 @@ async fn handle_streamer_message(
 
 fn set_provisioned_flag(
     indexer_registry_locked: &mut MutexGuard<IndexerRegistry>,
-    indexer_function: &&IndexerFunction,
+    indexer_function: &IndexerFunction,
 ) {
     match indexer_registry_locked.get_mut(&indexer_function.account_id) {
         Some(account_functions) => {
@@ -297,3 +297,49 @@ async fn reduce_rule_matches_for_indexer_function<'x>(
 
 #[cfg(test)]
 mod historical_block_processing_integration_tests;
+
+use indexer_rule_type::indexer_rule::{IndexerRule, IndexerRuleKind, MatchingRule, Status};
+use std::collections::HashMap;
+
+#[tokio::test]
+async fn set_provisioning_finds_functions_in_registry() {
+    let mut indexer_registry = IndexerRegistry::new();
+    let indexer_function = IndexerFunction {
+        account_id: "test_near".to_string().parse().unwrap(),
+        function_name: "test_indexer".to_string(),
+        code: "".to_string(),
+        start_block_height: None,
+        schema: None,
+        provisioned: false,
+        indexer_rule: IndexerRule {
+            indexer_rule_kind: IndexerRuleKind::Action,
+            id: None,
+            name: None,
+            matching_rule: MatchingRule::ActionAny {
+                affected_account_id: "social.near".to_string(),
+                status: Status::Success,
+            },
+        },
+    };
+
+    let mut functions: HashMap<String, IndexerFunction> = HashMap::new();
+    functions.insert(
+        indexer_function.function_name.clone(),
+        indexer_function.clone(),
+    );
+    indexer_registry.insert(indexer_function.account_id.clone(), functions);
+
+    let indexer_registry: SharedIndexerRegistry = std::sync::Arc::new(Mutex::new(indexer_registry));
+    let mut indexer_registry_locked = indexer_registry.lock().await;
+
+    set_provisioned_flag(&mut indexer_registry_locked, &&indexer_function);
+
+    let account_functions = indexer_registry_locked
+        .get(&indexer_function.account_id)
+        .unwrap();
+    let indexer_function = account_functions
+        .get(&indexer_function.function_name)
+        .unwrap();
+
+    assert!(indexer_function.provisioned);
+}

--- a/indexer/queryapi_coordinator/src/main.rs
+++ b/indexer/queryapi_coordinator/src/main.rs
@@ -46,7 +46,6 @@ pub(crate) struct QueryApiContext<'a> {
     pub registry_contract_id: &'a str,
     pub balance_cache: &'a BalanceCache,
     pub redis_connection_manager: &'a ConnectionManager,
-    pub json_rpc_client: &'a JsonRpcClient,
 }
 
 #[tokio::main]
@@ -102,7 +101,6 @@ async fn main() -> anyhow::Result<()> {
             let context = QueryApiContext {
                 redis_connection_manager: &redis_connection_manager,
                 queue_url: &queue_url,
-                json_rpc_client: &json_rpc_client,
                 balance_cache: &balances_cache,
                 registry_contract_id: &registry_contract_id,
                 streamer_message,

--- a/indexer/queryapi_coordinator/src/s3.rs
+++ b/indexer/queryapi_coordinator/src/s3.rs
@@ -253,7 +253,6 @@ mod tests {
     #[tokio::test]
     async fn list_with_single_contract() {
         let opts = Opts::parse();
-        let aws_config: &SdkConfig = &opts.lake_aws_sdk_config();
 
         let list = find_index_files_by_pattern(
             &opts.lake_aws_sdk_config(),
@@ -269,7 +268,6 @@ mod tests {
     #[tokio::test]
     async fn list_with_csv_contracts() {
         let opts = Opts::parse();
-        let aws_config: &SdkConfig = &opts.lake_aws_sdk_config();
 
         let list = find_index_files_by_pattern(
             &opts.lake_aws_sdk_config(),
@@ -285,7 +283,6 @@ mod tests {
     #[tokio::test]
     async fn list_with_wildcard_contracts() {
         let opts = Opts::parse();
-        let aws_config: &SdkConfig = &opts.lake_aws_sdk_config();
 
         let list = find_index_files_by_pattern(
             &opts.lake_aws_sdk_config(),
@@ -301,7 +298,6 @@ mod tests {
     #[tokio::test]
     async fn list_with_csv_and_wildcard_contracts() {
         let opts = Opts::parse();
-        let aws_config: &SdkConfig = &opts.lake_aws_sdk_config();
 
         let list = find_index_files_by_pattern(
             &opts.lake_aws_sdk_config(),


### PR DESCRIPTION
1st commit:
Requested start block is not necessarily a block that matches the filter, this corrects historical processing to request provisioning for the first matched block.

Minor adjustment and test for when provisioning is requested by real-time processing.

2nd commit:
Clean up some unused variables.