### PR TITLE
fix: Fetch cargo packages from registry in Docker build

### DIFF
--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -3,9 +3,9 @@ ARG CARGO_BUILD_MODE=release
 WORKDIR /tmp/
 COPY ./ ./
 RUN if [ "$CARGO_BUILD_MODE" = "debug" ]; then \
-        cargo build --package queryapi_coordinator --offline; \
+        cargo build --package queryapi_coordinator; \
     else \
-        cargo build --release --package queryapi_coordinator --offline; \
+        cargo build --release --package queryapi_coordinator; \
     fi
 
 FROM ubuntu:20.04


### PR DESCRIPTION
When we had a multistage build, the second cargo build could use `--offline` as all packages would exist from the first build. With the first build removed we need to fetch the packages from the registry.