### PR TITLE
fix: Handle errors emitted within worker threads

### DIFF
--- a/runner/src/stream-handler/stream-handler.ts
+++ b/runner/src/stream-handler/stream-handler.ts
@@ -8,7 +8,7 @@ export default class StreamHandler {
   private readonly worker?: Worker;
 
   constructor (
-    streamKey: string
+    public readonly streamKey: string
   ) {
     if (isMainThread) {
       this.worker = new Worker(path.join(__dirname, 'worker.js'), {
@@ -18,9 +18,17 @@ export default class StreamHandler {
       });
 
       this.worker.on('message', this.handleMessage);
+      this.worker.on('error', this.handleError);
     } else {
       throw new Error('StreamHandler should not be instantiated in a worker thread');
     }
+  }
+
+  private handleError (error: Error): void {
+    console.log(`Encountered error processing stream: ${this.streamKey}, terminating thread`, error);
+    this.worker?.terminate().catch(() => {
+      console.log(`Failed to terminate thread for stream: ${this.streamKey}`);
+    });
   }
 
   private handleMessage (message: Message): void {


### PR DESCRIPTION
Uncaught errors thrown within the worker will kill the entire application. This PR handles this by listening for these errors and terminating the thread if they arise.