### PR TITLE
feat: Use V2 endpoint to calculate social lag metric

### DIFF
--- a/indexer-js-queue-handler/serverless.yml
+++ b/indexer-js-queue-handler/serverless.yml
@@ -12,6 +12,7 @@ provider:
     REGION: ${self:provider.region}
     STAGE: ${opt:stage, 'dev'}
     HASURA_ENDPOINT: ${env:HASURA_ENDPOINT}
+    HASURA_ENDPOINT_V2: ${env:HASURA_ENDPOINT_V2}
     HASURA_ADMIN_SECRET: ${env:HASURA_ADMIN_SECRET}
     PG_ADMIN_USER: ${env:PG_ADMIN_USER}
     PG_ADMIN_PASSWORD: ${env:PG_ADMIN_PASSWORD}

--- a/indexer-js-queue-handler/social-lag-metrics-writer.js
+++ b/indexer-js-queue-handler/social-lag-metrics-writer.js
@@ -35,7 +35,7 @@ export const handler = async () => {
             },
         }),
         fetchJson(
-            `${process.env.HASURA_ENDPOINT}/v1/graphql`,
+            `${process.env.HASURA_ENDPOINT_V2}/v1/graphql`,
             {
                 query: `{
                     dataplatform_near_social_feed_posts(


### PR DESCRIPTION
I've created a new env var because updating the existing would cause the Lambdas to start writing to V2. Will add the following env variables to GitHub so they are picked up in the action:
- `LAMBDA_DEV:HASURA_ENDPOINT_V2` - https://queryapi-hasura-graphql-mainnet-vcqilefdcq-ew.a.run.app/
- `LAMBDA_PROD:HASURA_ENDPOINT_V2` - https://queryapi-hasura-graphql-mainnet-24ktefolwq-ew.a.run.app/

Resolves #343 