### PR TITLE
DPLT-1124 Create script to preemptively provision user DBs

### DIFF
--- a/indexer-js-queue-handler/pg-client.js
+++ b/indexer-js-queue-handler/pg-client.js
@@ -22,7 +22,7 @@ export default class PgClient {
     async query(query, params = []) {
         const client = await this.pgPool.connect();
         try {
-            await client.query(query, params);
+            return await client.query(query, params);
         } finally {
             client.release();
         }

--- a/indexer-js-queue-handler/scripts/provision-user-dbs.js
+++ b/indexer-js-queue-handler/scripts/provision-user-dbs.js
@@ -1,0 +1,54 @@
+// export HASURA_ENDPOINT=''
+// export HASURA_ADMIN_SECRET=''
+// export PG_ADMIN_USER=''
+// export PG_ADMIN_PASSWORD=''
+// export PG_ADMIN_DATABASE=''
+// export PG_HOST=''
+// export PG_PORT=
+
+import { execSync } from 'child_process'
+import { providers } from 'near-api-js'
+
+import Provisioner from '../provisioner.js'
+import HasuraClient from '../hasura-client.js'
+
+const provisioner = new Provisioner();
+
+const { rows } = await provisioner.pgClient.query('SELECT nspname AS name FROM pg_namespace;')
+
+const schemaNames = rows.map((row) => row.name);
+
+const accountIdsSet = schemaNames.reduce((accountIdsSet, schemaName) => {
+    const parts = schemaName.split('_near_');
+    if (parts.length > 1) {
+        accountIdsSet.add(`${parts[0]}_near`);
+    }
+    return accountIdsSet;
+}, new Set());
+
+const accountIds = Array.from(accountIdsSet);
+
+console.log(`Creating datasources for accounts: ${accountIds.join(', ')}`)
+
+for (const accountId of accountIds) {
+    console.log('---');
+    const sanitizedAccountId = provisioner.replaceSpecialChars(accountId);
+
+    const databaseName = sanitizedAccountId;
+    const userName = sanitizedAccountId;
+
+    if (await provisioner.hasuraClient.doesSourceExist(databaseName)) {
+        console.log(`Datasource ${databaseName} already exists, skipping.`)
+        continue;
+    }
+
+    const password = provisioner.generatePassword()
+    console.log(`Creating user: ${userName} and database: ${databaseName} with password: ${password}`);
+    await provisioner.createUserDb(userName, password, databaseName);
+
+    console.log(`Adding datasource ${databaseName} to Hasura`)
+    await provisioner.addDatasource(userName, password, databaseName);
+}
+console.log('---');
+
+console.log('Done');


### PR DESCRIPTION
This script will create a separate DB for each user, and then add it to Hasura. Preemptively creating separate DBs prevents the potential conflicts which arise when we deploy the separate DB change to prod and multiple indexers attempt to provision the same DB.