### PR TITLE
fix: Use correct PG env vars when adding hasura datasource

### DIFF
--- a/runner/src/hasura-client/hasura-client.ts
+++ b/runner/src/hasura-client/hasura-client.ts
@@ -328,8 +328,8 @@ export default class HasuraClient {
               password,
               database: databaseName,
               username: userName,
-              host: process.env.PG_HOST,
-              port: Number(process.env.PG_PORT),
+              host: process.env.PGHOST,
+              port: Number(process.env.PGPORT),
             }
           },
         },


### PR DESCRIPTION
New Runner was using the old env var names - typescript can't save us all the time 😅 