### PR TITLE
Replace block wait metric with Histogram

### DIFF
--- a/runner/src/metrics.ts
+++ b/runner/src/metrics.ts
@@ -1,10 +1,11 @@
 import express from 'express';
 import { Gauge, Histogram, Counter, AggregatorRegistry } from 'prom-client';
 
-const BLOCK_WAIT_DURATION = new Gauge({
+const BLOCK_WAIT_DURATION = new Histogram({
   name: 'queryapi_runner_block_wait_duration_milliseconds',
   help: 'Time an indexer function waited for a block before processing',
   labelNames: ['indexer', 'type'],
+  buckets: [1, 10, 100, 300, 500, 1000, 3000, 5000, 10000, 30000],
 });
 
 const CACHE_HIT = new Counter({

--- a/runner/src/stream-handler/worker.ts
+++ b/runner/src/stream-handler/worker.ts
@@ -113,7 +113,7 @@ async function blockQueueConsumer (workerContext: WorkerContext, streamKey: stri
         console.error('Block failed to process or does not have block height', block);
         continue;
       }
-      METRICS.BLOCK_WAIT_DURATION.labels({ indexer: indexerName, type: workerContext.streamType }).set(performance.now() - blockStartTime);
+      METRICS.BLOCK_WAIT_DURATION.labels({ indexer: indexerName, type: workerContext.streamType }).observe(performance.now() - blockStartTime);
       await indexer.runFunctions(block, functions, isHistorical, { provision: true });
 
       await workerContext.redisClient.deleteStreamMessage(streamKey, streamMessageId);


### PR DESCRIPTION
Current block wait metric uses a gauge, which is causing spikes in block wait to be lost. So, I have switched it to a histogram instead, which does a much better job at capturing peaks and having a variety of more useful expressions, some of which I list below. These expressions are also customizable. 

A more accurate average: 
`rate(queryapi_runner_block_wait_duration_milliseconds_sum[$__rate_interval]) / rate(queryapi_runner_block_wait_duration_milliseconds_count[$__rate_interval])`

The duration under which 95% of block requests were fulfilled
`histogram_quantile(0.95, sum(rate(queryapi_runner_block_wait_duration_milliseconds_bucket[$__rate_interval])) by (le))`

The % of requests for each indexer where the block wait was under 100ms
```
  sum(rate(queryapi_runner_block_wait_duration_milliseconds_bucket{le="100"}[$__rate_interval])) by (indexer)
/
  sum(rate(queryapi_runner_block_wait_duration_milliseconds_count[$__rate_interval])) by (indexer)
```