### PR TITLE
feat: Cancel historical backfill process before starting anew

### DIFF
--- a/indexer/Cargo.lock
+++ b/indexer/Cargo.lock
@@ -3349,6 +3349,7 @@ dependencies = [
  "storage",
  "tokio",
  "tokio-stream",
+ "tokio-util 0.6.10",
  "tracing",
  "tracing-subscriber 0.2.25",
  "unescape",

--- a/indexer/queryapi_coordinator/Cargo.toml
+++ b/indexer/queryapi_coordinator/Cargo.toml
@@ -17,6 +17,7 @@ prometheus = "0.13.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.55"
 tokio = { version = "1.1", features = ["sync", "time", "macros", "rt-multi-thread"] }
+tokio-util = "0.6.7"
 tokio-stream = { version = "0.1" }
 tracing = "0.1.34"
 

--- a/indexer/queryapi_coordinator/src/indexer_registry.rs
+++ b/indexer/queryapi_coordinator/src/indexer_registry.rs
@@ -162,15 +162,16 @@ async fn index_and_process_register_calls(
                             existing_streamer.cancel().await?;
                         }
 
-                        let streamer =
-                            crate::historical_block_processing::spawn_historical_message_thread(
-                                current_block_height,
-                                &new_indexer_function,
-                                context.redis_connection_manager,
-                                context.s3_client,
-                                context.chain_id,
-                                context.json_rpc_client,
-                            );
+                        let mut streamer = crate::historical_block_processing::Streamer::new();
+
+                        streamer.start(
+                            current_block_height,
+                            new_indexer_function.clone(),
+                            context.redis_connection_manager.clone(),
+                            context.s3_client.clone(),
+                            context.chain_id.clone(),
+                            context.json_rpc_client.clone(),
+                        )?;
 
                         streamers_lock.insert(new_indexer_function.get_full_name(), streamer);
                     }

--- a/indexer/queryapi_coordinator/src/indexer_registry.rs
+++ b/indexer/queryapi_coordinator/src/indexer_registry.rs
@@ -12,6 +12,7 @@ use tokio::sync::MutexGuard;
 use tokio::task::JoinHandle;
 use unescape::unescape;
 
+use crate::historical_block_processing::Streamer;
 use crate::indexer_reducer;
 use crate::indexer_reducer::FunctionCallInfo;
 use crate::indexer_types::{IndexerFunction, IndexerRegistry};
