### PR TITLE
feat: Only write duration metric on success

### DIFF
--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -10,6 +10,7 @@ metrics.startServer().catch((err) => {
 });
 
 const STREAM_HANDLER_THROTTLE_MS = 500;
+const IGNORED_METRIC_DURATION = -1;
 
 const processStream = async (streamKey: string): Promise<void> => {
   console.log('Started processing stream: ', streamKey);
@@ -61,7 +62,7 @@ const processStream = async (streamKey: string): Promise<void> => {
     } catch (err) {
       console.log(`Failed: ${indexerName}`, err);
     } finally {
-      metrics.EXECUTION_DURATION.labels({ indexer: indexerName, type: streamType }).set(endTime ? endTime - startTime : -1);
+      metrics.EXECUTION_DURATION.labels({ indexer: indexerName, type: streamType }).set(endTime ? endTime - startTime : IGNORED_METRIC_DURATION);
     }
   }
 };


### PR DESCRIPTION
`EXECUTION_DURATION` will only be written when the indexer has been successfully executed, otherwise it is set to `-1`. This allows us to filter out these values in Grafana, and therefore only show accurate metrics.