### PR TITLE
chore: Remove `backend_only` mutation default

### DIFF
--- a/indexer-js-queue-handler/__snapshots__/hasura-client.test.js.snap
+++ b/indexer-js-queue-handler/__snapshots__/hasura-client.test.js.snap
@@ -24,7 +24,6 @@ exports[`HasuraClient adds the specified permissions for the specified roles/tab
     {
       "args": {
         "permission": {
-          "backend_only": true,
           "check": {},
           "columns": "*",
           "computed_fields": [],
@@ -42,7 +41,6 @@ exports[`HasuraClient adds the specified permissions for the specified roles/tab
     {
       "args": {
         "permission": {
-          "backend_only": true,
           "check": {},
           "columns": "*",
           "computed_fields": [],
@@ -60,7 +58,6 @@ exports[`HasuraClient adds the specified permissions for the specified roles/tab
     {
       "args": {
         "permission": {
-          "backend_only": true,
           "check": {},
           "columns": "*",
           "computed_fields": [],
@@ -96,7 +93,6 @@ exports[`HasuraClient adds the specified permissions for the specified roles/tab
     {
       "args": {
         "permission": {
-          "backend_only": true,
           "check": {},
           "columns": "*",
           "computed_fields": [],
@@ -114,7 +110,6 @@ exports[`HasuraClient adds the specified permissions for the specified roles/tab
     {
       "args": {
         "permission": {
-          "backend_only": true,
           "check": {},
           "columns": "*",
           "computed_fields": [],
@@ -132,7 +127,6 @@ exports[`HasuraClient adds the specified permissions for the specified roles/tab
     {
       "args": {
         "permission": {
-          "backend_only": true,
           "check": {},
           "columns": "*",
           "computed_fields": [],

--- a/indexer-js-queue-handler/hasura-client.js
+++ b/indexer-js-queue-handler/hasura-client.js
@@ -230,9 +230,7 @@ export default class HasuraClient {
                 check: {},
                 computed_fields: [],
                 filter: {},
-                ...(permission === "select"
-                  ? { allow_aggregations: true }
-                  : { backend_only: true }),
+                ...(permission === "select" && { allow_aggregations: true })
               },
               source: 'default'
             },


### PR DESCRIPTION
This default was added to ensure that users couldn't edit other users data, by limiting mutations to the backend only. But this also hides the mutations from the schema, making them undiscoverable. Removing this default so that developers can see which mutations are available to use.
