### PR TITLE
DPLT-1044 Expose `fetch` to VM runner

### DIFF
--- a/indexer-js-queue-handler/indexer.js
+++ b/indexer-js-queue-handler/indexer.js
@@ -80,6 +80,7 @@ export default class Indexer {
                 vm.freeze(blockWithHelpers, 'block');
                 vm.freeze(context, 'context');
                 vm.freeze(context, 'console'); // provide console.log via context.log
+                vm.freeze(fetch, 'fetch');
                 vm.freeze(mutationsReturnValue, 'mutationsReturnValue'); // this still allows context.set to modify it
 
                 const modifiedFunction = this.transformIndexerFunction(indexerFunction.code);


### PR DESCRIPTION
Now that we have the ability to write custom metrics from within the runner, we can start writing the 'lag behind social'. But to do that we need to fetch the latest post block height from api.social.near. For that we need access `fetch`.