### PR TITLE
refactor/remove sqs from historical backfill

### DIFF
--- a/indexer/queryapi_coordinator/src/historical_block_processing.rs
+++ b/indexer/queryapi_coordinator/src/historical_block_processing.rs
@@ -1,5 +1,4 @@
 use crate::indexer_types::IndexerFunction;
-use crate::opts::{Opts, Parser};
 use crate::s3;
 use anyhow::{bail, Context};
 use aws_sdk_s3::Client as S3Client;
@@ -37,7 +36,6 @@ pub fn spawn_historical_message_thread(
             process_historical_messages_or_handle_error(
                 block_height,
                 new_indexer_function_copy,
-                Opts::parse(),
                 &redis_connection_manager,
                 &s3_client,
                 &chain_id,
@@ -51,7 +49,6 @@ pub fn spawn_historical_message_thread(
 pub(crate) async fn process_historical_messages_or_handle_error(
     block_height: BlockHeight,
     indexer_function: IndexerFunction,
-    opts: Opts,
     redis_connection_manager: &storage::ConnectionManager,
     s3_client: &S3Client,
     chain_id: &ChainId,
@@ -60,7 +57,6 @@ pub(crate) async fn process_historical_messages_or_handle_error(
     match process_historical_messages(
         block_height,
         indexer_function,
-        opts,
         redis_connection_manager,
         s3_client,
         chain_id,
@@ -83,7 +79,6 @@ pub(crate) async fn process_historical_messages_or_handle_error(
 pub(crate) async fn process_historical_messages(
     block_height: BlockHeight,
     indexer_function: IndexerFunction,
-    opts: Opts,
     redis_connection_manager: &storage::ConnectionManager,
     s3_client: &S3Client,
     chain_id: &ChainId,

--- a/indexer/queryapi_coordinator/src/historical_block_processing_integration_tests.rs
+++ b/indexer/queryapi_coordinator/src/historical_block_processing_integration_tests.rs
@@ -77,12 +77,17 @@ mod tests {
         };
 
         let opts = Opts::test_opts_with_aws();
+
         let aws_config: &SdkConfig = &opts.lake_aws_sdk_config();
         let s3_config = aws_sdk_s3::config::Builder::from(aws_config).build();
         let s3_client = aws_sdk_s3::Client::from_conf(s3_config);
+
         let redis_connection_manager = storage::connect(&opts.redis_connection_string)
             .await
             .unwrap();
+
+        let json_rpc_client = near_jsonrpc_client::JsonRpcClient::connect(opts.rpc_url());
+
         let fake_block_height =
             historical_block_processing::last_indexed_block_from_metadata(&s3_client)
                 .await
@@ -92,6 +97,8 @@ mod tests {
             indexer_function,
             opts,
             &redis_connection_manager,
+            &s3_client,
+            &json_rpc_client,
         )
         .await;
         assert!(result.unwrap() > 0);

--- a/indexer/queryapi_coordinator/src/historical_block_processing_integration_tests.rs
+++ b/indexer/queryapi_coordinator/src/historical_block_processing_integration_tests.rs
@@ -95,9 +95,9 @@ mod tests {
         let result = historical_block_processing::process_historical_messages(
             fake_block_height + 1,
             indexer_function,
-            opts,
             &redis_connection_manager,
             &s3_client,
+            &opts.chain_id(),
             &json_rpc_client,
         )
         .await;

--- a/indexer/queryapi_coordinator/src/historical_block_processing_integration_tests.rs
+++ b/indexer/queryapi_coordinator/src/historical_block_processing_integration_tests.rs
@@ -38,9 +38,11 @@ mod tests {
     async fn test_indexing_metadata_file() {
         let opts = Opts::test_opts_with_aws();
         let aws_config: &SdkConfig = &opts.lake_aws_sdk_config();
+        let s3_config = aws_sdk_s3::config::Builder::from(aws_config).build();
+        let s3_client = aws_sdk_s3::Client::from_conf(s3_config);
 
         let last_indexed_block =
-            historical_block_processing::last_indexed_block_from_metadata(aws_config)
+            historical_block_processing::last_indexed_block_from_metadata(&s3_client)
                 .await
                 .unwrap();
         let a: Range<u64> = 90000000..9000000000; // valid for the next 300 years
@@ -76,11 +78,13 @@ mod tests {
 
         let opts = Opts::test_opts_with_aws();
         let aws_config: &SdkConfig = &opts.lake_aws_sdk_config();
+        let s3_config = aws_sdk_s3::config::Builder::from(aws_config).build();
+        let s3_client = aws_sdk_s3::Client::from_conf(s3_config);
         let redis_connection_manager = storage::connect(&opts.redis_connection_string)
             .await
             .unwrap();
         let fake_block_height =
-            historical_block_processing::last_indexed_block_from_metadata(aws_config)
+            historical_block_processing::last_indexed_block_from_metadata(&s3_client)
                 .await
                 .unwrap();
         let result = historical_block_processing::process_historical_messages(
@@ -120,6 +124,8 @@ mod tests {
 
         let opts = Opts::test_opts_with_aws();
         let aws_config: &SdkConfig = &opts.lake_aws_sdk_config();
+        let s3_config = aws_sdk_s3::config::Builder::from(aws_config).build();
+        let s3_client = aws_sdk_s3::Client::from_conf(s3_config);
 
         let start_block_height = 77016214;
         let naivedatetime_utc = NaiveDate::from_ymd_opt(2022, 10, 03)
@@ -130,7 +136,7 @@ mod tests {
         let blocks = filter_matching_blocks_from_index_files(
             start_block_height,
             &indexer_function,
-            aws_config,
+            &s3_client,
             datetime_utc,
         )
         .await;
@@ -177,6 +183,8 @@ mod tests {
 
         let opts = Opts::test_opts_with_aws();
         let aws_config: &SdkConfig = &opts.lake_aws_sdk_config();
+        let s3_config = aws_sdk_s3::config::Builder::from(aws_config).build();
+        let s3_client = aws_sdk_s3::Client::from_conf(s3_config);
 
         let start_block_height = 45894620;
         let naivedatetime_utc = NaiveDate::from_ymd_opt(2021, 08, 01)
@@ -187,7 +195,7 @@ mod tests {
         let blocks = filter_matching_blocks_from_index_files(
             start_block_height,
             &indexer_function,
-            aws_config,
+            &s3_client,
             datetime_utc,
         )
         .await;

--- a/indexer/queryapi_coordinator/src/indexer_registry.rs
+++ b/indexer/queryapi_coordinator/src/indexer_registry.rs
@@ -173,6 +173,8 @@ fn index_and_process_register_calls(
                                 block_height,
                                 &new_indexer_function,
                                 context.redis_connection_manager,
+                                context.s3_client,
+                                context.chain_id,
                             )
                         {
                             spawned_start_from_block_threads.push(thread);

--- a/indexer/queryapi_coordinator/src/indexer_registry.rs
+++ b/indexer/queryapi_coordinator/src/indexer_registry.rs
@@ -175,6 +175,7 @@ fn index_and_process_register_calls(
                                 context.redis_connection_manager,
                                 context.s3_client,
                                 context.chain_id,
+                                context.json_rpc_client,
                             )
                         {
                             spawned_start_from_block_threads.push(thread);

--- a/indexer/queryapi_coordinator/src/indexer_registry.rs
+++ b/indexer/queryapi_coordinator/src/indexer_registry.rs
@@ -171,7 +171,7 @@ fn index_and_process_register_calls(
                         if let Some(thread) =
                             crate::historical_block_processing::spawn_historical_message_thread(
                                 block_height,
-                                &mut new_indexer_function,
+                                &new_indexer_function,
                                 context.redis_connection_manager,
                             )
                         {

--- a/indexer/queryapi_coordinator/src/main.rs
+++ b/indexer/queryapi_coordinator/src/main.rs
@@ -43,6 +43,7 @@ pub(crate) struct QueryApiContext<'a> {
     pub chain_id: &'a ChainId,
     pub queue_client: &'a queue::QueueClient,
     pub s3_client: &'a aws_sdk_s3::Client,
+    pub json_rpc_client: &'a JsonRpcClient,
     pub queue_url: &'a str,
     pub registry_contract_id: &'a str,
     pub balance_cache: &'a BalanceCache,
@@ -111,6 +112,7 @@ async fn main() -> anyhow::Result<()> {
                 streamer_message,
                 chain_id,
                 queue_client: &queue_client,
+                json_rpc_client: &json_rpc_client,
                 s3_client: &s3_client,
             };
             handle_streamer_message(context, indexer_registry.clone())


### PR DESCRIPTION
- refactor: Dont push to SQS during historical backfill
- refactor: Pass round `s3_client` rather than `s3_config`
- refactor: Instantiate singleton `s3_client`
- refactor: Instantiate singleton `json_rpc_client`
- refactor: Remove `Opts` reference from historical backfill
