### PR TITLE
DPLT-1055 Log multiple console.log / context.log arguments

### DIFF
--- a/indexer-js-queue-handler/indexer.js
+++ b/indexer-js-queue-handler/indexer.js
@@ -219,8 +219,8 @@ export default class Indexer {
             set: (key, value) => {
                 mutationsReturnValue.keysValues[key] = value;
             },
-            log: async (log) => {  // starting with imperative logging for both imperative and functional contexts
-                return await this.writeLog(functionName, block_height, log);
+            log: async (...log) => {  // starting with imperative logging for both imperative and functional contexts
+                return await this.writeLog(functionName, block_height, ...log);
             }
 
         };
@@ -253,8 +253,8 @@ export default class Indexer {
                     throw e; // allow catch outside of vm.run to receive the error
                 }
             },
-            log: async (log) => {
-                return await this.writeLog(functionName, block_height, log);
+            log: async (...log) => {
+                return await this.writeLog(functionName, block_height, ...log);
             },
             putMetric: (name, value) => {
                 const [accountId, fnName] = functionName.split('/');

--- a/indexer-js-queue-handler/indexer.test.js
+++ b/indexer-js-queue-handler/indexer.test.js
@@ -480,14 +480,14 @@ mutation _1 { set(functionName: "buildnear.testnet/test", key: "foo2", data: "in
 
     test('Indexer.runFunctions() console.logs', async () => {
         const logs = []
-        const context = {log: (m) => {
-            logs.push(m)
+        const context = {log: (...m) => {
+            logs.push(...m)
         }};
         const vm = new VM();
         vm.freeze(context, 'context');
         vm.freeze(context, 'console');
-        await vm.run('console.log("hello"); context.log("world")');
-        expect(logs).toEqual(['hello','world']);
+        await vm.run('console.log("hello", "brave new"); context.log("world")');
+        expect(logs).toEqual(['hello','brave new','world']);
     });
 
     test("Errors thrown in VM can be caught outside the VM", async () => {


### PR DESCRIPTION
writeLog allowed multiple console.log arguments but these were not being propagated through by the context.log functions.