### PR TITLE
refactor: Speed up Historical Backfill process

### DIFF
--- a/indexer/Cargo.lock
+++ b/indexer/Cargo.lock
@@ -3324,6 +3324,7 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "anyhow",
+ "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",
  "aws-types",

--- a/indexer/queryapi_coordinator/Cargo.toml
+++ b/indexer/queryapi_coordinator/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Near Inc <hello@nearprotocol.com>"]
 [dependencies]
 anyhow = "1.0.57"
 actix-web = "=4.0.1"
+aws-config = "0.53.0"
 borsh = "0.10.2"
 cached = "0.23.0"
 chrono = "0.4.25"

--- a/indexer/queryapi_coordinator/src/historical_block_processing.rs
+++ b/indexer/queryapi_coordinator/src/historical_block_processing.rs
@@ -11,8 +11,6 @@ use near_lake_framework::near_indexer_primitives::types::{BlockHeight, BlockId, 
 use serde_json::from_str;
 use tokio::task::JoinHandle;
 
-pub const INDEXED_DATA_FILES_BUCKET: &str = "near-delta-lake";
-pub const INDEXED_ACTIONS_FILES_FOLDER: &str = "silver/accounts/action_receipt_actions/metadata";
 pub const MAX_RPC_BLOCKS_TO_PROCESS: u8 = 20;
 
 pub struct Task {
@@ -267,8 +265,13 @@ pub(crate) async fn process_historical_messages(
 pub(crate) async fn last_indexed_block_from_metadata(
     s3_client: &S3Client,
 ) -> anyhow::Result<BlockHeight> {
-    let key = format!("{}/{}", INDEXED_ACTIONS_FILES_FOLDER, "latest_block.json");
-    let metadata = s3::fetch_text_file_from_s3(INDEXED_DATA_FILES_BUCKET, key, s3_client).await?;
+    let key = format!(
+        "{}/{}",
+        s3::INDEXED_ACTIONS_FILES_FOLDER,
+        "latest_block.json"
+    );
+    let metadata =
+        s3::fetch_text_file_from_s3(s3::INDEXED_DATA_FILES_BUCKET, key, s3_client).await?;
 
     let metadata: serde_json::Value = serde_json::from_str(&metadata).unwrap();
     let last_indexed_block = metadata["last_indexed_block"].clone();
@@ -291,7 +294,7 @@ pub(crate) async fn filter_matching_blocks_from_index_files(
     s3_client: &S3Client,
     start_date: DateTime<Utc>,
 ) -> anyhow::Result<Vec<BlockHeight>> {
-    let s3_bucket = INDEXED_DATA_FILES_BUCKET;
+    let s3_bucket = s3::INDEXED_DATA_FILES_BUCKET;
 
     let mut needs_dedupe_and_sort = false;
     let indexer_rule = &indexer_function.indexer_rule;
@@ -307,7 +310,7 @@ pub(crate) async fn filter_matching_blocks_from_index_files(
             s3::fetch_contract_index_files(
                 s3_client,
                 s3_bucket,
-                INDEXED_ACTIONS_FILES_FOLDER,
+                s3::INDEXED_ACTIONS_FILES_FOLDER,
                 start_date,
                 affected_account_id,
             )

--- a/indexer/queryapi_coordinator/src/historical_block_processing.rs
+++ b/indexer/queryapi_coordinator/src/historical_block_processing.rs
@@ -188,7 +188,7 @@ pub(crate) async fn process_historical_messages(
 
             tracing::info!(
                 target: crate::INDEXER,
-                "Flushing {} blocks from index files to historical Stream for indexer: {}",
+                "Flushing {} block heights from index files to historical Stream for indexer: {}",
                 blocks_from_index.len(),
                 indexer_function.get_full_name(),
             );
@@ -255,7 +255,7 @@ pub(crate) async fn process_historical_messages(
 
             tracing::info!(
                 target: crate::INDEXER,
-                "Flushed {} unindexed blocks to historical Stream for indexer: {}",
+                "Flushed {} unindexed block heights to historical Stream for indexer: {}",
                 filtered_block_count,
                 indexer_function.get_full_name(),
             );

--- a/indexer/queryapi_coordinator/src/historical_block_processing.rs
+++ b/indexer/queryapi_coordinator/src/historical_block_processing.rs
@@ -53,7 +53,7 @@ impl Streamer {
                 _ = cancellation_token_clone.cancelled() => {
                     tracing::info!(
                         target: crate::INDEXER,
-                        "Cancelling existing historical backfill for indexer: {:?}",
+                        "Cancelling existing historical backfill for indexer: {}",
                         indexer.get_full_name(),
                     );
                 },
@@ -67,7 +67,7 @@ impl Streamer {
                 ) => {
                     tracing::info!(
                         target: crate::INDEXER,
-                        "Finished historical backfill for indexer: {:?}",
+                        "Finished historical backfill for indexer: {}",
                         indexer.get_full_name(),
                     );
                 }
@@ -138,21 +138,22 @@ pub(crate) async fn process_historical_messages(
     let block_difference: i64 = (current_block_height - start_block) as i64;
     match block_difference {
         i64::MIN..=-1 => {
-            bail!("Skipping back fill, start_block_height is greater than current block height: {:?} {:?}",
-                                     indexer_function.account_id,
-                                     indexer_function.function_name);
+            bail!(
+                "Skipping back fill, start_block_height is greater than current block height: {}",
+                indexer_function.get_full_name(),
+            );
         }
         0 => {
-            bail!("Skipping back fill, start_block_height is equal to current block height: {:?} {:?}",
-                                     indexer_function.account_id,
-                                     indexer_function.function_name);
+            bail!(
+                "Skipping back fill, start_block_height is equal to current block height: {}",
+                indexer_function.get_full_name(),
+            );
         }
         1..=i64::MAX => {
             tracing::info!(
                 target: crate::INDEXER,
-                "Back filling {block_difference} blocks from {start_block} to current block height {current_block_height}: {:?} {:?}",
-                indexer_function.account_id,
-                indexer_function.function_name
+                "Back filling {block_difference} blocks from {start_block} to current block height {current_block_height}: {}",
+                indexer_function.get_full_name(),
             );
 
             storage::del(
@@ -189,7 +190,7 @@ pub(crate) async fn process_historical_messages(
 
             tracing::info!(
                 target: crate::INDEXER,
-                "Flushing {} blocks to historical Stream for indexer: {}",
+                "Flushing {} blocks from index files to historical Stream for indexer: {}",
                 blocks_from_index.len(),
                 indexer_function.get_full_name(),
             );

--- a/indexer/queryapi_coordinator/src/historical_block_processing.rs
+++ b/indexer/queryapi_coordinator/src/historical_block_processing.rs
@@ -64,7 +64,13 @@ impl Streamer {
                     &s3_client,
                     &chain_id,
                     &json_rpc_client,
-                ) => { }
+                ) => {
+                    tracing::info!(
+                        target: crate::INDEXER,
+                        "Finished historical backfill for indexer: {:?}",
+                        indexer.get_full_name(),
+                    );
+                }
             }
         });
 

--- a/indexer/queryapi_coordinator/src/historical_block_processing.rs
+++ b/indexer/queryapi_coordinator/src/historical_block_processing.rs
@@ -219,7 +219,7 @@ pub(crate) async fn process_historical_messages(
                 ChainId::Mainnet => near_lake_framework::LakeConfigBuilder::default().mainnet(),
                 ChainId::Testnet => near_lake_framework::LakeConfigBuilder::default().testnet(),
             }
-            .start_block_height(last_indexed_block + 1)
+            .start_block_height(last_indexed_block)
             .build()
             .context("Failed to build lake config")?;
 

--- a/indexer/queryapi_coordinator/src/main.rs
+++ b/indexer/queryapi_coordinator/src/main.rs
@@ -51,9 +51,8 @@ async fn main() -> anyhow::Result<()> {
     let chain_id = &opts.chain_id();
     let registry_contract_id = opts.registry_contract_id.clone();
 
-    let aws_config = &opts.lake_aws_sdk_config();
-    let s3_config = aws_sdk_s3::config::Builder::from(aws_config).build();
-    let s3_client = aws_sdk_s3::Client::from_conf(s3_config);
+    let aws_config = aws_config::from_env().load().await;
+    let s3_client = aws_sdk_s3::Client::new(&aws_config);
 
     tracing::info!(target: INDEXER, "Connecting to redis...");
     let redis_connection_manager = storage::connect(&opts.redis_connection_string).await?;

--- a/indexer/queryapi_coordinator/src/s3.rs
+++ b/indexer/queryapi_coordinator/src/s3.rs
@@ -7,6 +7,8 @@ use futures::future::try_join_all;
 // Currently that would be either 2,700 years of FunctionCall data or 1M contract folders.
 // If we hit 1M contracts we should build an index to support efficient wildcard contract matching.
 const MAX_S3_LIST_REQUESTS: usize = 1000;
+pub const INDEXED_DATA_FILES_BUCKET: &str = "near-delta-lake";
+pub const INDEXED_ACTIONS_FILES_FOLDER: &str = "silver/accounts/action_receipt_actions/metadata";
 
 fn storage_path_for_account(account: &str) -> String {
     let mut folders = account.split('.').collect::<Vec<&str>>();

--- a/indexer/queryapi_coordinator/src/s3.rs
+++ b/indexer/queryapi_coordinator/src/s3.rs
@@ -194,22 +194,18 @@ fn file_name_date_after(start_date: DateTime<Utc>, file_name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use crate::historical_block_processing::INDEXED_ACTIONS_FILES_FOLDER;
     use crate::historical_block_processing::INDEXED_DATA_FILES_BUCKET;
-    use crate::historical_block_processing::{INDEXED_ACTIONS_FILES_FOLDER, LAKE_BUCKET_PREFIX};
-    use crate::opts::Opts;
     use crate::s3::{
         fetch_text_file_from_s3, find_index_files_by_pattern, list_s3_bucket_by_prefix,
     };
-    use aws_sdk_s3::{Client as S3Client, Config};
 
     /// Parses env vars from .env, Run with
     /// cargo test s3::tests::list_delta_bucket -- mainnet from-latest;
     #[tokio::test]
     async fn list_delta_bucket() {
-        let opts = Opts::test_opts_with_aws();
-        let aws_config = &opts.lake_aws_sdk_config();
-        let s3_config = aws_sdk_s3::config::Builder::from(aws_config).build();
-        let s3_client = aws_sdk_s3::Client::from_conf(s3_config);
+        let aws_config = aws_config::from_env().load().await;
+        let s3_client = aws_sdk_s3::Client::new(&aws_config);
 
         let list = list_s3_bucket_by_prefix(
             &s3_client,
@@ -224,10 +220,8 @@ mod tests {
     /// cargo test s3::tests::list_with_single_contract -- mainnet from-latest
     #[tokio::test]
     async fn list_with_single_contract() {
-        let opts = Opts::test_opts_with_aws();
-        let aws_config = &opts.lake_aws_sdk_config();
-        let s3_config = aws_sdk_s3::config::Builder::from(aws_config).build();
-        let s3_client = aws_sdk_s3::Client::from_conf(s3_config);
+        let aws_config = aws_config::from_env().load().await;
+        let s3_client = aws_sdk_s3::Client::new(&aws_config);
 
         let list = find_index_files_by_pattern(
             &s3_client,
@@ -243,10 +237,8 @@ mod tests {
     /// cargo test s3::tests::list_with_csv_contracts -- mainnet from-latest
     #[tokio::test]
     async fn list_with_csv_contracts() {
-        let opts = Opts::test_opts_with_aws();
-        let aws_config = &opts.lake_aws_sdk_config();
-        let s3_config = aws_sdk_s3::config::Builder::from(aws_config).build();
-        let s3_client = aws_sdk_s3::Client::from_conf(s3_config);
+        let aws_config = aws_config::from_env().load().await;
+        let s3_client = aws_sdk_s3::Client::new(&aws_config);
 
         let list = find_index_files_by_pattern(
             &s3_client,
@@ -262,10 +254,8 @@ mod tests {
     /// cargo test s3::tests::list_with_wildcard_contracts -- mainnet from-latest
     #[tokio::test]
     async fn list_with_wildcard_contracts() {
-        let opts = Opts::test_opts_with_aws();
-        let aws_config = &opts.lake_aws_sdk_config();
-        let s3_config = aws_sdk_s3::config::Builder::from(aws_config).build();
-        let s3_client = aws_sdk_s3::Client::from_conf(s3_config);
+        let aws_config = aws_config::from_env().load().await;
+        let s3_client = aws_sdk_s3::Client::new(&aws_config);
 
         let list = find_index_files_by_pattern(
             &s3_client,
@@ -281,10 +271,8 @@ mod tests {
     /// cargo test s3::tests::list_with_csv_and_wildcard_contracts -- mainnet from-latest
     #[tokio::test]
     async fn list_with_csv_and_wildcard_contracts() {
-        let opts = Opts::test_opts_with_aws();
-        let aws_config = &opts.lake_aws_sdk_config();
-        let s3_config = aws_sdk_s3::config::Builder::from(aws_config).build();
-        let s3_client = aws_sdk_s3::Client::from_conf(s3_config);
+        let aws_config = aws_config::from_env().load().await;
+        let s3_client = aws_sdk_s3::Client::new(&aws_config);
 
         let list = find_index_files_by_pattern(
             &s3_client,
@@ -319,14 +307,11 @@ mod tests {
     async fn handle_key_404() {
         let mut success = false;
 
-        let opts = Opts::test_opts_with_aws();
-        let s3_config: Config =
-            aws_sdk_s3::config::Builder::from(&opts.lake_aws_sdk_config()).build();
-
-        let s3_client: S3Client = S3Client::from_conf(s3_config);
+        let aws_config = aws_config::from_env().load().await;
+        let s3_client = aws_sdk_s3::Client::new(&aws_config);
 
         let s3_result = fetch_text_file_from_s3(
-            format!("{}{}", LAKE_BUCKET_PREFIX, "mainnet").as_str(),
+            "near-lake-data-mainnet",
             "does_not_exist/block.json".to_string(),
             &s3_client,
         )


### PR DESCRIPTION
## Problem

The Historical backfill is composed of two main steps:
1. Fetching matching blocks from `near-delta-lake`/Databricks index files
2. Manually filtering all blocks between the `last_indexed_block` from `near-delta-lake` and the `block_height` in which the historical process was triggered

Only after each of these steps are completed are the blocks flushed to Redis. This leads to a large delay from when the process was triggered, to when the blocks are actually executed by Runner, creating the appearance of things 'not working'.

## Changes
This PR makes the following changes to reduce the time between trigger, and execution:

### Flush blocks indexed blocks immediately
Fetching blocks from the index file (Step 1.), is relatively quick process. Rather than wait for (Step 2.), we can flush the blocks immediately, and then continue on to the following step.

### Prefetch blocks in manual filtering
In manual filtering, blocks are processed sequentially. To speed this process up, we can fetch ahead so that we minimise the time spent waiting for S3 requests. Luckily, `near-lake-framework` does exactly this, therefore manual filtering has been refactored to use this.

## Results
The following is from a backfill of 19,959,790 blocks run locally. I'd expect the Before to be much lower given the geographical distance compared to actual our infrastructure, but the results are still positive :).

Time till first block appears on Redis:
- Before: 33 minutes
- After: 2 seconds

Time to completion:
- Before: 33 minutes
- After: 45 seconds