### PR TITLE
Fix Connection Unavailable Error

### DIFF
--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -14,6 +14,7 @@ export default class DmlHandler {
     hasuraClient: HasuraClient = new HasuraClient(),
     PgClient = PgClientModule
   ): Promise<DmlHandler> {
+    console.log('CALL MADE');
     const connectionParameters = await hasuraClient.getDbConnectionParameters(account);
     const pgClient = new PgClient({
       user: connectionParameters.username,

--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -14,7 +14,6 @@ export default class DmlHandler {
     hasuraClient: HasuraClient = new HasuraClient(),
     PgClient = PgClientModule
   ): Promise<DmlHandler> {
-    console.log('CALL MADE');
     const connectionParameters = await hasuraClient.getDbConnectionParameters(account);
     const pgClient = new PgClient({
       user: connectionParameters.username,

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -470,7 +470,7 @@ CREATE TABLE
     expect(result.length).toEqual(2);
   });
 
-  test('indexer builds context and does simultaneous inserts', async () => {
+  test('indexer builds context and does simultaneous upserts', async () => {
     const mockDmlHandler: any = {
       create: jest.fn().mockImplementation(() => {
         return { upsert: jest.fn().mockReturnValue([{ colA: 'valA' }, { colA: 'valA' }]) };
@@ -500,7 +500,7 @@ CREATE TABLE
     }
     await Promise.all(promises);
     expect(mockDmlHandler.create).toHaveBeenCalledTimes(1);
-  }, 100000);
+  });
 
   test('indexer builds context and selects objects from existing table', async () => {
     const selectFn = jest.fn();

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -218,7 +218,7 @@ export default class Indexer {
     try {
       const tables = this.getTableNames(schema);
       const sanitizedTableNames = new Set<string>();
-      let dmlHandler: DmlHandler;
+      const dmlHandlerLazyLoader: Promise<DmlHandler> = this.deps.DmlHandler.create(account);
 
       // Generate and collect methods for each table name
       const result = tables.reduce((prev, tableName) => {
@@ -239,8 +239,8 @@ export default class Indexer {
               await this.writeLog(`context.db.${sanitizedTableName}.insert`, blockHeight, defaultLog + '.insert',
                 `Inserting object ${JSON.stringify(objectsToInsert)} into table ${tableName} on schema ${schemaName}`);
 
-              // Create DmlHandler if it doesn't exist
-              dmlHandler = dmlHandler ?? await this.deps.DmlHandler.create(account);
+              // Wait for initialiiation of DmlHandler
+              const dmlHandler = await dmlHandlerLazyLoader;
 
               // Call insert with parameters
               return await dmlHandler.insert(schemaName, tableName, Array.isArray(objectsToInsert) ? objectsToInsert : [objectsToInsert]);
@@ -250,8 +250,8 @@ export default class Indexer {
               await this.writeLog(`context.db.${sanitizedTableName}.select`, blockHeight, defaultLog + '.select',
                 `Selecting objects with values ${JSON.stringify(filterObj)} in table ${tableName} on schema ${schemaName} with ${limit === null ? 'no' : limit} limit`);
 
-              // Create DmlHandler if it doesn't exist
-              dmlHandler = dmlHandler ?? await this.deps.DmlHandler.create(account);
+              // Wait for initialiiation of DmlHandler
+              const dmlHandler = await dmlHandlerLazyLoader;
 
               // Call select with parameters
               return await dmlHandler.select(schemaName, tableName, filterObj, limit);
@@ -261,8 +261,8 @@ export default class Indexer {
               await this.writeLog(`context.db.${sanitizedTableName}.update`, blockHeight, defaultLog + '.update',
                 `Updating objects that match ${JSON.stringify(filterObj)} with values ${JSON.stringify(updateObj)} in table ${tableName} on schema ${schemaName}`);
 
-              // Create DmlHandler if it doesn't exist
-              dmlHandler = dmlHandler ?? await this.deps.DmlHandler.create(account);
+              // Wait for initialiiation of DmlHandler
+              const dmlHandler = await dmlHandlerLazyLoader;
 
               // Call update with parameters
               return await dmlHandler.update(schemaName, tableName, filterObj, updateObj);
@@ -272,8 +272,8 @@ export default class Indexer {
               await this.writeLog(`context.db.${sanitizedTableName}.upsert`, blockHeight, defaultLog + '.upsert',
                 `Inserting objects with values ${JSON.stringify(objectsToInsert)} into table ${tableName} on schema ${schemaName}. Conflict on columns ${conflictColumns.join(', ')} will update values in columns ${updateColumns.join(', ')}`);
 
-              // Create DmlHandler if it doesn't exist
-              dmlHandler = dmlHandler ?? await this.deps.DmlHandler.create(account);
+              // Wait for initialiiation of DmlHandler
+              const dmlHandler = await dmlHandlerLazyLoader;
 
               // Call upsert with parameters
               return await dmlHandler.upsert(schemaName, tableName, Array.isArray(objectsToInsert) ? objectsToInsert : [objectsToInsert], conflictColumns, updateColumns);
@@ -283,8 +283,8 @@ export default class Indexer {
               await this.writeLog(`context.db.${sanitizedTableName}.delete`, blockHeight, defaultLog + '.delete',
                 `Deleting objects with values ${JSON.stringify(filterObj)} from table ${tableName} on schema ${schemaName}`);
 
-              // Create DmlHandler if it doesn't exist
-              dmlHandler = dmlHandler ?? await this.deps.DmlHandler.create(account);
+              // Wait for initialiiation of DmlHandler
+              const dmlHandler = await dmlHandlerLazyLoader;
 
               // Call delete with parameters
               return await dmlHandler.delete(schemaName, tableName, filterObj);
@@ -294,7 +294,7 @@ export default class Indexer {
 
         return {
           ...prev,
-          ...funcForTable
+          ...funcForTable,
         };
       }, {});
       return result;

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -294,7 +294,7 @@ export default class Indexer {
 
         return {
           ...prev,
-          ...funcForTable,
+          ...funcForTable
         };
       }, {});
       return result;

--- a/runner/src/pg-client.ts
+++ b/runner/src/pg-client.ts
@@ -12,11 +12,10 @@ interface ConnectionParams {
 export default class PgClient {
   private readonly pgPool: Pool;
   public format: typeof pgFormatModule;
-  sleep = async (ms: number): Promise<void> => { await new Promise((resolve) => setTimeout(resolve, ms)); };
 
   constructor (
     connectionParams: ConnectionParams,
-    poolConfig: PoolConfig = { max: 2, idleTimeoutMillis: 30000 },
+    poolConfig: PoolConfig = { max: 10, idleTimeoutMillis: 30000 },
     PgPool: typeof Pool = Pool,
     pgFormat: typeof pgFormatModule = pgFormatModule
   ) {
@@ -32,6 +31,7 @@ export default class PgClient {
   }
 
   async query<R extends QueryResultRow = any>(query: string, params: any[] = []): Promise<QueryResult<R>> {
+    // Automatically manages client connections to pool
     return await this.pgPool.query<R>(query, params);
   }
 }

--- a/runner/src/pg-client.ts
+++ b/runner/src/pg-client.ts
@@ -12,10 +12,11 @@ interface ConnectionParams {
 export default class PgClient {
   private readonly pgPool: Pool;
   public format: typeof pgFormatModule;
+  sleep = async (ms: number): Promise<void> => { await new Promise((resolve) => setTimeout(resolve, ms)); };
 
   constructor (
     connectionParams: ConnectionParams,
-    poolConfig: PoolConfig = { max: 10, idleTimeoutMillis: 30000 },
+    poolConfig: PoolConfig = { max: 2, idleTimeoutMillis: 30000 },
     PgPool: typeof Pool = Pool,
     pgFormat: typeof pgFormatModule = pgFormatModule
   ) {
@@ -31,11 +32,6 @@ export default class PgClient {
   }
 
   async query<R extends QueryResultRow = any>(query: string, params: any[] = []): Promise<QueryResult<R>> {
-    const client = await this.pgPool.connect();
-    try {
-      return await (client.query<R>(query, params));
-    } finally {
-      client.release();
-    }
+    return await this.pgPool.query<R>(query, params);
   }
 }


### PR DESCRIPTION
So after a lot of testing, I found the problem. It turns out that the lazy loading implementation I used for context.db was set up so that any calls to a db function would first check if the dmlHandler exists (Load on access). If not, then instantiate it. This is helpful for situations where the functions aren't used. However, this had a side effect: If a bunch of db function calls come in simultaneously, they will all poll dmlHandler and see it is uninitialized and all try and create a new one. Each initialization will try to create a pool with 10 available clients. And then all of them will create at least one client each. This will exhaust the clients very quick if there's enough of them. Changing it so that the dmlHandler is lazy loaded immediately instead. And on access, it will await its completion before calling any functions. This ensures there is no more than 1 client active for that invocation. I wrote a test as well which tries 100 simultaneous calls and verified 1 pool is created.

Transaction Support can come next, now that the pooling works correctly now. 