### PR TITLE
QueryAPI Logging Features + UI/UX changes

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "eslint-config-next": "13.1.6",
     "graphiql": "3.0.6",
     "graphql": "^16.6.0",
+    "gridjs": "6.0.6",
     "near-api-js": "1.1.0",
     "near-social-bridge": "^1.4.1",
     "next": "13.1.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@apollo/client": "^3.8.7",
     "@graphiql/plugin-code-exporter": "0.3.5",
     "@graphiql/plugin-explorer": "0.3.5",
     "@monaco-editor/react": "^4.1.3",
@@ -25,7 +26,8 @@
     "eslint": "8.34.0",
     "eslint-config-next": "13.1.6",
     "graphiql": "3.0.6",
-    "graphql": "^16.6.0",
+    "graphql": "^16.8.1",
+    "graphql-ws": "^5.14.2",
     "gridjs": "6.0.6",
     "near-api-js": "1.1.0",
     "near-social-bridge": "^1.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,6 @@
     "eslint-config-next": "13.1.6",
     "graphiql": "3.0.6",
     "graphql": "^16.8.1",
-    "graphql-ws": "^5.14.2",
     "gridjs": "6.0.6",
     "near-api-js": "1.1.0",
     "near-social-bridge": "^1.4.1",

--- a/frontend/src/components/Editor/Editor.js
+++ b/frontend/src/components/Editor/Editor.js
@@ -381,6 +381,12 @@ const Editor = ({
         height: "85vh",
       }}
     >
+      {!indexerDetails.code && (
+        <Alert className="px-3 pt-3" variant="danger">
+          Indexer Function could not be found. Are you sure this indexer exists?
+        </Alert>
+      )}
+    {indexerDetails.code && <>
       <EditorButtons
         handleFormating={handleFormating}
         handleCodeGen={handleCodeGen}
@@ -455,6 +461,7 @@ const Editor = ({
           handleEditorMount={handleEditorMount}
         />
       </div>
+      </>}
     </div>
   );
 };

