### PR TITLE
DPLT-1044 Change `HISTORICAL` dimension to `EXECUTION_TYPE`

### DIFF
--- a/indexer-js-queue-handler/__snapshots__/metrics.test.js.snap
+++ b/indexer-js-queue-handler/__snapshots__/metrics.test.js.snap
@@ -19,8 +19,8 @@ exports[`Metrics writes the block height for an indexer function 1`] = `
             "Value": "dev",
           },
           {
-            "Name": "HISTORICAL",
-            "Value": false,
+            "Name": "EXECUTION_TYPE",
+            "Value": "real-time",
           },
         ],
         "MetricName": "INDEXER_FUNCTION_LATEST_BLOCK_HEIGHT",

--- a/indexer-js-queue-handler/metrics.js
+++ b/indexer-js-queue-handler/metrics.js
@@ -31,8 +31,8 @@ export default class Metrics {
                                 Value: process.env.STAGE,
                             },
                             {
-                                Name: "HISTORICAL",
-                                Value: isHistorical,
+                                Name: "EXECUTION_TYPE",
+                                Value: isHistorical ? "historical" : "real-time",
                             },
                         ],
                         Unit: "None",


### PR DESCRIPTION
Dimensions must be of string type, so labelling whether the function if `historical` or `real-time` makes more sense here.