### PR TITLE
DPLT-1044 Add `context.fetchFromSocialApi`

### DIFF
--- a/indexer-js-queue-handler/__snapshots__/indexer.test.js.snap
+++ b/indexer-js-queue-handler/__snapshots__/indexer.test.js.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Indexer unit tests Indexer.buildImperativeContextForFunction() can fetch from the near social api 1`] = `
+[
+  [
+    "https://api.near.social/index",
+    {
+      "body": "{"action":"post","key":"main","options":{"limit":1,"order":"desc"}}",
+      "headers": {
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+    },
+  ],
+]
+`;
+
 exports[`Indexer unit tests Indexer.runFunctions() allows imperative execution of GraphQL operations 1`] = `
 [
   [

--- a/indexer-js-queue-handler/indexer.js
+++ b/indexer-js-queue-handler/indexer.js
@@ -80,7 +80,6 @@ export default class Indexer {
                 vm.freeze(blockWithHelpers, 'block');
                 vm.freeze(context, 'context');
                 vm.freeze(context, 'console'); // provide console.log via context.log
-                vm.freeze(fetch, 'fetch');
                 vm.freeze(mutationsReturnValue, 'mutationsReturnValue'); // this still allows context.set to modify it
 
                 const modifiedFunction = this.transformIndexerFunction(indexerFunction.code);
@@ -221,7 +220,9 @@ export default class Indexer {
             },
             log: async (...log) => {  // starting with imperative logging for both imperative and functional contexts
                 return await this.writeLog(functionName, block_height, ...log);
-            }
+            },
+            // pass through fetch via context to provide (eventual) greater control
+            fetch
 
         };
     }
@@ -266,6 +267,8 @@ export default class Indexer {
                     value
                 );
             },
+            // pass through fetch via context to provide (eventual) greater control
+            fetch
         };
     }
 

--- a/indexer-js-queue-handler/indexer.js
+++ b/indexer-js-queue-handler/indexer.js
@@ -221,9 +221,6 @@ export default class Indexer {
             log: async (...log) => {  // starting with imperative logging for both imperative and functional contexts
                 return await this.writeLog(functionName, block_height, ...log);
             },
-            // pass through fetch via context to provide (eventual) greater control
-            fetch
-
         };
     }
 
@@ -267,8 +264,9 @@ export default class Indexer {
                     value
                 );
             },
-            // pass through fetch via context to provide (eventual) greater control
-            fetch
+            fetchFromSocialApi: async (path, options) => {
+                return this.deps.fetch(`https://api.near.social${path}`, options);
+            }
         };
     }
 

--- a/indexer-js-queue-handler/indexer.test.js
+++ b/indexer-js-queue-handler/indexer.test.js
@@ -318,6 +318,30 @@ mutation _1 { set(functionName: "buildnear.testnet/test", key: "foo2", data: "in
         ]);
     });
 
+    test('Indexer.buildImperativeContextForFunction() can fetch from the near social api', async () => {
+        const mockFetch = jest.fn();
+        const indexer = new Indexer('mainnet', { fetch: mockFetch, awsXray: mockAwsXray, metrics: mockMetrics });
+
+        const context = indexer.buildImperativeContextForFunction();
+
+        await context.fetchFromSocialApi('/index', {
+            method: 'POST',
+            headers: {
+                ['Content-Type']: 'application/json',
+            },
+            body: JSON.stringify({
+                action: 'post',
+                key: 'main',
+                options: {
+                    limit: 1,
+                    order: 'desc'
+                }
+            })
+        });
+
+        expect(mockFetch.mock.calls).toMatchSnapshot();
+    });
+
     test('Indexer.buildImperativeContextForFunction() throws when a GraphQL response contains errors', async () => {
         const mockFetch = jest.fn()
             .mockResolvedValue({


### PR DESCRIPTION
ref: https://github.com/near/queryapi-mvp/pull/131

This PR limits the `fetch` function exposed to the VM to only `api.near.social`. This limits the potential security vulnerabilities that come with exposing `fetch` as is.