### PR TITLE
DPLT-1129 Publish unprocessed stream messages count to Grafana

### DIFF
--- a/indexer/queryapi_coordinator/src/metrics.rs
+++ b/indexer/queryapi_coordinator/src/metrics.rs
@@ -1,6 +1,6 @@
 use actix_web::{get, App, HttpServer, Responder};
 use lazy_static::lazy_static;
-use prometheus::{Encoder, IntCounter, IntGauge, Opts};
+use prometheus::{Encoder, IntCounter, IntGauge, IntGaugeVec, Opts};
 use tracing::info;
 
 lazy_static! {
@@ -14,6 +14,23 @@ lazy_static! {
         "Number of indexed blocks"
     )
     .unwrap();
+    pub(crate) static ref UNPROCESSED_STREAM_MESSAGES: IntGaugeVec = try_create_int_gauge_vec(
+        "queryapi_coordinator_unprocessed_stream_messages",
+        "Number of Redis Stream messages not processed by Runner",
+        &["stream"]
+    )
+    .unwrap();
+}
+
+fn try_create_int_gauge_vec(
+    name: &str,
+    help: &str,
+    labels: &[&str],
+) -> prometheus::Result<IntGaugeVec> {
+    let opts = Opts::new(name, help);
+    let gauge = IntGaugeVec::new(opts, labels)?;
+    prometheus::register(Box::new(gauge.clone()))?;
+    Ok(gauge)
 }
 
 fn try_create_int_gauge(name: &str, help: &str) -> prometheus::Result<IntGauge> {

--- a/indexer/queryapi_coordinator/src/utils.rs
+++ b/indexer/queryapi_coordinator/src/utils.rs
@@ -1,7 +1,7 @@
 use crate::metrics;
 
 pub(crate) async fn stats(redis_connection_manager: storage::ConnectionManager) {
-    let interval_secs = 10;
+    let interval_secs = 5;
     let mut previous_processed_blocks: u64 =
         storage::get::<u64>(&redis_connection_manager, "blocks_processed")
             .await

--- a/indexer/queryapi_coordinator/src/utils.rs
+++ b/indexer/queryapi_coordinator/src/utils.rs
@@ -1,3 +1,5 @@
+use crate::metrics;
+
 pub(crate) async fn stats(redis_connection_manager: storage::ConnectionManager) {
     let interval_secs = 10;
     let mut previous_processed_blocks: u64 =
@@ -46,6 +48,34 @@ pub(crate) async fn stats(redis_connection_manager: storage::ConnectionManager) 
             alert_rules_count,
         );
         previous_processed_blocks = processed_blocks;
+
+        let streams = storage::smembers(&redis_connection_manager, storage::INDEXER_SET_KEY)
+            .await
+            .unwrap_or(Vec::new());
+
+        for stream in streams {
+            let latest_id = storage::get::<String>(
+                &redis_connection_manager,
+                storage::generate_stream_last_id_key(&stream),
+            )
+            .await
+            .unwrap_or(storage::STREAM_SMALLEST_ID.to_string());
+
+            let unprocessed_message_count = storage::xrange(
+                &redis_connection_manager,
+                storage::generate_stream_key(&stream),
+                &latest_id,
+                storage::STREAM_LARGEST_ID,
+            )
+            .await
+            .unwrap_or(Vec::new())
+            .len() as i64;
+
+            metrics::UNPROCESSED_STREAM_MESSAGES
+                .with_label_values(&[&stream])
+                .set(unprocessed_message_count);
+        }
+
         tokio::time::sleep(std::time::Duration::from_secs(interval_secs)).await;
     }
 }


### PR DESCRIPTION
The unprocessed stream message count is retrieved by getting the 'last processed ID', which is published by Runner, and then calculating the remaining messages. This is currently done in Coordinator, as it's already hooked up to Prometheus/Grafana, but I might end up moving it to Runner once that's connected.