### PR TITLE
DPLT-1136: Implement update, upsert, and delete on context.db

### DIFF
--- a/runner/src/dml-handler/dml-handler.test.ts
+++ b/runner/src/dml-handler/dml-handler.test.ts
@@ -35,7 +35,7 @@ describe('DML Handler tests', () => {
       accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
     };
 
-    const dmlHandler = new DmlHandler(ACCOUNT, hasuraClient, PgClient);
+    const dmlHandler = await DmlHandler.create(ACCOUNT, hasuraClient, PgClient);
 
     await dmlHandler.insert(SCHEMA, TABLE_NAME, [inputObj]);
     expect(query.mock.calls).toEqual([
@@ -55,7 +55,7 @@ describe('DML Handler tests', () => {
       receipt_id: 'abc',
     }];
 
-    const dmlHandler = new DmlHandler(ACCOUNT, hasuraClient, PgClient);
+    const dmlHandler = await DmlHandler.create(ACCOUNT, hasuraClient, PgClient);
 
     await dmlHandler.insert(SCHEMA, TABLE_NAME, inputObj);
     expect(query.mock.calls).toEqual([
@@ -69,7 +69,7 @@ describe('DML Handler tests', () => {
       block_height: 999,
     };
 
-    const dmlHandler = new DmlHandler(ACCOUNT, hasuraClient, PgClient);
+    const dmlHandler = await DmlHandler.create(ACCOUNT, hasuraClient, PgClient);
 
     await dmlHandler.select(SCHEMA, TABLE_NAME, inputObj);
     expect(query.mock.calls).toEqual([
@@ -83,7 +83,7 @@ describe('DML Handler tests', () => {
       block_height: 999,
     };
 
-    const dmlHandler = new DmlHandler(ACCOUNT, hasuraClient, PgClient);
+    const dmlHandler = await DmlHandler.create(ACCOUNT, hasuraClient, PgClient);
 
     await dmlHandler.select(SCHEMA, TABLE_NAME, inputObj, 1);
     expect(query.mock.calls).toEqual([
@@ -102,7 +102,7 @@ describe('DML Handler tests', () => {
       receipt_id: 111,
     };
 
-    const dmlHandler = new DmlHandler(ACCOUNT, hasuraClient, PgClient);
+    const dmlHandler = await DmlHandler.create(ACCOUNT, hasuraClient, PgClient);
 
     await dmlHandler.update(SCHEMA, TABLE_NAME, whereObj, updateObj);
     expect(query.mock.calls).toEqual([
@@ -110,7 +110,7 @@ describe('DML Handler tests', () => {
     ]);
   });
 
-  test('Test valid update on two fields', async () => {
+  test('Test valid upsert on two fields', async () => {
     const inputObj = [{
       account_id: 'morgs_near',
       block_height: 1,
@@ -125,7 +125,7 @@ describe('DML Handler tests', () => {
     const conflictCol = ['account_id', 'block_height'];
     const updateCol = ['receipt_id'];
 
-    const dmlHandler = new DmlHandler(ACCOUNT, hasuraClient, PgClient);
+    const dmlHandler = await DmlHandler.create(ACCOUNT, hasuraClient, PgClient);
 
     await dmlHandler.upsert(SCHEMA, TABLE_NAME, inputObj, conflictCol, updateCol);
     expect(query.mock.calls).toEqual([
@@ -139,7 +139,7 @@ describe('DML Handler tests', () => {
       block_height: 999,
     };
 
-    const dmlHandler = new DmlHandler(ACCOUNT, hasuraClient, PgClient);
+    const dmlHandler = await DmlHandler.create(ACCOUNT, hasuraClient, PgClient);
 
     await dmlHandler.delete(SCHEMA, TABLE_NAME, inputObj);
     expect(query.mock.calls).toEqual([

--- a/runner/src/dml-handler/dml-handler.test.ts
+++ b/runner/src/dml-handler/dml-handler.test.ts
@@ -39,7 +39,7 @@ describe('DML Handler tests', () => {
 
     await dmlHandler.insert(SCHEMA, TABLE_NAME, [inputObj]);
     expect(query.mock.calls).toEqual([
-      ['INSERT INTO test_schema.test_table (account_id,block_height,block_timestamp,content,receipt_id,accounts_liked) VALUES (\'test_acc_near\', \'999\', \'UTC\', \'test_content\', \'111\', \'["cwpuzzles.near","devbose.near"]\') RETURNING *;', []]
+      ['INSERT INTO test_schema.test_table (account_id,block_height,block_timestamp,content,receipt_id,accounts_liked) VALUES (\'test_acc_near\', \'999\', \'UTC\', \'test_content\', \'111\', \'["cwpuzzles.near","devbose.near"]\') RETURNING *', []]
     ]);
   });
 
@@ -59,7 +59,7 @@ describe('DML Handler tests', () => {
 
     await dmlHandler.insert(SCHEMA, TABLE_NAME, [inputObj]);
     expect(query.mock.calls).toEqual([
-      ['INSERT INTO test_schema.test_table (0,1) VALUES (\'{"account_id":"morgs_near","block_height":1,"receipt_id":"abc"}\'::jsonb, \'{"account_id":"morgs_near","block_height":2,"receipt_id":"abc"}\'::jsonb) RETURNING *;', []]
+      ['INSERT INTO test_schema.test_table (0,1) VALUES (\'{"account_id":"morgs_near","block_height":1,"receipt_id":"abc"}\'::jsonb, \'{"account_id":"morgs_near","block_height":2,"receipt_id":"abc"}\'::jsonb) RETURNING *', []]
     ]);
   });
 
@@ -88,6 +88,25 @@ describe('DML Handler tests', () => {
     await dmlHandler.select(SCHEMA, TABLE_NAME, inputObj, 1);
     expect(query.mock.calls).toEqual([
       ['SELECT * FROM test_schema.test_table WHERE account_id=$1 AND block_height=$2 LIMIT 1', Object.values(inputObj)]
+    ]);
+  });
+
+  test('Test valid update on two fields', async () => {
+    const whereObj = {
+      account_id: 'test_acc_near',
+      block_height: 999,
+    };
+
+    const updateObj = {
+      content: 'test_content',
+      receipt_id: 111,
+    };
+
+    const dmlHandler = new DmlHandler(ACCOUNT, hasuraClient, PgClient);
+
+    await dmlHandler.update(SCHEMA, TABLE_NAME, whereObj, updateObj);
+    expect(query.mock.calls).toEqual([
+      ['UPDATE test_schema.test_table SET content=$1, receipt_id=$2 WHERE account_id=$3 AND block_height=$4 RETURNING *', [...Object.values(updateObj), ...Object.values(whereObj)]]
     ]);
   });
 });

--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -34,7 +34,7 @@ export default class DmlHandler {
     const keys = Object.keys(objects[0]);
     // Get array of values from each object, and return array of arrays as result. Expects all objects to have the same number of items in same order
     const values = objects.map(obj => keys.map(key => obj[key]));
-    const query = `INSERT INTO ${schemaName}.${tableName} (${keys.join(',')}) VALUES %L RETURNING *`;
+    const query = `INSERT INTO ${schemaName}.${tableName} (${keys.join(', ')}) VALUES %L RETURNING *`;
 
     const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query, values), []), `Failed to execute '${query}' on ${schemaName}.${tableName}.`);
     if (result.rows?.length === 0) {
@@ -75,6 +75,40 @@ export default class DmlHandler {
     const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query), queryValues), `Failed to execute '${query}' on ${schemaName}.${tableName}.`);
     if (!(result.rows && result.rows.length > 0)) {
       console.log('No rows were selected.');
+    }
+    return result.rows;
+  }
+
+  async upsert (schemaName: string, tableName: string, objects: any[], conflictColumns: string[], updateColumns: string[]): Promise<any[]> {
+    await this.initialized; // Ensure constructor completed before proceeding
+    if (!objects?.length) {
+      return [];
+    }
+
+    const keys = Object.keys(objects[0]);
+    // Get array of values from each object, and return array of arrays as result. Expects all objects to have the same number of items in same order
+    const values = objects.map(obj => keys.map(key => obj[key]));
+    const updatePlaceholders = updateColumns.map(col => `${col} = excluded.${col}`).join(', ');
+    const query = `INSERT INTO ${schemaName}.${tableName} (${keys.join(', ')}) VALUES %L ON CONFLICT (${conflictColumns.join(', ')}) DO UPDATE SET ${updatePlaceholders} RETURNING *`;
+
+    const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query, values), []), `Failed to execute '${query}' on ${schemaName}.${tableName}.`);
+    if (result.rows?.length === 0) {
+      console.log('No rows were inserted or updated.');
+    }
+    return result.rows;
+  }
+
+  async delete (schemaName: string, tableName: string, object: any): Promise<any[]> {
+    await this.initialized; // Ensure constructor completed before proceeding
+
+    const keys = Object.keys(object);
+    const values = Object.values(object);
+    const param = Array.from({ length: keys.length }, (_, index) => `${keys[index]}=$${index + 1}`).join(' AND ');
+    const query = `DELETE FROM ${schemaName}.${tableName} WHERE ${param} RETURNING *`;
+
+    const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query), values), `Failed to execute '${query}' on ${schemaName}.${tableName}.`);
+    if (!(result.rows && result.rows.length > 0)) {
+      console.log('No rows were deleted.');
     }
     return result.rows;
   }

--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -34,7 +34,7 @@ export default class DmlHandler {
     const keys = Object.keys(objects[0]);
     // Get array of values from each object, and return array of arrays as result. Expects all objects to have the same number of items in same order
     const values = objects.map(obj => keys.map(key => obj[key]));
-    const query = `INSERT INTO ${schemaName}.${tableName} (${keys.join(',')}) VALUES %L RETURNING *;`;
+    const query = `INSERT INTO ${schemaName}.${tableName} (${keys.join(',')}) VALUES %L RETURNING *`;
 
     const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query, values), []), `Failed to execute '${query}' on ${schemaName}.${tableName}.`);
     if (result.rows?.length === 0) {
@@ -55,6 +55,24 @@ export default class DmlHandler {
     }
 
     const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query), values), `Failed to execute '${query}' on ${schemaName}.${tableName}.`);
+    if (!(result.rows && result.rows.length > 0)) {
+      console.log('No rows were selected.');
+    }
+    return result.rows;
+  }
+
+  async update (schemaName: string, tableName: string, whereObject: any, updateObject: any): Promise<any[]> {
+    await this.initialized; // Ensure constructor completed before proceeding
+
+    const updateKeys = Object.keys(updateObject);
+    const updateParam = Array.from({ length: updateKeys.length }, (_, index) => `${updateKeys[index]}=$${index + 1}`).join(', ');
+    const whereKeys = Object.keys(whereObject);
+    const whereParam = Array.from({ length: whereKeys.length }, (_, index) => `${whereKeys[index]}=$${index + 1 + updateKeys.length}`).join(' AND ');
+
+    const queryValues = [...Object.values(updateObject), ...Object.values(whereObject)];
+    const query = `UPDATE ${schemaName}.${tableName} SET ${updateParam} WHERE ${whereParam} RETURNING *`;
+
+    const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query), queryValues), `Failed to execute '${query}' on ${schemaName}.${tableName}.`);
     if (!(result.rows && result.rows.length > 0)) {
       console.log('No rows were selected.');
     }

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -534,28 +534,79 @@ CREATE TABLE
     expect(result.length).toEqual(2);
   });
 
-  test('indexer builds context and verifies all methods generated', async () => {
+  test('indexer builds context and upserts on existing table', async () => {
     const mockDmlHandler: any = jest.fn().mockImplementation(() => {
       return {
-        insert: jest.fn().mockReturnValue(true),
-        select: jest.fn().mockReturnValue(true)
+        upsert: jest.fn().mockImplementation((_, __, objects, conflict, update) => {
+          if (objects.length === 2 && conflict.includes('account_id') && update.includes('content')) {
+            return [{ colA: 'valA' }, { colA: 'valA' }];
+          } else if (objects.length === 1 && conflict.includes('account_id') && update.includes('content')) {
+            return [{ colA: 'valA' }];
+          }
+          return [{}];
+        })
       };
     });
 
     const indexer = new Indexer('mainnet', { DmlHandler: mockDmlHandler });
+    const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
+
+    const objToInsert = [{
+      account_id: 'morgs_near',
+      block_height: 1,
+      receipt_id: 'abc',
+      content: 'test',
+      block_timestamp: 800,
+      accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
+    },
+    {
+      account_id: 'morgs_near',
+      block_height: 2,
+      receipt_id: 'abc',
+      content: 'test',
+      block_timestamp: 801,
+      accounts_liked: JSON.stringify(['cwpuzzles.near'])
+    }];
+
+    let result = await context.db.upsert_posts(objToInsert, ['account_id', 'block_height'], ['content', 'block_timestamp']);
+    expect(result.length).toEqual(2);
+    result = await context.db.upsert_posts(objToInsert[0], ['account_id', 'block_height'], ['content', 'block_timestamp']);
+    expect(result.length).toEqual(1);
+  });
+
+  test('indexer builds context and deletes objects from existing table', async () => {
+    const mockDmlHandler: any = jest.fn().mockImplementation(() => {
+      return { delete: jest.fn().mockReturnValue([{ colA: 'valA' }, { colA: 'valA' }]) };
+    });
+
+    const indexer = new Indexer('mainnet', { DmlHandler: mockDmlHandler });
+    const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
+
+    const deleteFilter = {
+      account_id: 'morgs_near',
+      receipt_id: 'abc',
+    };
+    const result = await context.db.delete_posts(deleteFilter);
+    expect(result.length).toEqual(2);
+  });
+
+  test('indexer builds context and verifies all methods generated', async () => {
+    const mockDmlHandler: any = jest.fn();
+
+    const indexer = new Indexer('mainnet', { DmlHandler: mockDmlHandler });
     const context = indexer.buildContext(STRESS_TEST_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
 
-    expect(Object.keys(context.db)).toStrictEqual(
-      ['insert_creator_quest', 'select_creator_quest', 'update_creator_quest',
-        'insert_composer_quest', 'select_composer_quest', 'update_composer_quest',
-        'insert_contractor___quest', 'select_contractor___quest', 'update_contractor___quest',
-        'insert_posts', 'select_posts', 'update_posts',
-        'insert_comments', 'select_comments', 'update_comments',
-        'insert_post_likes', 'select_post_likes', 'update_post_likes',
-        'insert_My_Table1', 'select_My_Table1', 'update_My_Table1',
-        'insert_Another_Table', 'select_Another_Table', 'update_Another_Table',
-        'insert_Third_Table', 'select_Third_Table', 'update_Third_Table',
-        'insert_yet_another_table', 'select_yet_another_table', 'update_yet_another_table']);
+    expect(Object.keys(context.db)).toStrictEqual([
+      'insert_creator_quest', 'select_creator_quest', 'update_creator_quest', 'upsert_creator_quest', 'delete_creator_quest',
+      'insert_composer_quest', 'select_composer_quest', 'update_composer_quest', 'upsert_composer_quest', 'delete_composer_quest',
+      'insert_contractor___quest', 'select_contractor___quest', 'update_contractor___quest', 'upsert_contractor___quest', 'delete_contractor___quest',
+      'insert_posts', 'select_posts', 'update_posts', 'upsert_posts', 'delete_posts',
+      'insert_comments', 'select_comments', 'update_comments', 'upsert_comments', 'delete_comments',
+      'insert_post_likes', 'select_post_likes', 'update_post_likes', 'upsert_post_likes', 'delete_post_likes',
+      'insert_My_Table1', 'select_My_Table1', 'update_My_Table1', 'upsert_My_Table1', 'delete_My_Table1',
+      'insert_Another_Table', 'select_Another_Table', 'update_Another_Table', 'upsert_Another_Table', 'delete_Another_Table',
+      'insert_Third_Table', 'select_Third_Table', 'update_Third_Table', 'upsert_Third_Table', 'delete_Third_Table',
+      'insert_yet_another_table', 'select_yet_another_table', 'update_yet_another_table', 'upsert_yet_another_table', 'delete_yet_another_table']);
   });
 
   test('indexer builds context and returns empty array if failed to generate db methods', async () => {

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -279,14 +279,14 @@ export default class Indexer {
           [`update_${sanitizedTableName}`]: async (whereObj: any, updateObj: any) => {
             await this.writeLog(`context.db.update_${sanitizedTableName}`, blockHeight,
               `Calling context.db.update_${sanitizedTableName}.`,
-              `Updating object that matches ${JSON.stringify(whereObj)} with values ${JSON.stringify(updateObj)} in table ${tableName} on schema ${schemaName}`);
+              `Updating objects that match ${JSON.stringify(whereObj)} with values ${JSON.stringify(updateObj)} in table ${tableName} on schema ${schemaName}`);
             dmlHandler = dmlHandler ?? new this.deps.DmlHandler(account);
             return await dmlHandler.update(schemaName, tableName, whereObj, updateObj);
           },
           [`upsert_${sanitizedTableName}`]: async (objects: any, conflictColumns: string[], updateColumns: string[]) => {
             await this.writeLog(`context.db.upsert_${sanitizedTableName}`, blockHeight,
               `Calling context.db.upsert_${sanitizedTableName}.`,
-              `Inserting objects with values ${JSON.stringify(objects)} in table ${tableName} on schema ${schemaName}. On conflict on columns ${conflictColumns.join(', ')} will update values in columns ${updateColumns.join(', ')}`);
+              `Inserting objects with values ${JSON.stringify(objects)} in table ${tableName} on schema ${schemaName}. Conflict on columns ${conflictColumns.join(', ')} will update values in columns ${updateColumns.join(', ')}`);
             dmlHandler = dmlHandler ?? new this.deps.DmlHandler(account);
             return await dmlHandler.upsert(schemaName, tableName, Array.isArray(objects) ? objects : [objects], conflictColumns, updateColumns);
           },

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -271,9 +271,16 @@ export default class Indexer {
           [`select_${sanitizedTableName}`]: async (object: any, limit = null) => {
             await this.writeLog(`context.db.select_${sanitizedTableName}`, blockHeight,
               `Calling context.db.select_${sanitizedTableName}.`,
-              `Selecting objects with values ${JSON.stringify(object)} from table ${tableName} on schema ${schemaName} with limit ${limit === null ? 'no' : limit}`);
+              `Selecting objects with values ${JSON.stringify(object)} in table ${tableName} on schema ${schemaName} with ${limit === null ? 'no' : limit} limit`);
             dmlHandler = dmlHandler ?? new this.deps.DmlHandler(account);
             return await dmlHandler.select(schemaName, tableName, object, limit);
+          },
+          [`update_${sanitizedTableName}`]: async (whereObj: any, updateObj: any) => {
+            await this.writeLog(`context.db.update_${sanitizedTableName}`, blockHeight,
+              `Calling context.db.update_${sanitizedTableName}.`,
+              `Updating object that matches ${JSON.stringify(whereObj)} with values ${JSON.stringify(updateObj)} in table ${tableName} on schema ${schemaName}`);
+            dmlHandler = dmlHandler ?? new this.deps.DmlHandler(account);
+            return await dmlHandler.update(schemaName, tableName, whereObj, updateObj);
           }
         };
 


### PR DESCRIPTION
~~NOTE: PR targeting my active PR https://github.com/near/queryapi/pull/188 for now to show accurate diff. Once that PR is merged, I'll switch this PR back to main (Or open a new one) and do a push to fix the commit history and reopen for review. This is just to be available to look at in the mean time.~~

**PR 188 has been merged and I have rebased and force pushed the history to this PR. There are no conflicts with main.**

Adding functionality for update, upsert, delete. Added relevant tests as well as performed simple integration tests using existing tests. No problems found there. Will do a full test in dev after push as well by updating a forked social_feed indexer to use context.db exclusively. 