@@ -102,7 +103,7 @@ pub(crate) async fn index_registry_changes(
     current_block_height: BlockHeight,
     registry: &mut MutexGuard<'_, IndexerRegistry>,
     context: &QueryApiContext<'_>,
-) -> Vec<JoinHandle<i64>> {
+) -> Vec<Streamer> {
     index_and_process_remove_calls(registry, context);
 
     index_and_process_register_calls(current_block_height, registry, context)
@@ -112,7 +113,7 @@ fn index_and_process_register_calls(
     current_block_height: BlockHeight,
     registry: &mut MutexGuard<IndexerRegistry>,
     context: &QueryApiContext,
-) -> Vec<JoinHandle<i64>> {
+) -> Vec<Streamer> {
     let registry_method_name = "register_indexer_function";
     let registry_calls_rule =
         build_registry_indexer_rule(registry_method_name, context.registry_contract_id);

--- a/indexer/queryapi_coordinator/src/indexer_registry.rs
+++ b/indexer/queryapi_coordinator/src/indexer_registry.rs
@@ -169,7 +169,7 @@ fn index_and_process_register_calls(
                     }
 
                     if new_indexer_function.start_block_height.is_some() {
-                        if let Some(thread) =
+                        let streamer =
                             crate::historical_block_processing::spawn_historical_message_thread(
                                 current_block_height,
                                 &new_indexer_function,
@@ -177,10 +177,9 @@ fn index_and_process_register_calls(
                                 context.s3_client,
                                 context.chain_id,
                                 context.json_rpc_client,
-                            )
-                        {
-                            spawned_start_from_block_threads.push(thread);
-                        }
+                            );
+
+                        spawned_start_from_block_threads.push(streamer);
                     }
 
                     fns.insert(update.method_name.clone(), new_indexer_function);

--- a/indexer/queryapi_coordinator/src/indexer_registry.rs
+++ b/indexer/queryapi_coordinator/src/indexer_registry.rs
@@ -99,17 +99,17 @@ pub(crate) fn build_registry_from_json(raw_registry: Value) -> IndexerRegistry {
 
 /// Returns spawned start_from_block threads
 pub(crate) async fn index_registry_changes(
-    block_height: BlockHeight,
+    current_block_height: BlockHeight,
     registry: &mut MutexGuard<'_, IndexerRegistry>,
     context: &QueryApiContext<'_>,
 ) -> Vec<JoinHandle<i64>> {
     index_and_process_remove_calls(registry, context);
 
-    index_and_process_register_calls(block_height, registry, context)
+    index_and_process_register_calls(current_block_height, registry, context)
 }
 
 fn index_and_process_register_calls(
-    block_height: BlockHeight,
+    current_block_height: BlockHeight,
     registry: &mut MutexGuard<IndexerRegistry>,
     context: &QueryApiContext,
 ) -> Vec<JoinHandle<i64>> {
@@ -145,7 +145,7 @@ fn index_and_process_register_calls(
                             tracing::info!(
                                 target: crate::INDEXER,
                                 "Block {}. Indexed creation call to {registry_method_name}: {:?} {:?}",
-                                block_height,
+                                current_block_height,
                                 new_indexer_function.account_id.clone(),
                                 new_indexer_function.function_name.clone()
                             );
@@ -156,7 +156,7 @@ fn index_and_process_register_calls(
                             tracing::info!(
                                 target: crate::INDEXER,
                                 "Block {}. Indexed update call to {registry_method_name}: {:?} {:?}",
-                                block_height,
+                                current_block_height,
                                 new_indexer_function.account_id.clone(),
                                 new_indexer_function.function_name.clone(),
                             );
@@ -170,7 +170,7 @@ fn index_and_process_register_calls(
                     if new_indexer_function.start_block_height.is_some() {
                         if let Some(thread) =
                             crate::historical_block_processing::spawn_historical_message_thread(
-                                block_height,
+                                current_block_height,
                                 &new_indexer_function,
                                 context.redis_connection_manager,
                                 context.s3_client,

--- a/indexer/queryapi_coordinator/src/main.rs
+++ b/indexer/queryapi_coordinator/src/main.rs
@@ -1,6 +1,6 @@
 use futures::stream::{self, StreamExt};
 use near_jsonrpc_client::JsonRpcClient;
-use tokio::sync::{Mutex, MutexGuard};
+use tokio::sync::Mutex;
 
 use indexer_rules_engine::types::indexer_rule_match::{ChainId, IndexerRuleMatch};
 use near_lake_framework::near_indexer_primitives::types::BlockHeight;
@@ -32,6 +32,7 @@ pub(crate) struct QueryApiContext<'a> {
     pub json_rpc_client: &'a JsonRpcClient,
     pub registry_contract_id: &'a str,
     pub redis_connection_manager: &'a ConnectionManager,
+    pub indexer_registry: &'a SharedIndexerRegistry,
 }
 
 #[tokio::main]
@@ -88,8 +89,10 @@ async fn main() -> anyhow::Result<()> {
                 chain_id,
                 json_rpc_client: &json_rpc_client,
                 s3_client: &s3_client,
+                indexer_registry: &indexer_registry,
             };
-            handle_streamer_message(context, indexer_registry.clone())
+
+            handle_streamer_message(context)
         })
         .buffer_unordered(1usize);
 
@@ -108,13 +111,15 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
-async fn handle_streamer_message(
-    context: QueryApiContext<'_>,
-    indexer_registry: SharedIndexerRegistry,
-) -> anyhow::Result<u64> {
-    let mut indexer_registry_locked = indexer_registry.lock().await;
-    let indexer_functions =
-        indexer_registry::registry_as_vec_of_indexer_functions(&indexer_registry_locked);
+async fn handle_streamer_message(context: QueryApiContext<'_>) -> anyhow::Result<u64> {
+    let indexer_functions = {
+        let lock = context.indexer_registry.lock().await;
+
+        lock.values()
+            .flat_map(|fns| fns.values())
+            .cloned()
+            .collect::<Vec<_>>()
+    };
 
     let mut indexer_function_filter_matches_futures = stream::iter(indexer_functions.iter())
         .map(|indexer_function| {
@@ -138,12 +143,8 @@ async fn handle_streamer_message(
     )
     .await?;
 
-    let spawned_indexers = indexer_registry::index_registry_changes(
-        block_height,
-        &mut indexer_registry_locked,
-        &context,
-    )
-    .await;
+    let spawned_indexers = indexer_registry::index_registry_changes(block_height, &context).await;
+
     if !spawned_indexers.is_empty() {
         tracing::info!(
             target: INDEXER,
@@ -169,7 +170,7 @@ async fn handle_streamer_message(
                 );
 
                 if !indexer_function.provisioned {
-                    set_provisioned_flag(&mut indexer_registry_locked, indexer_function);
+                    set_provisioned_flag(context.indexer_registry, indexer_function).await;
                 }
 
                 storage::sadd(
@@ -216,11 +217,15 @@ async fn handle_streamer_message(
     Ok(context.streamer_message.block.header.height)
 }
 
-fn set_provisioned_flag(
-    indexer_registry_locked: &mut MutexGuard<IndexerRegistry>,
+async fn set_provisioned_flag(
+    indexer_registry: &SharedIndexerRegistry,
     indexer_function: &IndexerFunction,
 ) {
-    match indexer_registry_locked.get_mut(&indexer_function.account_id) {
+    match indexer_registry
+        .lock()
+        .await
+        .get_mut(&indexer_function.account_id)
+    {
         Some(account_functions) => {
             match account_functions.get_mut(&indexer_function.function_name) {
                 Some(indexer_function) => {
@@ -315,7 +320,7 @@ mod tests {
             std::sync::Arc::new(Mutex::new(indexer_registry));
         let mut indexer_registry_locked = indexer_registry.lock().await;
 
-        set_provisioned_flag(&mut indexer_registry_locked, &indexer_function);
+        set_provisioned_flag(&indexer_registry, &indexer_function);
 
         let account_functions = indexer_registry_locked
             .get(&indexer_function.account_id)

--- a/indexer/queryapi_coordinator/src/main.rs
+++ b/indexer/queryapi_coordinator/src/main.rs
@@ -151,7 +151,7 @@ async fn handle_streamer_message(context: QueryApiContext<'_>) -> anyhow::Result
     )
     .await?;
 
-    indexer_registry::index_registry_changes(block_height, &context).await;
+    indexer_registry::index_registry_changes(block_height, &context).await?;
 
     while let Some(indexer_function_with_matches) =
         indexer_function_filter_matches_futures.next().await


### PR DESCRIPTION
This PR updates Coordinator such that **only one** Historical Backfill process can exist for a given Indexer Function. Currently, these processes do not have awareness of each other, meaning a developer can trigger multiple simultaneous backfills, with them all writing to the same Redis Stream. The major changes are detailed below.

## Streamer/Historical backfill tasks
In this PR, I've introduced the `historical_block_processing::Streamer` struct. This is used to encapsulate the async task which is spawned for handling the Historical Backfill. I went with "Streamer", as I envision this becoming the single process which handles both historical/real-time messages for a given Indexer, as described in https://github.com/near/queryapi/issues/216#issuecomment-1777938653.

`Streamer` is responsible for starting the `async` task, and provides a basic API for interacting with it. Right now, that only includes cancelling it. Cancelling a `Streamer` will drop the existing future, preventing any new messages from being added, and then delete the Redis Stream removing all existing messages.

## Indexer Registry Mutex/Async
`indexer_registry` is the in-memory representation of the given Indexer Registry. Currently, we pass around the `MutexGuard` to mutate this data, resulting in the lock being held for much longer than is needed, blocking all other consumers from taking the lock. There isn't much contention for this lock, so it isn't a problem right now, but could end up being one in future.

Adding in the `Streamer` `Mutex` made mitigating this problem trivial, so I went ahead and made some changes. I've updated the code so that we pass around the `Mutex` itself, rather than the guard, allowing us to the hold the lock for the least amount of time possible. This required updating most methods within `indexer_registry` to `async`, so that we could take the `async` `lock`.

With the `Mutex` being used rather than the `MutexGuard`, it seemed sensible to add `indexer_registry` to `QueryAPIContext`, rather than passing it round individually.