### PR TITLE
fix: Ensure historical invocations are configured correctly

### DIFF
--- a/runner/src/stream-handler/worker.ts
+++ b/runner/src/stream-handler/worker.ts
@@ -20,6 +20,7 @@ void (async function main () {
 
   let indexerName = '';
   const streamType = redisClient.getStreamType(streamKey);
+  const isHistorical = streamType === 'historical';
 
   while (true) {
     try {
@@ -46,7 +47,7 @@ void (async function main () {
           provisioned: false,
         },
       };
-      await indexer.runFunctions(Number(message.block_height), functions, false, {
+      await indexer.runFunctions(Number(message.block_height), functions, isHistorical, {
         provision: true,
       });
 


### PR DESCRIPTION
Previously, indexer executions were hardcoded to run with `isHistorical = false`. This caused the `Current Block Height` to be incorrectly set to the `Current Historical Block height`.

This PR updates Runner so that `isHistorical` is correctly set.