### PR TITLE
fix: Improve Scope of Table Name Regex to Resolve Errors

### DIFF
--- a/frontend/src/utils/indexerRunner.js
+++ b/frontend/src/utils/indexerRunner.js
@@ -63,13 +63,12 @@ export default class IndexerRunner {
     });
   }
 
-  async executeIndexerFunction(height, blockDetails, indexingCode, schema, schemaName) {
-    let innerCode = indexingCode.match(/getBlock\s*\([^)]*\)\s*{([\s\S]*)}/)[1];
+  getTableNames (schema) {
     const tableRegex = /CREATE TABLE\s+(?:IF NOT EXISTS)?\s+"?(.+?)"?\s*\(/g;
     const tableNames = Array.from(schema.matchAll(tableRegex), match => {
       let tableName;
-      if (match[1].includes(".")) { // If expression after create has schemaName.tableName, return only tableName
-        tableName = match[1].split(".")[1];
+      if (match[1].includes('.')) { // If expression after create has schemaName.tableName, return only tableName
+        tableName = match[1].split('.')[1];
         tableName = tableName.startsWith('"') ? tableName.substring(1) : tableName;
       } else {
         tableName = match[1];
@@ -77,6 +76,13 @@ export default class IndexerRunner {
       return /^\w+$/.test(tableName) ? tableName : `"${tableName}"`; // If table name has special characters, it must be inside double quotes
     });
     this.validateTableNames(tableNames);
+    console.log('Retrieved the following table names from schema: ', tableNames);
+    return tableNames;
+  }
+
+  async executeIndexerFunction(height, blockDetails, indexingCode, schema, schemaName) {
+    let innerCode = indexingCode.match(/getBlock\s*\([^)]*\)\s*{([\s\S]*)}/)[1];
+    const tableNames = this.getTableNames(schema);
 
     if (blockDetails) {
       const block = Block.fromStreamerMessage(blockDetails);

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -65,7 +65,7 @@ describe('Indexer unit tests', () => {
       );`;
 
   const STRESS_TEST_SCHEMA = `
-  CREATE TABLE
+CREATE TABLE
   creator_quest (
     account_id VARCHAR PRIMARY KEY,
     num_components_created INTEGER NOT NULL DEFAULT 0,
@@ -80,7 +80,7 @@ CREATE TABLE
   );
 
 CREATE TABLE
-  contractor - quest (
+  "contractor - quest" (
     account_id VARCHAR PRIMARY KEY,
     num_contracts_deployed INTEGER NOT NULL DEFAULT 0,
     completed BOOLEAN NOT NULL DEFAULT FALSE
@@ -147,6 +147,10 @@ CREATE TABLE IF NOT EXISTS
 
 CREATE TABLE
   "Another-Table" (id serial PRIMARY KEY);
+
+CREATE TABLE
+IF NOT EXISTS
+  "Third-Table" (id serial PRIMARY KEY);
 
 CREATE TABLE
   yet_another_table (id serial PRIMARY KEY);
@@ -517,26 +521,26 @@ CREATE TABLE
 
     // These calls would fail on a real database, but we are merely checking to ensure they exist
     expect(Object.keys(context.db)).toStrictEqual(
-      [
-        'insert_creator_quest',
+      ['insert_creator_quest',
         'select_creator_quest',
         'insert_composer_quest',
         'select_composer_quest',
-        'insert_"contractor - quest"',
-        'select_"contractor - quest"',
+        'insert__contractor___quest_',
+        'select__contractor___quest_',
         'insert_posts',
         'select_posts',
         'insert_comments',
         'select_comments',
         'insert_post_likes',
         'select_post_likes',
-        'insert_"My Table1"',
-        'select_"My Table1"',
-        'insert_"Another-Table"',
-        'select_"Another-Table"',
+        'insert__My_Table1_',
+        'select__My_Table1_',
+        'insert__Another_Table_',
+        'select__Another_Table_',
+        'insert__Third_Table_',
+        'select__Third_Table_',
         'insert_yet_another_table',
-        'select_yet_another_table']
-    );
+        'select_yet_another_table']);
   });
 
   test('Indexer.runFunctions() allows imperative execution of GraphQL operations', async () => {

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -65,8 +65,7 @@ describe('Indexer unit tests', () => {
       );`;
 
   const STRESS_TEST_SCHEMA = `
-CREATE TABLE
-  creator_quest (
+CREATE TABLE creator_quest (
     account_id VARCHAR PRIMARY KEY,
     num_components_created INTEGER NOT NULL DEFAULT 0,
     completed BOOLEAN NOT NULL DEFAULT FALSE
@@ -519,28 +518,41 @@ CREATE TABLE
     const indexer = new Indexer('mainnet', { DmlHandler: mockDmlHandler });
     const context = indexer.buildContext(STRESS_TEST_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
 
-    // These calls would fail on a real database, but we are merely checking to ensure they exist
     expect(Object.keys(context.db)).toStrictEqual(
       ['insert_creator_quest',
         'select_creator_quest',
         'insert_composer_quest',
         'select_composer_quest',
-        'insert__contractor___quest_',
-        'select__contractor___quest_',
+        'insert_contractor___quest',
+        'select_contractor___quest',
         'insert_posts',
         'select_posts',
         'insert_comments',
         'select_comments',
         'insert_post_likes',
         'select_post_likes',
-        'insert__My_Table1_',
-        'select__My_Table1_',
-        'insert__Another_Table_',
-        'select__Another_Table_',
-        'insert__Third_Table_',
-        'select__Third_Table_',
+        'insert_My_Table1',
+        'select_My_Table1',
+        'insert_Another_Table',
+        'select_Another_Table',
+        'insert_Third_Table',
+        'select_Third_Table',
         'insert_yet_another_table',
         'select_yet_another_table']);
+  });
+
+  test('indexer builds context and returns empty array if failed to generate db methods', async () => {
+    const mockDmlHandler: any = jest.fn().mockImplementation(() => {
+      return {
+        insert: jest.fn().mockReturnValue(true),
+        select: jest.fn().mockReturnValue(true)
+      };
+    });
+
+    const indexer = new Indexer('mainnet', { DmlHandler: mockDmlHandler });
+    const context = indexer.buildContext('', 'morgs.near/social_feed1', 1, 'postgres');
+
+    expect(Object.keys(context.db)).toStrictEqual([]);
   });
 
   test('Indexer.runFunctions() allows imperative execution of GraphQL operations', async () => {

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -186,38 +186,7 @@ export default class Indexer {
     ].reduce((acc, val) => val(acc), indexerFunction);
   }
 
-  validateTableNames (tableNames: string[]): void {
-    if (!(Array.isArray(tableNames) && tableNames.length > 0)) {
-      throw new Error('Schema does not have any tables. There should be at least one table.');
-    }
-    const correctTableNameFormat = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
-
-    tableNames.forEach(name => {
-      if (!name.includes('"') && !correctTableNameFormat.test(name)) { // Only test if table name doesn't have quotes
-        throw new Error(`Table name ${name} is not formatted correctly. Table names must not start with a number and only contain alphanumerics or underscores.`);
-      }
-    });
-  }
-
-  getTableNames (schema: string): string[] {
-    const tableRegex = /CREATE TABLE\s+(?:IF NOT EXISTS)?\s+"?(.+?)"?\s*\(/g;
-    const tableNames = Array.from(schema.matchAll(tableRegex), match => {
-      let tableName;
-      if (match[1].includes('.')) { // If expression after create has schemaName.tableName, return only tableName
-        tableName = match[1].split('.')[1];
-        tableName = tableName.startsWith('"') ? tableName.substring(1) : tableName;
-      } else {
-        tableName = match[1];
-      }
-      return /^\w+$/.test(tableName) ? tableName : `"${tableName}"`; // If table name has special characters, it must be inside double quotes
-    });
-    this.validateTableNames(tableNames);
-    console.log('Retrieved the following table names from schema: ', tableNames);
-    return tableNames;
-  }
-
   buildContext (schema: string, functionName: string, blockHeight: number, hasuraRoleName: string): Context {
-    const tables = this.getTableNames(schema);
     const account = functionName.split('/')[0].replace(/[.-]/g, '_');
     const functionNameWithoutAccount = functionName.split('/')[1].replace(/[.-]/g, '_');
     const schemaName = functionName.replace(/[^a-zA-Z0-9]/g, '_');
@@ -246,30 +215,79 @@ export default class Indexer {
       fetchFromSocialApi: async (path, options) => {
         return await this.deps.fetch(`https://api.near.social${path}`, options);
       },
-      db: this.buildDatabaseContext(account, schemaName, tables, blockHeight)
+      db: this.buildDatabaseContext(account, schemaName, schema, blockHeight)
     };
   }
 
-  buildDatabaseContext (account: string, schemaName: string, tables: string[], blockHeight: number): Record<string, (...args: any[]) => any> {
-    let dmlHandler: DmlHandler | null = null;
-    const result = tables.reduce((prev, tableName) => ({
-      ...prev,
-      [`insert_${tableName.replace(/[^a-zA-Z0-9_]/g, '_')}`]: async (objects: any) => {
-        await this.writeLog(`context.db.insert_${tableName.replace(/[^a-zA-Z0-9_]/g, '_')}`, blockHeight,
-          `Calling context.db.insert_${tableName.replace(/[^a-zA-Z0-9_]/g, '_')}.`,
-          `Inserting object ${JSON.stringify(objects)} into table ${tableName} on schema ${schemaName}`);
-        dmlHandler = dmlHandler ?? new this.deps.DmlHandler(account);
-        return await dmlHandler.insert(schemaName, tableName, Array.isArray(objects) ? objects : [objects]);
-      },
-      [`select_${tableName.replace(/[^a-zA-Z0-9_]/g, '_')}`]: async (object: any, limit = null) => {
-        await this.writeLog(`context.db.select_${tableName.replace(/[^a-zA-Z0-9_]/g, '_')}`, blockHeight,
-          `Calling context.db.select_${tableName.replace(/[^a-zA-Z0-9_]/g, '_')}.`,
-          `Selecting objects with values ${JSON.stringify(object)} from table ${tableName} on schema ${schemaName} with limit ${limit === null ? 'no' : limit}`);
-        dmlHandler = dmlHandler ?? new this.deps.DmlHandler(account);
-        return await dmlHandler.select(schemaName, tableName, object, limit);
-      },
-    }), {});
-    return result;
+  validateTableNames (tableNames: string[]): void {
+    if (!(Array.isArray(tableNames) && tableNames.length > 0)) {
+      throw new Error('Schema does not have any tables. There should be at least one table.');
+    }
+    const correctTableNameFormat = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+    tableNames.forEach(name => {
+      if (!name.includes('"') && !correctTableNameFormat.test(name)) { // Only test if table name doesn't have quotes
+        throw new Error(`Table name ${name} is not formatted correctly. Table names must not start with a number and only contain alphanumerics or underscores.`);
+      }
+    });
+  }
+
+  getTableNames (schema: string): string[] {
+    const tableRegex = /CREATE TABLE\s+(?:IF NOT EXISTS\s+)?"?(.+?)"?\s*\(/g;
+    const tableNames = Array.from(schema.matchAll(tableRegex), match => {
+      let tableName;
+      if (match[1].includes('.')) { // If expression after create has schemaName.tableName, return only tableName
+        tableName = match[1].split('.')[1];
+        tableName = tableName.startsWith('"') ? tableName.substring(1) : tableName;
+      } else {
+        tableName = match[1];
+      }
+      return /^\w+$/.test(tableName) ? tableName : `"${tableName}"`; // If table name has special characters, it must be inside double quotes
+    });
+    this.validateTableNames(tableNames);
+    console.log('Retrieved the following table names from schema: ', tableNames);
+    return tableNames;
+  }
+
+  sanitizeTableName (tableName: string): string {
+    tableName = tableName.startsWith('"') && tableName.endsWith('"') ? tableName.substring(1, tableName.length - 1) : tableName;
+    return tableName.replace(/[^a-zA-Z0-9_]/g, '_');
+  }
+
+  buildDatabaseContext (account: string, schemaName: string, schema: string, blockHeight: number): Record<string, (...args: any[]) => any> {
+    try {
+      const tables = this.getTableNames(schema);
+      let dmlHandler: DmlHandler | null = null;
+      const result = tables.reduce((prev, tableName) => {
+        const sanitizedTableName = this.sanitizeTableName(tableName);
+        const funcForTable = {
+          [`insert_${sanitizedTableName}`]: async (objects: any) => {
+            await this.writeLog(`context.db.insert_${sanitizedTableName}`, blockHeight,
+              `Calling context.db.insert_${sanitizedTableName}.`,
+              `Inserting object ${JSON.stringify(objects)} into table ${tableName} on schema ${schemaName}`);
+            dmlHandler = dmlHandler ?? new this.deps.DmlHandler(account);
+            return await dmlHandler.insert(schemaName, tableName, Array.isArray(objects) ? objects : [objects]);
+          },
+          [`select_${sanitizedTableName}`]: async (object: any, limit = null) => {
+            await this.writeLog(`context.db.select_${sanitizedTableName}`, blockHeight,
+              `Calling context.db.select_${sanitizedTableName}.`,
+              `Selecting objects with values ${JSON.stringify(object)} from table ${tableName} on schema ${schemaName} with limit ${limit === null ? 'no' : limit}`);
+            dmlHandler = dmlHandler ?? new this.deps.DmlHandler(account);
+            return await dmlHandler.select(schemaName, tableName, object, limit);
+          }
+        };
+
+        return {
+          ...prev,
+          ...funcForTable
+        };
+      }, {});
+      return result;
+    } catch (error) {
+      console.warn('Caught error when generating context.db methods. Building no functions. You can still use other context object methods.\n', error);
+    }
+
+    return {}; // Default to empty object if error
   }
 
   async setStatus (functionName: string, blockHeight: number, status: string): Promise<any> {


### PR DESCRIPTION
The previous regex was not able to support DDL where the table names were not encapsulated in quotes. Through more research, I learned as well that putting the table name in quotes causes the table name it be case sensitive and also allow special characters. I also omitted checking for "IF NOT EXISTS". So, I updated the regex to allow optional white space and "IF NOT EXISTS". Then, I skip a SINGLE optional double quote, match anything until another optional double quote or white space. Everything between the white space following either TABLE or EXISTS and potentially two double quotes is now the table name. The name can have special characters so I ensure that any such names have double quotes added back in. I also support table names defined by schema.tableName. Finally, for testing I did the following: 

Tested generating table names in front end by opening all indexers and running debug mode to generate methods. All indexers succeeded, including notable ones like bos_quests, social_feed, and widget_testing. 

I also added a stress test schema which is a valid DDL schema (verified using format button) which contains all kinds of edge cases, and ensure the generated method names correctly sanitize the special characters to underscores. There might be other ways to more cleanly implement this transition of special characters to function name but I think this is fine for now, and we hopefully will have autocomplete for the context object soon. 

Finally, I also did an integration test using the existing insert function to confirm functionality has remained unimpacted. 