### PR TITLE
fix: Use `Histogram` to prevent stale metrics being scraped

### DIFF
--- a/runner/src/metrics.ts
+++ b/runner/src/metrics.ts
@@ -7,7 +7,7 @@ const UNPROCESSED_STREAM_MESSAGES = new promClient.Gauge({
   labelNames: ['indexer', 'type'],
 });
 
-const EXECUTION_DURATION = new promClient.Gauge({
+const EXECUTION_DURATION = new promClient.Histogram({
   name: 'queryapi_runner_execution_duration_milliseconds',
   help: 'Time taken to execute an indexer function',
   labelNames: ['indexer', 'type'],

--- a/runner/src/stream-handler/stream-handler.ts
+++ b/runner/src/stream-handler/stream-handler.ts
@@ -3,7 +3,7 @@ import { Worker, isMainThread } from 'worker_threads';
 
 import { type Message } from './types';
 import { METRICS } from '../metrics';
-import { Gauge } from 'prom-client';
+import { Gauge, Histogram } from 'prom-client';
 
 export default class StreamHandler {
   private readonly worker?: Worker;
@@ -35,6 +35,10 @@ export default class StreamHandler {
   private handleMessage (message: Message): void {
     if (METRICS[message.type] instanceof Gauge) {
       (METRICS[message.type] as Gauge).labels(message.labels).set(message.value);
+    }
+
+    if (METRICS[message.type] instanceof Histogram) {
+      (METRICS[message.type] as Histogram).labels(message.labels).observe(message.value);
     }
   }
 }


### PR DESCRIPTION
This PR migrates the `EXECUTION_DURATION` to `Histogram` from `Gauge`. With `Gauge`s, the previously recorded metric value will continue to be scraped creating a flat-line graph in Grafana. Histograms allow us to better approximate the metric over a specific time range, removing these flat-lines.

Resolves #208 