--- a/frontend/src/components/Editor/EditorButtons.jsx
+++ b/frontend/src/components/Editor/EditorButtons.jsx
@@ -72,7 +72,6 @@ const EditorButtons = ({
         >
           <Row className="w-100">
             <Col style={{ display: "flex", justifyContent: "start", flexDirection: "column" }}>
-
               <Breadcrumb className="flex">
                 <Breadcrumb.Item className="flex align-center " href="#">
                   {accountId}
@@ -110,7 +109,7 @@ const EditorButtons = ({
               )}
             </Col>
             <Col
-              style={{ display: "flex", justifyContent: "end", height: "40px" }}
+              style={{ display: "flex", justifyContent: "end", flexDirection: "column", alignItems: "flex-end" }}
             >
               <ButtonGroup
                 className="inline-block"
@@ -147,47 +146,6 @@ const EditorButtons = ({
                     </>
                 )}
 
-                <OverlayTrigger
-                  placement="bottom"
-                  overlay={<Tooltip>Reset Changes To Code</Tooltip>}
-                >
-                  <Button
-                    size="sm"
-                    className="flex align-center"
-                    variant="secondary"
-                    onClick={() => setShowResetCodeModel(true)}
-                  >
-                    <ArrowCounterclockwise size={22} />
-                  </Button>
-                </OverlayTrigger>
-
-                <OverlayTrigger
-                  placement="bottom"
-                  overlay={<Tooltip>Format Code</Tooltip>}
-                >
-                  <Button
-                    size="sm"
-                    variant="secondary"
-                    className="flex align-center"
-                    onClick={() => handleFormating()}
-                  >
-                    <Justify style={{ paddingRight: "2px" }} size={24} />
-                  </Button>
-                </OverlayTrigger>
-
-                <OverlayTrigger
-                  placement="bottom"
-                  overlay={<Tooltip>Generate Types</Tooltip>}
-                >
-                  <Button
-                    size="sm"
-                    variant="secondary"
-                    className="flex align-center"
-                    onClick={() => handleCodeGen()}
-                  >
-                    <Code style={{ paddingRight: "2px" }} size={24} />
-                  </Button>
-                </OverlayTrigger>
                 {!isCreateNewIndexer && (
                   <OverlayTrigger
                     placement="bottom"
@@ -232,6 +190,51 @@ const EditorButtons = ({
                   </OverlayTrigger>
                 )}
               </ButtonGroup>
+              <Row
+                style={{ display: "flex", justifyContent: "center", width: "60%", padding: "5px" }}
+              >
+                <ButtonGroup>
+                  <OverlayTrigger
+                    placement="bottom"
+                    overlay={<Tooltip>Reset Changes To Code</Tooltip>}
+                  >
+                    <Button
+                      size="sm"
+                      className="flex align-center"
+                      variant="secondary"
+                      onClick={() => setShowResetCodeModel(true)}
+                    >
+                      <ArrowCounterclockwise size={22} />
+                    </Button>
+                  </OverlayTrigger>
+                  <OverlayTrigger
+                    placement="bottom"
+                    overlay={<Tooltip>Format Code</Tooltip>}
+                  >
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      className="flex align-center"
+                      onClick={() => handleFormating()}
+                    >
+                      <Justify style={{ paddingRight: "2px" }} size={24} />
+                    </Button>
+                  </OverlayTrigger>
+                  <OverlayTrigger
+                    placement="bottom"
+                    overlay={<Tooltip>Generate Types</Tooltip>}
+                  >
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      className="flex align-center"
+                      onClick={() => handleCodeGen()}
+                    >
+                      <Code style={{ paddingRight: "2px" }} size={24} />
+                    </Button>
+                  </OverlayTrigger>
+                </ButtonGroup>
+              </Row>
             </Col>
           </Row>
           {debugMode && heights.length > 0 && (

--- a/frontend/src/components/Editor/EditorButtons.jsx
+++ b/frontend/src/components/Editor/EditorButtons.jsx
@@ -19,7 +19,8 @@ import {
   TrashFill,
   XCircle,
   NodePlus,
-  Code
+  Code,
+  FileText,
 } from "react-bootstrap-icons";
 import { BlockPicker } from "./BlockPicker";
 import { IndexerDetailsContext } from '../../contexts/IndexerDetailsContext';
@@ -49,7 +50,9 @@ const EditorButtons = ({
     debugMode,
     isCreateNewIndexer,
     indexerNameField,
-    setIndexerNameField
+    setIndexerNameField,
+    setShowLogsView,
+    showLogsView,
   } = useContext(IndexerDetailsContext);
 
   const removeHeight = (index) => {
@@ -185,6 +188,22 @@ const EditorButtons = ({
                     <Code style={{ paddingRight: "2px" }} size={24} />
                   </Button>
                 </OverlayTrigger>
+                {!isCreateNewIndexer && (
+                  <OverlayTrigger
+                    placement="bottom"
+                    overlay={<Tooltip>Open Logs</Tooltip>}
+                  >
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      className="flex align-center"
+                      onClick={() => setShowLogsView(true)}
+                    >
+                      <FileText style={{ paddingRight: "2px" }} size={24} />
+                      Show Logs
+                    </Button>
+                  </OverlayTrigger>
+                )}
                 {(!isUserIndexer && !isCreateNewIndexer) ? (
                   <OverlayTrigger
                     placement="bottom"

--- a/frontend/src/components/Logs/IndexerLogs.jsx
+++ b/frontend/src/components/Logs/IndexerLogs.jsx
@@ -1,0 +1,285 @@
+import React, { useContext, useRef, useEffect, useState } from "react";
+import { Grid, html } from "gridjs";
+import "gridjs/dist/theme/mermaid.css";
+import { IndexerDetailsContext } from "../../contexts/IndexerDetailsContext";
+import LogButtons from "./LogButtons";
+import { useInitialPayload } from "near-social-bridge";
+
+const LIMIT = 100;
+
+const IndexerLogsComponent = () => {
+  const { indexerDetails, debugMode, setLogsView } = useContext(
+    IndexerDetailsContext
+  );
+  const functionName = `${indexerDetails.accountId}/${indexerDetails.indexerName}`;
+
+  const DEBUG_LIST_STORAGE_KEY = `QueryAPI:debugList:${indexerDetails.accountId}#${indexerDetails.indexerName} `;
+
+  const { height, selectedTab, currentUserAccountId } = useInitialPayload();
+  const [heights, setHeights] = useState(
+    localStorage.getItem(DEBUG_LIST_STORAGE_KEY) || []
+  );
+  useEffect(() => {
+    localStorage.setItem(DEBUG_LIST_STORAGE_KEY, heights);
+  }, [heights]);
+
+  const indexerLogsRef = useRef(null);
+  const indexerStateRef = useRef(null);
+
+  function formatTimestamp(timestamp) {
+    const date = new Date(timestamp);
+
+    const options = {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    };
+    const formattedDate = date.toLocaleDateString(undefined, options);
+
+    const now = new Date();
+    const diffInSeconds = Math.round((now - date) / 1000);
+    let relativeTime = undefined;
+    if (diffInSeconds < 60) {
+      relativeTime = "(just now)";
+    } else if (diffInSeconds < 3600) {
+      relativeTime = `(${Math.floor(diffInSeconds / 60)} minutes ago)`;
+    } else if (diffInSeconds < 86400) {
+      relativeTime = `(${Math.floor(diffInSeconds / 3600)} hours ago)`;
+    }
+
+    return `${formattedDate} ${relativeTime ?? ""}`;
+  }
+
+  function formatTimestampToReadableLocal(timestamp) {
+    const date = new Date(timestamp);
+
+    const options = {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    };
+    const formattedDate = date.toLocaleString(undefined, options);
+
+    return formattedDate;
+  }
+
+  const processLogs = (data) => {
+    const logEntries = data.indexer_log_entries.map((row) => ({
+      block_height: row.block_height,
+      timestamp: row.timestamp,
+      message: row.message,
+    }));
+
+    const groupedEntries = new Map();
+
+    logEntries.forEach(({ block_height, timestamp, message }) => {
+      if (!groupedEntries.has(block_height)) {
+        groupedEntries.set(block_height, []);
+      }
+      groupedEntries.get(block_height).push({ timestamp, message });
+    });
+
+    const mergedEntries = Array.from(groupedEntries).map(
+      ([block_height, entries]) => {
+        const messages = entries
+          .map(
+            (e) =>
+              `<strong>Timestamp: ${e.timestamp
+              }(${formatTimestampToReadableLocal(
+                e.timestamp
+              )}):</strong> \n <p>${e.message}</p>`
+          )
+          .join("<br>");
+
+        const minTimestamp = entries.reduce(
+          (min, e) => (e.timestamp < min ? e.timestamp : min),
+          entries[0].timestamp
+        );
+
+        const formattedMinTimstamp = formatTimestamp(minTimestamp);
+        const humanReadableStamp = formatTimestampToReadableLocal(minTimestamp);
+
+        return {
+          block_height,
+          timestamp: { humanReadableStamp, formattedMinTimstamp },
+          messages,
+        };
+      }
+    );
+
+    return mergedEntries;
+  };
+
+  useEffect(() => {
+    const grid = new Grid({
+      columns: [
+        {
+          name: "Current Block Height",
+          formatter: (cell) => html(`<div style="text-align: right"> ${cell}</div>`)
+        },
+        {
+          name: "Current Historical Block Height",
+          formatter: (cell) => html(`<div style="text-align: right"> ${cell}</div>`)
+        },
+        {
+          name: "Status",
+          formatter: (cell) => html(`<div style="text-align: right"> ${cell}</div>`)
+        },
+      ],
+      search: false,
+      sort: false,
+      resizable: true,
+      fixedHeader: true,
+      server: {
+        url: `${process.env.NEXT_PUBLIC_HASURA_ENDPOINT}/api/rest/queryapi/logs/?_functionName=${functionName}`,
+        headers: {
+          "x-hasura-role": "append",
+        },
+        then: (data) => {
+          return data.indexer_state.map((state) => [
+            state.current_block_height,
+            state.current_historical_block_height,
+            state.status,
+          ]);
+        },
+      },
+      style: {
+        container: {
+          "font-family": '"Roboto Mono", monospace',
+        },
+        table: {},
+        th: {
+          "text-align": "center",
+          "max-width": "950px",
+          width: "800px",
+        },
+        td: {
+          "text-align": "center",
+          "font-size": "11px",
+          "background-color": "rgb(255, 255, 255)",
+          "max-height": "400px",
+          padding: "5px",
+        },
+      },
+    });
+
+    grid.render(indexerStateRef.current);
+    // };
+    // fetchData();
+  }, []);
+
+  useEffect(() => {
+    const grid = new Grid({
+      columns: [
+        {
+          name: "Block Height",
+          formatter: (cell) => html(`<div style="text-align: center;"><a target='_blank' href='https://legacy.explorer.near.org/?query=${cell}'>${cell}</a></div>`)
+        },
+        "Timestamp",
+        {
+          name: "Message",
+          formatter: (cell) => html(`<div>${cell}</div>`),
+          sort: false,
+        },
+      ],
+      search: {
+        server: {
+          url: (prev, keyword) => `${process.env.NEXT_PUBLIC_HASURA_ENDPOINT}/api/rest/queryapi/logsByBlock/?_functionName=${functionName}&_blockHeight=${keyword}`,
+          then: (data) => {
+          const logs = processLogs(data).map((log) => [
+            log.block_height,
+            log.timestamp.formattedMinTimstamp,
+            log.messages,
+          ]);
+          return logs;
+        },
+          debounceTimeout: 2000,
+        }
+      },
+      sort: true,
+      resizable: true,
+      fixedHeader: true,
+      pagination: {
+        limit: 30,
+        server: {
+          url: (prev, page, limit) => {
+            return prev + "&limit=" + limit + "&offset=" + page * limit;
+          },
+        },
+      },
+      server: {
+        url: `${process.env.NEXT_PUBLIC_HASURA_ENDPOINT}/api/rest/queryapi/logs/?_functionName=${functionName}`,
+        headers: {
+          "x-hasura-role": "append",
+        },
+        then: (data) => {
+          const logs = processLogs(data).map((log) => [
+            log.block_height,
+            log.timestamp.formattedMinTimstamp,
+            log.messages,
+          ]);
+          return logs;
+        },
+        total: (data) => data.indexer_log_entries_aggregate.aggregate.count,
+      },
+      style: {
+        container: {
+          "font-family": '"Roboto Mono", monospace',
+        },
+        table: {},
+        th: {
+          "text-align": "center",
+          "max-width": "950px",
+          width: "800px",
+        },
+        td: {
+          "text-align": "left",
+          "font-size": "11px",
+          "background-color": "rgb(255, 255, 255)",
+          "max-height": "400px",
+          padding: "5px",
+        },
+      },
+      language: {
+        search: {
+          placeholder: "🔍 Search by Block Height...",
+        },
+        pagination: {
+          results: () => "Indexer Logs",
+        },
+      },
+    });
+
+    grid.render(indexerLogsRef.current);
+  }, []);
+
+  return (
+    <>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          width: "100%",
+          height: "85vh",
+        }}
+      >
+        <LogButtons
+          currentUserAccountId={currentUserAccountId}
+          heights={heights}
+          setHeights={setHeights}
+          latestHeight={height}
+          isUserIndexer={indexerDetails.accountId === currentUserAccountId}
+        />
+        <div ref={indexerStateRef} />
+        <div ref={indexerLogsRef} />
+      </div>
+    </>
+  );
+};
+
+export default IndexerLogsComponent;

--- a/frontend/src/components/Logs/LogButtons.jsx
+++ b/frontend/src/components/Logs/LogButtons.jsx
@@ -1,0 +1,136 @@
+import React, { useContext } from "react";
+import {
+  Breadcrumb,
+  Button,
+  Form,
+  InputGroup,
+  Navbar,
+  Container,
+  Col,
+  Row,
+  ButtonGroup,
+  OverlayTrigger,
+  Tooltip,
+  Badge,
+} from "react-bootstrap";
+import {
+  ArrowCounterclockwise,
+  Justify,
+  TrashFill,
+  XCircle,
+  NodePlus,
+  Code,
+} from "react-bootstrap-icons";
+import { IndexerDetailsContext } from "../../contexts/IndexerDetailsContext";
+
+const LogButtons = ({
+  currentUserAccountId,
+  heights,
+  setHeights,
+  latestHeight,
+  isUserIndexer,
+}) => {
+  const {
+    indexerName,
+    accountId,
+    indexerDetails,
+    debugMode,
+    setShowLogsView,
+    showLogsView,
+  } = useContext(IndexerDetailsContext);
+
+  const removeHeight = (index) => {
+    setHeights(heights.filter((_, i) => i !== index));
+  };
+
+  return (
+    <>
+      <Navbar bg="light" variant="light">
+        <Container
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            margin: "0px",
+            marginBottom: "5px",
+            maxWidth: "100%",
+          }}
+        >
+          <Row className="w-100">
+            <Col
+              style={{
+                display: "flex",
+                justifyContent: "start",
+                flexDirection: "column",
+              }}
+            >
+              <Breadcrumb className="flex">
+                <Breadcrumb.Item className="flex align-center " href="#">
+                  {accountId}
+                </Breadcrumb.Item>
+                {indexerName && (
+                  <Breadcrumb.Item href="#" active style={{ display: "flex" }}>
+                    {indexerName}
+                  </Breadcrumb.Item>
+                )}
+              </Breadcrumb>
+              {
+                <InputGroup size="sm" style={{ width: "fit-content" }}>
+                  <InputGroup.Text> Contract Filter</InputGroup.Text>
+                  <Form.Control
+                    value={indexerDetails.config.filter}
+                    disabled={true}
+                    type="text"
+                    placeholder="social.near"
+                  />
+                </InputGroup>
+              }
+            </Col>
+            <Col
+              style={{ display: "flex", justifyContent: "end", height: "40px" }}
+            >
+              <ButtonGroup
+                className="inline-block"
+                aria-label="Action Button Group"
+              >
+                <>
+                  <OverlayTrigger
+                    placement="bottom"
+                    overlay={<Tooltip>Open Editor</Tooltip>}
+                  >
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      className="flex align-center"
+                      onClick={() => setShowLogsView(false)}
+                    >
+                      <Code style={{ paddingRight: "2px" }} size={24} />
+                      Go To Editor
+                    </Button>
+                  </OverlayTrigger>
+                </>
+              </ButtonGroup>
+            </Col>
+          </Row>
+          {debugMode && heights.length > 0 && (
+            <Row className="w-100 pt-2">
+              <div>
+                {heights.map((height, index) => (
+                  <Badge pill bg="secondary" className="mx-1 mr-2" key={index}>
+                    {height}
+                    <XCircle
+                      size={18}
+                      style={{ paddingLeft: "4px", cursor: "pointer" }}
+                      onClick={() => removeHeight(index)}
+                    />
+                  </Badge>
+                ))}
+              </div>
+            </Row>
+          )}
+        </Container>
+      </Navbar>
+    </>
+  );
+};
+
+export default LogButtons;

--- a/frontend/src/components/Logs/Status.jsx
+++ b/frontend/src/components/Logs/Status.jsx
@@ -3,7 +3,6 @@ import {
   Card,
   Badge,
   ListGroup,
-  ProgressBar,
   OverlayTrigger,
   Tooltip,
 } from "react-bootstrap";
@@ -25,9 +24,6 @@ const Status = ({ functionName, latestHeight }) => {
       _functionName: functionName,
     },
   });
-
-  // const statusVariant = status === "running" ? "success" : "danger";
-  // const progressPercentage = (currentBlockHeight / latestHeight) * 100;
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error : {error.message}</p>;
@@ -55,24 +51,13 @@ const Status = ({ functionName, latestHeight }) => {
             >
               <OverlayTrigger
                 placement="bottom"
-                overlay={<Tooltip>The Current Block Height is {latestHeight}. Your indexer has a gap of {latestHeight - item.current_block_height} Blocks</Tooltip>}
+                overlay={<Tooltip>Near's Current Block Height is {latestHeight}. Your indexer has a gap of {latestHeight - item.current_block_height} Blocks</Tooltip>}
               >
-                <ProgressBar
-                  variant={item.status === "RUNNING" ? "success" : "danger"}
-                  animated={item.status === "RUNNING"}
-                  striped={true}
-                  label={`${(
-                    (item.current_block_height / latestHeight) *
-                    100
-                  ).toFixed(0)}%`}
-                  now={(item.current_block_height / latestHeight) * 100}
-                  style={{ marginTop: "10px", height: "18px" }}
-                />
-              </OverlayTrigger>
               <ListGroup.Item>
                 Current Block Height:{" "}
                 <strong>{item.current_block_height}</strong>
               </ListGroup.Item>
+              </OverlayTrigger>
               <ListGroup.Item>
                 Historical Block Height:{" "}
                 <strong>{item.current_historical_block_height}</strong>

--- a/frontend/src/components/Logs/Status.jsx
+++ b/frontend/src/components/Logs/Status.jsx
@@ -1,0 +1,103 @@
+import React from "react";
+import {
+  Card,
+  Badge,
+  ListGroup,
+  ProgressBar,
+  OverlayTrigger,
+  Tooltip,
+} from "react-bootstrap";
+import { useQuery, gql } from "@apollo/client";
+
+const Status = ({ functionName, latestHeight }) => {
+  const GET_STATUS = gql`
+    query GetState($_functionName: String!) {
+      indexer_state(where: { function_name: { _eq: $_functionName } }) {
+        status
+        function_name
+        current_block_height
+        current_historical_block_height
+      }
+    }
+  `;
+  const { loading, error, data } = useQuery(GET_STATUS, {
+    variables: {
+      _functionName: functionName,
+    },
+  });
+
+  // const statusVariant = status === "running" ? "success" : "danger";
+  // const progressPercentage = (currentBlockHeight / latestHeight) * 100;
+
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p>Error : {error.message}</p>;
+  return (
+    <div>
+      {data &&
+        data.indexer_state.map((item, index) => (
+          <Card
+            key={index}
+            className="text-center"
+            style={{
+              margin: "20px",
+              padding: "20px",
+              marginTop: "20px",
+            }}
+          >
+            <Card.Header as="h5">
+              Indexer Status: {item.function_name}
+            </Card.Header>
+            <ListGroup
+              variant="flush"
+              style={{
+                textAlign: "left",
+              }}
+            >
+              <OverlayTrigger
+                placement="bottom"
+                overlay={<Tooltip>The Current Block Height is {latestHeight}. Your indexer has a gap of {latestHeight - item.current_block_height} Blocks</Tooltip>}
+              >
+                <ProgressBar
+                  variant={item.status === "RUNNING" ? "success" : "danger"}
+                  animated={item.status === "RUNNING"}
+                  striped={true}
+                  label={`${(
+                    (item.current_block_height / latestHeight) *
+                    100
+                  ).toFixed(0)}%`}
+                  now={(item.current_block_height / latestHeight) * 100}
+                  style={{ marginTop: "10px", height: "18px" }}
+                />
+              </OverlayTrigger>
+              <ListGroup.Item>
+                Current Block Height:{" "}
+                <strong>{item.current_block_height}</strong>
+              </ListGroup.Item>
+              <ListGroup.Item>
+                Historical Block Height:{" "}
+                <strong>{item.current_historical_block_height}</strong>
+              </ListGroup.Item>
+              <ListGroup.Item>
+                <OverlayTrigger
+                  placement="bottom"
+                  overlay={<Tooltip>{item.status === "RUNNING" ? "Indexer is operating normally" : "Indexer stopped due to errors. Check Logs for more details."}</Tooltip>}
+                >
+                  <>
+                    Status:{" "}
+                    <Badge
+                      pill
+                      bg={item.status === "RUNNING" ? "success" : "danger"}
+                    >
+                      {item.status}
+                    </Badge>
+                  </>
+                </OverlayTrigger>
+              </ListGroup.Item>
+            </ListGroup>
+          </Card>
+        ))}
+    </div>
+  );
+};
+
+export default Status;

--- a/frontend/src/components/Playground/graphiql.jsx
+++ b/frontend/src/components/Playground/graphiql.jsx
@@ -9,7 +9,7 @@ import '@graphiql/plugin-code-exporter/dist/style.css';
 import '@graphiql/plugin-explorer/dist/style.css';
 
 const HASURA_ENDPOINT =
-  process.env.NEXT_PUBLIC_HASURA_ENDPOINT ||
+  `${process.env.NEXT_PUBLIC_HASURA_ENDPOINT}/v1/graphql` ||
   "https://near-queryapi.dev.api.pagoda.co/v1/graphql";
 
 const graphQLFetcher = async (graphQLParams, accountId) => {

--- a/frontend/src/contexts/IndexerDetailsContext.js
+++ b/frontend/src/contexts/IndexerDetailsContext.js
@@ -6,6 +6,7 @@ import {
   wrapCode,
 } from "../utils/formatters";
 
+import { useInitialPayload } from "near-social-bridge";
 import { getLatestBlockHeight } from "../utils/getLatestBlockHeight";
 // interface IndexerDetails {
 //   accountId: String,
@@ -54,6 +55,12 @@ export const IndexerDetailsProvider = ({ children }) => {
   const [showLogsView, setShowLogsView] = useState(false);
   const [latestHeight, setLatestHeight] = useState(0);
   const [isCreateNewIndexer, setIsCreateNewIndexer] = useState(false);
+
+  const { activeView } = useInitialPayload();
+
+  useEffect(() => {
+    if (activeView == 'status') setShowLogsView(true)
+  }, [])
 
   const requestIndexerDetails = async () => {
     const data = await queryIndexerFunctionDetails(accountId, indexerName);

--- a/frontend/src/contexts/IndexerDetailsContext.js
+++ b/frontend/src/contexts/IndexerDetailsContext.js
@@ -39,6 +39,8 @@ export const IndexerDetailsContext = React.createContext({
   indexerName: undefined,
   setIndexerName: () => { },
   setIndexerDetails: () => { },
+  showLogsView: false,
+  setShowLogsView: () => { },
 });
 
 export const IndexerDetailsProvider = ({ children }) => {
@@ -49,6 +51,7 @@ export const IndexerDetailsProvider = ({ children }) => {
   const [showPublishModal, setShowPublishModal] = useState(false);
   const [showForkIndexerModal, setShowForkIndexerModal] = useState(false);
   const [debugMode, setDebugMode] = useState(false);
+  const [showLogsView, setShowLogsView] = useState(false);
   const [latestHeight, setLatestHeight] = useState(0);
   const [isCreateNewIndexer, setIsCreateNewIndexer] = useState(false);
 
@@ -117,7 +120,9 @@ export const IndexerDetailsProvider = ({ children }) => {
         setDebugMode,
         latestHeight,
         isCreateNewIndexer,
-        setIsCreateNewIndexer
+        setIsCreateNewIndexer,
+        showLogsView,
+        setShowLogsView,
       }}
     >
       {children}

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -8,15 +8,26 @@ import {
 } from "near-social-bridge";
 import { IndexerDetailsProvider } from '../contexts/IndexerDetailsContext';
 import 'regenerator-runtime/runtime';
+import { ApolloClient, InMemoryCache, ApolloProvider, gql } from '@apollo/client';
 overrideLocalStorage();
 
 export default function App({ Component, pageProps }: AppProps) {
+  const client = new ApolloClient({
+    uri: `${process.env.NEXT_PUBLIC_HASURA_ENDPOINT}/v1/graphql`,
+    cache: new InMemoryCache(),
+    options: {
+      headers: {
+        "x-hasura-role": "append"
+      }
+    }
+  });
   return (
     <NearSocialBridgeProvider waitForStorage fallback={<Spinner />}>
+      <ApolloProvider client={client}>
       <IndexerDetailsProvider>
         <Component {...pageProps} />
       </IndexerDetailsProvider>
+      </ApolloProvider>
     </NearSocialBridgeProvider>
   );
 }
-

--- a/frontend/src/pages/indexer-logs/index.js
+++ b/frontend/src/pages/indexer-logs/index.js
@@ -1,15 +1,15 @@
 import React, { useEffect, useContext } from "react";
 
-import Editor from "../../components/Editor";
+import IndexerLogs from "../../components/Logs/IndexerLogs";
 import { withRouter } from 'next/router'
 import { Alert } from 'react-bootstrap';
+// import { EditorContext } from '../../contexts/EditorContext';
 import { IndexerDetailsContext } from '../../contexts/IndexerDetailsContext';
-import IndexerLogs from "../../components/Logs/IndexerLogs";
 
-const QueryApiEditorPage = ({ router }) => {
+const IndexerLogsPage = ({ router }) => {
   const { accountId, indexerName } = router.query
-  const { setAccountId, setIndexerName, showLogsView } = useContext(IndexerDetailsContext);
-
+  // const { setAccountId, setIndexerName } = useContext(EditorContext);
+  const { setAccountId, setIndexerName } = useContext(IndexerDetailsContext);
   useEffect(() => {
     if (accountId == undefined || indexerName == undefined) {
       return;
@@ -28,13 +28,7 @@ const QueryApiEditorPage = ({ router }) => {
     )
   }
   return (
-    <>
-      {showLogsView ? (
-        <IndexerLogs />
-      ) : (
-        <Editor actionButtonText="Publish" onLoadErrorText="An error occurred while trying to query indexer function details from registry." />
-      )}
-    </>
+      <IndexerLogs/>
   );
 };
 

--- a/frontend/widgets/src/QueryApi.App.jsx
+++ b/frontend/widgets/src/QueryApi.App.jsx
@@ -1,6 +1,7 @@
 const view = props.view;
 const path = props.path;
 const tab = props.tab;
+const activeIndexerView = props.activeIndexerView;
 const selectedIndexerPath = props.selectedIndexerPath;
 
 return (
@@ -11,6 +12,7 @@ return (
       path,
       tab,
       selectedIndexerPath,
+      activeIndexerView
     }}
   />
 );

--- a/frontend/widgets/src/QueryApi.Dashboard.jsx
+++ b/frontend/widgets/src/QueryApi.Dashboard.jsx
@@ -3,7 +3,7 @@ const [selected_accountId, selected_indexerName] = props.selectedIndexerPath
   ? props.selectedIndexerPath.split("/")
   : [undefined, undefined];
 
-const activeTab = props.view ?? "indexers";
+const activeTab = props.view ? props.view : (props.selectedIndexerPath ? "indexer" : "explore")
 const activeIndexerView = props.activeIndexerView ?? "editor";
 const limit = 7;
 let totalIndexers = 0;
@@ -56,12 +56,8 @@ const Subheading = styled.h2`
 `;
 
 const Editor = styled.div`
-  // visibility: ${state.activeIndexerView === "status" ? "hidden" : "visible"};
-  // order: ${state.activeIndexerView === "status" ? 2 : 1};
 `;
 const Status = styled.div`
-  // visibility: ${state.activeIndexerView === "editor" ? "hidden" : "visible"};
-  // order: ${state.activeIndexerView === "editor" ? 1 : 2};
 `;
 
 const Wrapper = styled.div`
@@ -376,12 +372,12 @@ const indexerView = (accountId, indexerName) => {
 };
 
 return (
-  <Wrapper negativeMargin={state.activeTab === "indexers"}>
+  <Wrapper negativeMargin={state.activeTab === "explore"}>
     <Tabs>
       <TabsButton
         type="button"
-        onClick={() => selectTab("indexers")}
-        selected={state.activeTab === "indexers"}
+        onClick={() => selectTab("explore")}
+        selected={state.activeTab === "explore"}
       >
         Explore Indexers
       </TabsButton>
@@ -408,11 +404,11 @@ return (
       )}
     </Tabs>
     <Main>
-      <Section active={state.activeTab === "indexers"}>
+      <Section active={state.activeTab === "explore"}>
         <NavBarLogo
           href={`https://near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App`}
           title="QueryApi"
-          onClick={() => selectTab("indexers")}
+          onClick={() => selectTab("explore")}
         >
           <Widget
             src="mob.near/widget/Image"
@@ -476,7 +472,6 @@ return (
         )}
       </Section>
       <Section negativeMargin primary active={state.activeTab === "indexer"}>
-        {state.activeIndexerView === "editor" && (
           <Editor>
             {state.indexers.length > 0 &&
               (state.selected_indexer != undefined ? (
@@ -492,12 +487,11 @@ return (
                 accountId: selected_accountId ?? state.indexers[0].accountId,
                 path: "query-api-editor",
                 tab: props.tab,
-                activeIndexerView: state.activeIndexerView
+                activeView: state.activeIndexerView
               }}
             />
           </Editor>
-        )}
-        {state.activeIndexerView === "create-new-indexer" && (
+        {state.activeTab === "create-new-indexer" && (
           <div>
             {state.indexers.length > 0 &&
               (state.selected_indexer != undefined ? (

--- a/frontend/widgets/src/QueryApi.Dashboard.jsx
+++ b/frontend/widgets/src/QueryApi.Dashboard.jsx
@@ -4,11 +4,13 @@ const [selected_accountId, selected_indexerName] = props.selectedIndexerPath
   : [undefined, undefined];
 
 const activeTab = props.view ?? "indexers";
+const activeIndexerView = props.activeIndexerView ?? "editor";
 const limit = 7;
 let totalIndexers = 0;
 
 State.init({
   activeTab: activeTab,
+  activeIndexerView: activeIndexerView,
   my_indexers: [],
   all_indexers: [],
   selected_indexer: undefined,
@@ -51,6 +53,15 @@ const Subheading = styled.h2`
   text-overflow: ${(p) => (p.ellipsis ? "ellipsis" : "unset")};
   white-space: nowrap;
   outline: none;
+`;
+
+const Editor = styled.div`
+  // visibility: ${state.activeIndexerView === "status" ? "hidden" : "visible"};
+  // order: ${state.activeIndexerView === "status" ? 2 : 1};
+`;
+const Status = styled.div`
+  // visibility: ${state.activeIndexerView === "editor" ? "hidden" : "visible"};
+  // order: ${state.activeIndexerView === "editor" ? 1 : 2};
 `;
 
 const Wrapper = styled.div`
@@ -310,9 +321,15 @@ const selectTab = (tabName) => {
   });
 };
 
+const selectIndexerPage = (viewName) => {
+  Storage.privateSet("queryapi:activeIndexerTabView", viewName);
+  State.update({
+    activeIndexerView: viewName,
+  });
+};
 const indexerView = (accountId, indexerName) => {
-  const editUrl = `https://near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}&view=editor-window`;
-  const statusUrl = `https://near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}&view=indexer-status`;
+  const editUrl = `https://near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}&view=indexer&activeIndexerView=editor`;
+  const statusUrl = `https://near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}&view=indexer&activeIndexerView=status`;
   const playgroundLink = `https://cloud.hasura.io/public/graphiql?endpoint=${REPL_GRAPHQL_ENDPOINT}/v1/graphql&header=x-hasura-role%3A${accountId.replaceAll(
     ".",
     "_"
@@ -344,10 +361,10 @@ const indexerView = (accountId, indexerName) => {
       </CardBody>
 
       <CardFooter className="flex justify-center items-center">
-        <ButtonLink onClick={() => selectTab("indexer-status")}>
+        <ButtonLink onClick={() => selectIndexerPage("status")}>
           View Status
         </ButtonLink>
-        <ButtonLink primary onClick={() => selectTab("editor-window")}>
+        <ButtonLink primary onClick={() => selectIndexerPage("editor")}>
           {accountId === context.accountId ? "Edit Indexer" : "View Indexer"}
         </ButtonLink>
         <ButtonLink href={playgroundLink} target="_blank">
@@ -366,7 +383,7 @@ return (
         onClick={() => selectTab("indexers")}
         selected={state.activeTab === "indexers"}
       >
-        Indexers
+        Explore Indexers
       </TabsButton>
       {state.activeTab == "create-new-indexer" && (
         <TabsButton
@@ -382,18 +399,10 @@ return (
         <>
           <TabsButton
             type="button"
-            onClick={() => selectTab("editor-window")}
-            selected={state.activeTab === "editor-window"}
+            onClick={() => selectTab("indexer")}
+            selected={state.activeTab === "indexer"}
           >
-            Indexer Editor
-          </TabsButton>
-
-          <TabsButton
-            type="button"
-            onClick={() => selectTab("indexer-status")}
-            selected={state.activeTab === "indexer-status"}
-          >
-            Indexer Status
+            Indexer ({props.selectedIndexerPath})
           </TabsButton>
         </>
       )}
@@ -466,37 +475,9 @@ return (
           </div>
         )}
       </Section>
-      <Section active={state.activeTab === "indexer-status"}>
-        {state.activeTab === "indexer-status" && (
-          <div>
-            {state.indexers.length > 0 &&
-              (state.selected_indexer != "" ? (
-                <H2>{state.selected_indexer}</H2>
-              ) : (
-                <H2>{state.indexers[0].indexerName}</H2>
-              ))}
-            {indexerView(
-              selected_accountId ?? state.indexers[0].accountId,
-              selected_indexerName ?? state.indexers[0].indexerName
-            )}
-            <Widget
-              src={`${REPL_ACCOUNT_ID}/widget/QueryApi.IndexerStatus`}
-              props={{
-                indexer_name:
-                  selected_indexerName ?? state.indexers[0].indexerName,
-                accountId: selected_accountId ?? state.indexers[0].accountId,
-              }}
-            />
-          </div>
-        )}
-      </Section>
-      <Section
-        negativeMargin
-        primary
-        active={state.activeTab === "editor-window"}
-      >
-        {state.activeTab === "editor-window" && (
-          <div>
+      <Section negativeMargin primary active={state.activeTab === "indexer"}>
+        {state.activeIndexerView === "editor" && (
+          <Editor>
             {state.indexers.length > 0 &&
               (state.selected_indexer != undefined ? (
                 <H2>{state.selected_indexer}</H2>
@@ -511,11 +492,12 @@ return (
                 accountId: selected_accountId ?? state.indexers[0].accountId,
                 path: "query-api-editor",
                 tab: props.tab,
+                activeIndexerView: state.activeIndexerView
               }}
             />
-          </div>
+          </Editor>
         )}
-        {state.activeTab === "create-new-indexer" && (
+        {state.activeIndexerView === "create-new-indexer" && (
           <div>
             {state.indexers.length > 0 &&
               (state.selected_indexer != undefined ? (

--- a/frontend/widgets/src/QueryApi.Dashboard.jsx
+++ b/frontend/widgets/src/QueryApi.Dashboard.jsx
@@ -3,7 +3,7 @@ const [selected_accountId, selected_indexerName] = props.selectedIndexerPath
   ? props.selectedIndexerPath.split("/")
   : [undefined, undefined];
 
-const activeTab = props.view ? props.view : (props.selectedIndexerPath ? "indexer" : "explore")
+const activeTab = props.view == "create-new-indexer" ? "create-new-indexer" : props.selectedIndexerPath ? "indexer" : "explore"
 const activeIndexerView = props.activeIndexerView ?? "editor";
 const limit = 7;
 let totalIndexers = 0;

--- a/frontend/widgets/src/QueryApi.Dashboard.jsx
+++ b/frontend/widgets/src/QueryApi.Dashboard.jsx
@@ -114,7 +114,7 @@ const Title = styled.h1`
 
 const TabsButton = styled.button`
   font-weight: 600;
-  font-size: 12px;
+  font-size: 14px;
   line-height: 16px;
   padding: 0 12px;
   position: relative;
@@ -324,7 +324,7 @@ const selectIndexerPage = (viewName) => {
   });
 };
 const indexerView = (accountId, indexerName) => {
-  const editUrl = `https://near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}&view=indexer&activeIndexerView=editor`;
+  const editUrl = `https://near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}`;
   const statusUrl = `https://near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}&view=indexer&activeIndexerView=status`;
   const playgroundLink = `https://cloud.hasura.io/public/graphiql?endpoint=${REPL_GRAPHQL_ENDPOINT}/v1/graphql&header=x-hasura-role%3A${accountId.replaceAll(
     ".",

--- a/frontend/widgets/src/QueryApi.Editor.jsx
+++ b/frontend/widgets/src/QueryApi.Editor.jsx
@@ -8,14 +8,11 @@ if (props.indexerName) {
   externalAppUrl += `&indexerName=${props.indexerName}`;
 }
 const initialViewHeight = 1000;
-if (!context.accountId) {
-  return "Please sign in to use this widget.";
-}
 
 const initialPayload = {
   height: Near.block("optimistic").header.height,
   selectedTab: tab,
-  activeView: activeView,
+  activeView,
   currentUserAccountId: context.accountId,
 };
 

--- a/frontend/widgets/src/QueryApi.Editor.jsx
+++ b/frontend/widgets/src/QueryApi.Editor.jsx
@@ -1,5 +1,6 @@
 const path = props.path || "query-api-editor";
 const tab = props.tab || "";
+const activeView = props.activeView || "editor";
 let accountId = props.accountId || context.accountId;
 let externalAppUrl = `${REPL_EXTERNAL_APP_URL}/${path}?accountId=${accountId}`;
 
@@ -14,6 +15,7 @@ if (!context.accountId) {
 const initialPayload = {
   height: Near.block("optimistic").header.height,
   selectedTab: tab,
+  activeView: activeView,
   currentUserAccountId: context.accountId,
 };
 

--- a/frontend/widgets/src/QueryApi.IndexerCard.jsx
+++ b/frontend/widgets/src/QueryApi.IndexerCard.jsx
@@ -1,6 +1,6 @@
 const accountId = props.accountId || context.accountId;
 const indexerName = props.indexerName;
-const editUrl = `https://near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}&view=indexer&activeIndexerView=editor`;
+const editUrl = `https://near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}`;
 const statusUrl = `https://near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}&view=indexer&activeIndexerView=status`;
 const playgroundLink = `https://cloud.hasura.io/public/graphiql?endpoint=${REPL_GRAPHQL_ENDPOINT}/v1/graphql&header=x-hasura-role%3A${accountId.replaceAll(
   ".",

--- a/frontend/widgets/src/QueryApi.IndexerCard.jsx
+++ b/frontend/widgets/src/QueryApi.IndexerCard.jsx
@@ -1,7 +1,7 @@
 const accountId = props.accountId || context.accountId;
 const indexerName = props.indexerName;
-const editUrl = `https://near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}&view=editor-window`;
-const statusUrl = `https://near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}&view=indexer-status`;
+const editUrl = `https://near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}&view=indexer&activeIndexerView=editor`;
+const statusUrl = `https://near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}&view=indexer&activeIndexerView=status`;
 const playgroundLink = `https://cloud.hasura.io/public/graphiql?endpoint=${REPL_GRAPHQL_ENDPOINT}/v1/graphql&header=x-hasura-role%3A${accountId.replaceAll(
   ".",
   "_"
@@ -178,7 +178,7 @@ return (
         href={editUrl}
         onClick={() =>
           State.update({
-            activeTab: "editor-window",
+            activeTab: "editor",
           })
         }
       >


### PR DESCRIPTION
This PR addresses a few painpoints of logging and QueryAPI Indexer development. 

1. Logs can now be seen through the QueryAPI editor window via a `Show Logs` button.
             - No need to switch between `Indexer Status` & `Editor` window anymore saving time and frustration with the editor taking a few seconds to load.
             - Enables more powerful integrations with the editor for future PRs (e.g: adding blocks to debug directly from the indexer Logs table)

2. Logs are easier to digest now and search now. 
             - Logs are grouped by `block_height` so now the user sees all the messages belonging to a block's execution together.
             - Additionally the user can use the `search` functionality to search for any block_height where the function was executed to view its log in entirety.
             - Logs have relative dates now e.g (4 mins ago...)
             - BlockHeights can be clicked on to take you to the explorer link
             
3. Simplifying QueryAPI links.
             - There is no need for `&view=status/editor-window` to be passed in anymore.
             - As long as `selectedIndexerPath` is defined, the user is sent to the editor window. If `&view=status` is passed the user is redirected to the indexer logs page within the editor window.
             - Note: I have a PR on `queryapi/docs` to reflect these changes: https://github.com/near/docs/pull/1584
  
  Notes: Instead of using GraphQL to fetch logs, we are using a feature of Hasura which `restifies` your graphql queries.
  You can find details here: https://near-queryapi.api.pagoda.co/console/api/rest/list
  
  - The Old Indexer Status Widget should still be avalaible if needed via the following link: https://near.org/dataplatform.near/widget/QueryApi.IndexerStatus?accountId=dataplatform.near&indexer_name=social_feed
  
Other small updates
- If a invalid indexer path is chosen, the editor will show an error
- QueryAPI is avalaible for users in read only mode even if they are not logged in on near.org

### This PR does not add WS support. This will be done in a future PR. 
  
![image](https://github.com/near/queryapi/assets/25015977/0e94ede2-6cca-41ae-9dd4-827ff388ba48)
![image](https://github.com/near/queryapi/assets/25015977/01e655cb-786d-4913-9b09-e00014037863)
![queryapi logs testing](https://github.com/near/queryapi/assets/25015977/c66d980c-0988-492e-b225-46371ff7572e)
