### PR TITLE
feat: Transaction Support for Indexer runFunction Invocations

### DIFF
--- a/runner/src/dml-handler/dml-handler.test.ts
+++ b/runner/src/dml-handler/dml-handler.test.ts
@@ -37,9 +37,9 @@ describe('DML Handler tests', () => {
     });
 
     const dmlHandler = await DmlHandler.create(ACCOUNT, hasuraClient, mockPgClient);
-    await dmlHandler.startConnection();
-    await dmlHandler.startConnection();
-    await dmlHandler.startConnection();
+    await dmlHandler.startConnection('test_indexer');
+    await dmlHandler.startConnection('test_indexer');
+    await dmlHandler.startConnection('test_indexer');
 
     expect(startConnection).toHaveBeenCalledTimes(1);
   });
@@ -57,13 +57,13 @@ describe('DML Handler tests', () => {
     });
 
     const dmlHandler = await DmlHandler.create(ACCOUNT, hasuraClient, mockPgClient);
-    await dmlHandler.startConnection();
-    await dmlHandler.endConnection();
-    await dmlHandler.endConnection();
+    await dmlHandler.startConnection('test_indexer');
+    await dmlHandler.endConnection('test_indexer');
+    await dmlHandler.endConnection('test_indexer');
 
     expect(startConnection).toHaveBeenCalledTimes(1);
     expect(endConnection).toHaveBeenCalledTimes(1);
-    expect(endConnection).toHaveBeenCalledWith(false);
+    expect(endConnection).toHaveBeenCalledWith(false, 'test_indexer');
   });
 
   test('Test close connection with failed queries to database', async () => {
@@ -80,15 +80,15 @@ describe('DML Handler tests', () => {
     });
 
     const dmlHandler = await DmlHandler.create(ACCOUNT, hasuraClient, mockPgClient);
-    await dmlHandler.startConnection();
-    await dmlHandler.startConnection();
+    await dmlHandler.startConnection('test_indexer');
+    await dmlHandler.startConnection('test_indexer');
     dmlHandler.setTransactionFailed();
-    await dmlHandler.endConnection();
-    await dmlHandler.endConnection();
+    await dmlHandler.endConnection('test_indexer');
+    await dmlHandler.endConnection('test_indexer');
 
     expect(startConnection).toHaveBeenCalledTimes(1);
     expect(endConnection).toHaveBeenCalledTimes(1);
-    expect(endConnection).toHaveBeenCalledWith(true);
+    expect(endConnection).toHaveBeenCalledWith(true, 'test_indexer');
   });
 
   test('Test valid insert one with array', async () => {

--- a/runner/src/dml-handler/dml-handler.test.ts
+++ b/runner/src/dml-handler/dml-handler.test.ts
@@ -21,40 +21,46 @@ describe('DML Handler tests', () => {
   beforeEach(() => {
     query = jest.fn().mockReturnValue({ rows: [] });
     PgClient = jest.fn().mockImplementation(() => {
-      return { query, format: pgFormat };
+      return { startConnection: jest.fn(), query, format: pgFormat };
     });
   });
 
   test('Test open connection to database', async () => {
     const startConnection = jest.fn();
+    const query = jest.fn();
     const mockPgClient: any = jest.fn().mockImplementation(() => {
       return {
         startConnection,
         endConnection: jest.fn(),
-        query: jest.fn(),
+        query,
       };
     });
+
     const dmlHandler = await DmlHandler.create(ACCOUNT, hasuraClient, mockPgClient);
     await dmlHandler.startConnection();
     await dmlHandler.startConnection();
     await dmlHandler.startConnection();
+
     expect(startConnection).toHaveBeenCalledTimes(1);
   });
 
   test('Test close connection with successful queries to database', async () => {
     const startConnection = jest.fn();
     const endConnection = jest.fn();
+    const query = jest.fn();
     const mockPgClient: any = jest.fn().mockImplementation(() => {
       return {
         startConnection,
         endConnection,
-        query: jest.fn(),
+        query,
       };
     });
+
     const dmlHandler = await DmlHandler.create(ACCOUNT, hasuraClient, mockPgClient);
     await dmlHandler.startConnection();
     await dmlHandler.endConnection();
     await dmlHandler.endConnection();
+
     expect(startConnection).toHaveBeenCalledTimes(1);
     expect(endConnection).toHaveBeenCalledTimes(1);
     expect(endConnection).toHaveBeenCalledWith(false);
@@ -63,7 +69,7 @@ describe('DML Handler tests', () => {
   test('Test close connection with failed queries to database', async () => {
     const startConnection = jest.fn();
     const endConnection = jest.fn();
-    const query = jest.fn().mockImplementation(() => { throw new Error('query fail'); });
+    const query = jest.fn();
     const mockPgClient: any = jest.fn().mockImplementation(() => {
       return {
         startConnection,
@@ -73,23 +79,13 @@ describe('DML Handler tests', () => {
       };
     });
 
-    const inputObj = {
-      account_id: 'test_acc_near',
-      block_height: 999,
-      block_timestamp: 'UTC',
-      content: 'test_content',
-      receipt_id: 111,
-      accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
-    };
-
     const dmlHandler = await DmlHandler.create(ACCOUNT, hasuraClient, mockPgClient);
     await dmlHandler.startConnection();
     await dmlHandler.startConnection();
-    await expect(async () => {
-      await dmlHandler.insert(SCHEMA, TABLE_NAME, [inputObj]);
-    }).rejects.toThrow('query fail');
+    dmlHandler.setTransactionFailed();
     await dmlHandler.endConnection();
     await dmlHandler.endConnection();
+
     expect(startConnection).toHaveBeenCalledTimes(1);
     expect(endConnection).toHaveBeenCalledTimes(1);
     expect(endConnection).toHaveBeenCalledWith(true);

--- a/runner/src/dml-handler/dml-handler.test.ts
+++ b/runner/src/dml-handler/dml-handler.test.ts
@@ -21,7 +21,7 @@ describe('DML Handler tests', () => {
   beforeEach(() => {
     query = jest.fn().mockReturnValue({ rows: [] });
     PgClient = jest.fn().mockImplementation(() => {
-      return { startConnection: jest.fn(), query, format: pgFormat };
+      return { query, format: pgFormat };
     });
   });
 
@@ -35,40 +35,34 @@ describe('DML Handler tests', () => {
 
   test('Test open connection to database', async () => {
     const startConnection = jest.fn();
-    const query = jest.fn();
     const mockPgClient: any = jest.fn().mockImplementation(() => {
       return {
         startConnection,
         endConnection: jest.fn(),
-        query,
+        query: jest.fn(),
       };
     });
-
     const dmlHandler = await DmlHandler.create(ACCOUNT, hasuraClient, mockPgClient);
     await dmlHandler.startConnection();
     await dmlHandler.startConnection();
     await dmlHandler.startConnection();
-
     expect(startConnection).toHaveBeenCalledTimes(1);
   });
 
   test('Test close connection with successful queries to database', async () => {
     const startConnection = jest.fn();
     const endConnection = jest.fn();
-    const query = jest.fn();
     const mockPgClient: any = jest.fn().mockImplementation(() => {
       return {
         startConnection,
         endConnection,
-        query,
+        query: jest.fn(),
       };
     });
-
     const dmlHandler = await DmlHandler.create(ACCOUNT, hasuraClient, mockPgClient);
     await dmlHandler.startConnection();
     await dmlHandler.endConnection();
     await dmlHandler.endConnection();
-
     expect(startConnection).toHaveBeenCalledTimes(1);
     expect(endConnection).toHaveBeenCalledTimes(1);
     expect(endConnection).toHaveBeenCalledWith(false);
@@ -77,7 +71,7 @@ describe('DML Handler tests', () => {
   test('Test close connection with failed queries to database', async () => {
     const startConnection = jest.fn();
     const endConnection = jest.fn();
-    const query = jest.fn();
+    const query = jest.fn().mockImplementation(() => { throw new Error('query fail'); });
     const mockPgClient: any = jest.fn().mockImplementation(() => {
       return {
         startConnection,
@@ -87,13 +81,23 @@ describe('DML Handler tests', () => {
       };
     });
 
+    const inputObj = {
+      account_id: 'test_acc_near',
+      block_height: 999,
+      block_timestamp: 'UTC',
+      content: 'test_content',
+      receipt_id: 111,
+      accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
+    };
+
     const dmlHandler = await DmlHandler.create(ACCOUNT, hasuraClient, mockPgClient);
     await dmlHandler.startConnection();
     await dmlHandler.startConnection();
-    dmlHandler.setTransactionFailed();
+    await expect(async () => {
+      await dmlHandler.insert(SCHEMA, TABLE_NAME, [inputObj]);
+    }).rejects.toThrow('query fail');
     await dmlHandler.endConnection();
     await dmlHandler.endConnection();
-
     expect(startConnection).toHaveBeenCalledTimes(1);
     expect(endConnection).toHaveBeenCalledTimes(1);
     expect(endConnection).toHaveBeenCalledWith(true);

--- a/runner/src/dml-handler/dml-handler.test.ts
+++ b/runner/src/dml-handler/dml-handler.test.ts
@@ -25,6 +25,14 @@ describe('DML Handler tests', () => {
     });
   });
 
+  test('TEST FOR OVERLOADING DATABASE WITH ONE POOL', async () => {
+    for (let i = 0; i < 100; i++) {
+      const dmlHandler = await DmlHandler.create('morgs_near');
+      const client = await dmlHandler.connUsingPool();
+      client.release();
+    }
+  });
+
   test('Test open connection to database', async () => {
     const startConnection = jest.fn();
     const query = jest.fn();

--- a/runner/src/dml-handler/dml-handler.test.ts
+++ b/runner/src/dml-handler/dml-handler.test.ts
@@ -25,14 +25,6 @@ describe('DML Handler tests', () => {
     });
   });
 
-  test('TEST FOR OVERLOADING DATABASE WITH ONE POOL', async () => {
-    for (let i = 0; i < 100; i++) {
-      const dmlHandler = await DmlHandler.create('morgs_near');
-      const client = await dmlHandler.connUsingPool();
-      client.release();
-    }
-  });
-
   test('Test open connection to database', async () => {
     const startConnection = jest.fn();
     const query = jest.fn();

--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -105,4 +105,16 @@ export default class DmlHandler {
     }
     return result.rows;
   }
+
+  async startTransaction (): Promise<void> {
+    await this.pgClient.transactionStart();
+  }
+
+  async commitTransaction (): Promise<void> {
+    await this.pgClient.transactionCommit();
+  }
+
+  async rollbackTransaction (): Promise<void> {
+    await this.pgClient.transactionRollback();
+  }
 }

--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -9,7 +9,7 @@ export default class DmlHandler {
   private constructor (
     private readonly pgClient: PgClientModule,
     private connected: boolean = false,
-    private failedQuery: boolean = false,
+    private failedTransaction: boolean = false,
   ) {}
 
   static async create (
@@ -110,16 +110,14 @@ export default class DmlHandler {
   }
 
   private async makeQuery (schemaName: string, tableName: string, query: string, values: unknown[], formatValues: boolean): Promise<any[]> {
-    try {
-      await this.startConnection();
-      const formattedQuery = formatValues ? this.pgClient.format(query, values) : this.pgClient.format(query);
-      const queryValues = formatValues ? [] : values;
-      const result = await wrapError(async () => await this.pgClient.query(formattedQuery, queryValues), `Failed to execute '${query}' on ${schemaName}."${tableName}".`);
-      return result.rows;
-    } catch (error) {
-      this.failedQuery = true;
-      throw error;
-    }
+    const formattedQuery = formatValues ? this.pgClient.format(query, values) : this.pgClient.format(query);
+    const queryValues = formatValues ? [] : values;
+    const result = await wrapError(async () => await this.pgClient.query(formattedQuery, queryValues), `Failed to execute '${query}' on ${schemaName}."${tableName}".`);
+    return result.rows;
+  }
+
+  setTransactionFailed (): void {
+    this.failedTransaction = true;
   }
 
   async startConnection (): Promise<void> {
@@ -131,10 +129,10 @@ export default class DmlHandler {
 
   async endConnection (): Promise<void> {
     if (this.connected) {
-      await this.pgClient.endConnection(this.failedQuery);
+      await this.pgClient.endConnection(this.failedTransaction);
     }
     this.connected = false;
-    this.failedQuery = false;
+    this.failedTransaction = false;
   }
 
   async connUsingPool (): Promise<PoolClient> {

--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -1,7 +1,6 @@
 import { wrapError } from '../utility';
 import PgClientModule from '../pg-client';
 import HasuraClient from '../hasura-client/hasura-client';
-import { type PoolClient } from 'pg';
 
 export default class DmlHandler {
   validTableNameRegex = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
@@ -133,9 +132,5 @@ export default class DmlHandler {
     }
     this.connected = false;
     this.failedTransaction = false;
-  }
-
-  async connUsingPool (): Promise<PoolClient> {
-    return await this.pgClient.conn();
   }
 }

--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -1,6 +1,7 @@
 import { wrapError } from '../utility';
 import PgClientModule from '../pg-client';
 import HasuraClient from '../hasura-client/hasura-client';
+import { type PoolClient } from 'pg';
 
 export default class DmlHandler {
   validTableNameRegex = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
@@ -132,5 +133,9 @@ export default class DmlHandler {
     }
     this.connected = false;
     this.failedTransaction = false;
+  }
+
+  async connUsingPool (): Promise<PoolClient> {
+    return await this.pgClient.conn();
   }
 }

--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -119,16 +119,16 @@ export default class DmlHandler {
     this.failedTransaction = true;
   }
 
-  async startConnection (): Promise<void> {
+  async startConnection (functionName: string): Promise<void> {
     if (!this.connected) {
-      await this.pgClient.startConnection();
+      await this.pgClient.startConnection(functionName);
       this.connected = true;
     }
   }
 
-  async endConnection (): Promise<void> {
+  async endConnection (functionName: string): Promise<void> {
     if (this.connected) {
-      await this.pgClient.endConnection(this.failedTransaction);
+      await this.pgClient.endConnection(this.failedTransaction, functionName);
     }
     this.connected = false;
     this.failedTransaction = false;

--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -110,6 +110,7 @@ export default class DmlHandler {
 
   private async makeQuery (schemaName: string, tableName: string, query: string, values: unknown[], formatValues: boolean): Promise<any[]> {
     try {
+      await this.startConnection();
       const formattedQuery = formatValues ? this.pgClient.format(query, values) : this.pgClient.format(query);
       const queryValues = formatValues ? [] : values;
       const result = await wrapError(async () => await this.pgClient.query(formattedQuery, queryValues), `Failed to execute '${query}' on ${schemaName}."${tableName}".`);

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -472,101 +472,6 @@ CREATE TABLE
     expect(result.length).toEqual(2);
   });
 
-  test('indexer skips connections to db when no context.db methods invoked', async () => {
-    const mockDmlHandlerPromise: Promise<DmlHandler> = Promise.resolve({
-      startConnection: jest.fn(),
-      endConnection: jest.fn(),
-    } as unknown as DmlHandler);
-    const mockDmlHandler: any = {
-      create: jest.fn().mockReturnValue(mockDmlHandlerPromise),
-    } as unknown as DmlHandler;
-
-    const functions: Record<string, any> = {};
-    functions['morgs.near/social_feed1'] = {
-      code: `
-            const postData = {
-              account_id: 'morgs_near',
-              block_height: 1,
-              receipt_id: 'abc',
-              content: 'test',
-              block_timestamp: 800,
-              accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
-            };
-        `,
-      schema: SIMPLE_SCHEMA
-    };
-    const mockBlock = Block.fromStreamerMessage({
-      block: {
-        chunks: [],
-        header: {
-          height: 123
-        }
-      },
-      shards: {}
-    } as unknown as StreamerMessage) as unknown as Block;
-
-    const indexer = new Indexer({
-      fetch: genericMockFetch as unknown as typeof fetch,
-      DmlHandler: mockDmlHandler
-    });
-    await indexer.runFunctions(mockBlock, functions, false);
-
-    expect((await mockDmlHandlerPromise).startConnection).toBeCalledTimes(0);
-    expect((await mockDmlHandlerPromise).endConnection).toBeCalledTimes(1);
-  });
-
-  test('indexer code catches failed query error, not triggering rollback', async () => {
-    const mockDmlHandlerPromise: Promise<DmlHandler> = Promise.resolve({
-      startConnection: jest.fn(),
-      setTransactionFailed: jest.fn(),
-      endConnection: jest.fn(),
-      insert: jest.fn().mockImplementation(() => { throw new Error('query fail'); }),
-    } as unknown as DmlHandler);
-    const mockDmlHandler: any = {
-      create: jest.fn().mockReturnValue(mockDmlHandlerPromise),
-    } as unknown as DmlHandler;
-
-    const functions: Record<string, any> = {};
-    functions['morgs.near/social_feed1'] = {
-      code: `
-            const postData = {
-              account_id: 'morgs_near',
-              block_height: 1,
-              receipt_id: 'abc',
-              content: 'test',
-              block_timestamp: 800,
-              accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
-            };
-            try {
-              await context.db.Posts.insert(postData);
-            } catch (error) {
-              console.log('Error caught during insert');
-            }
-        `,
-      schema: SIMPLE_SCHEMA
-    };
-    const mockBlock = Block.fromStreamerMessage({
-      block: {
-        chunks: [],
-        header: {
-          height: 123
-        }
-      },
-      shards: {}
-    } as unknown as StreamerMessage) as unknown as Block;
-
-    const indexer = new Indexer({
-      fetch: genericMockFetch as unknown as typeof fetch,
-      DmlHandler: mockDmlHandler
-    });
-    await indexer.runFunctions(mockBlock, functions, false);
-
-    expect((await mockDmlHandlerPromise).startConnection).toBeCalledTimes(1);
-    expect((await mockDmlHandlerPromise).setTransactionFailed).toBeCalledTimes(0);
-    expect((await mockDmlHandlerPromise).endConnection).toBeCalledTimes(1);
-    expect((await mockDmlHandlerPromise).insert).toBeCalledTimes(1);
-  });
-
   test('indexer succeeds all queries, triggering commit', async () => {
     const mockDmlHandlerPromise: Promise<DmlHandler> = Promise.resolve({
       startConnection: jest.fn(),
@@ -620,7 +525,6 @@ CREATE TABLE
   test('indexer fails one query, triggering rollback of all other queries', async () => {
     const mockDmlHandlerPromise: Promise<DmlHandler> = Promise.resolve({
       startConnection: jest.fn(),
-      setTransactionFailed: jest.fn(),
       endConnection: jest.fn(),
       insert: jest.fn().mockImplementation(() => { throw new Error('query fail'); }),
       upsert: jest.fn()
@@ -689,11 +593,10 @@ CREATE TABLE
     }).rejects.toThrow('query fail');
 
     expect((await mockDmlHandlerPromise).startConnection).toBeCalledTimes(1);
-    expect((await mockDmlHandlerPromise).setTransactionFailed).toBeCalledTimes(1);
     expect((await mockDmlHandlerPromise).endConnection).toBeCalledTimes(1);
     expect((await mockDmlHandlerPromise).insert).toBeCalledTimes(1);
     expect((await mockDmlHandlerPromise).upsert).toHaveBeenCalled();
-  });
+  }, 100000);
 
   test('indexer builds context and does simultaneous upserts', async () => {
     const mockDmlHandler: Promise<DmlHandler> = Promise.resolve({
@@ -1014,17 +917,6 @@ CREATE TABLE
         errors: null,
       }),
     }));
-    const startConnection = jest.fn();
-    const setTransactionFailed = jest.fn();
-    const endConnection = jest.fn();
-    const mockDmlHandlerPromise: Promise<DmlHandler> = Promise.resolve({
-      startConnection,
-      setTransactionFailed,
-      endConnection,
-    } as unknown as DmlHandler);
-    const mockDmlHandler: any = {
-      create: jest.fn().mockReturnValue(mockDmlHandlerPromise),
-    } as unknown as DmlHandler;
     const blockHeight = 456;
     const mockBlock = Block.fromStreamerMessage({
       block: {
@@ -1035,7 +927,7 @@ CREATE TABLE
       },
       shards: {}
     } as unknown as StreamerMessage) as unknown as Block;
-    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: mockDmlHandler });
+    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
 
     const functions: Record<string, any> = {};
     functions['buildnear.testnet/test'] = {
@@ -1047,9 +939,6 @@ CREATE TABLE
 
     await expect(indexer.runFunctions(mockBlock, functions, false)).rejects.toThrow(new Error('boom'));
     expect(mockFetch.mock.calls).toMatchSnapshot();
-    expect(startConnection).toBeCalledTimes(0);
-    expect(setTransactionFailed).toBeCalledTimes(1);
-    expect(endConnection).toBeCalledTimes(1);
   });
 
   test('Indexer.runFunctions() provisions a GraphQL endpoint with the specified schema', async () => {

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -110,7 +110,6 @@ export default class Indexer {
           // For now, we just log the message. In the future we could sanitize the stack trace
           // and give the correct line number offsets within the indexer function
           console.error(`${functionName}: Error running IndexerFunction on block ${blockHeight}: ${error.message}`);
-          (await dmlHandlerLazyLoader).setTransactionFailed();
           await this.writeLog(functionName, blockHeight, 'Error running IndexerFunction', error.message);
           throw e;
         } finally {

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -101,7 +101,7 @@ export default class Indexer {
         const modifiedFunction = this.transformIndexerFunction(indexerFunction.code);
         try {
           if (modifiedFunction.includes('context.db')) {
-            await (await dmlHandlerLazyLoader).startConnection();
+            await (await dmlHandlerLazyLoader).startConnection(functionName);
           }
           await vm.run(modifiedFunction);
         } catch (e) {
@@ -114,7 +114,7 @@ export default class Indexer {
           await this.writeLog(functionName, blockHeight, 'Error running IndexerFunction', error.message);
           throw e;
         } finally {
-          await (await dmlHandlerLazyLoader).endConnection();
+          await (await dmlHandlerLazyLoader).endConnection(functionName);
         }
         simultaneousPromises.push(this.writeFunctionState(functionName, blockHeight, isHistorical));
       } catch (e) {

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -100,7 +100,9 @@ export default class Indexer {
 
         const modifiedFunction = this.transformIndexerFunction(indexerFunction.code);
         try {
-          await (await dmlHandlerLazyLoader).startConnection();
+          if (modifiedFunction.includes('context.db')) {
+            await (await dmlHandlerLazyLoader).startConnection();
+          }
           await vm.run(modifiedFunction);
         } catch (e) {
           const error = e as Error;

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -110,6 +110,7 @@ export default class Indexer {
           // For now, we just log the message. In the future we could sanitize the stack trace
           // and give the correct line number offsets within the indexer function
           console.error(`${functionName}: Error running IndexerFunction on block ${blockHeight}: ${error.message}`);
+          (await dmlHandlerLazyLoader).setTransactionFailed();
           await this.writeLog(functionName, blockHeight, 'Error running IndexerFunction', error.message);
           throw e;
         } finally {

--- a/runner/src/pg-client.ts
+++ b/runner/src/pg-client.ts
@@ -1,4 +1,4 @@
-import { Pool, type PoolConfig, type QueryResult, type QueryResultRow } from 'pg';
+import { Pool, type PoolClient, type PoolConfig, type QueryResult, type QueryResultRow } from 'pg';
 import pgFormatModule from 'pg-format';
 
 interface ConnectionParams {
@@ -11,13 +11,14 @@ interface ConnectionParams {
 
 export default class PgClient {
   private readonly pgPool: Pool;
+  private pgClient: PoolClient | undefined;
   public format: typeof pgFormatModule;
 
   constructor (
     connectionParams: ConnectionParams,
     poolConfig: PoolConfig = { max: 10, idleTimeoutMillis: 30000 },
     PgPool: typeof Pool = Pool,
-    pgFormat: typeof pgFormatModule = pgFormatModule
+    pgFormat: typeof pgFormatModule = pgFormatModule,
   ) {
     this.pgPool = new PgPool({
       user: connectionParams.user,
@@ -27,11 +28,42 @@ export default class PgClient {
       database: connectionParams.database,
       ...poolConfig,
     });
+    this.pgClient = undefined;
     this.format = pgFormat;
   }
 
+  async transactionStart (): Promise<void> {
+    this.pgClient = await this.pgPool.connect();
+    await this.pgClient.query('BEGIN');
+    console.log('Transaction started successfully. Postgres client connected.');
+  }
+
+  async transactionCommit (): Promise<void> {
+    if (!this.pgClient) {
+      throw new Error('No client to commit transaction with.');
+    }
+    await this.pgClient.query('COMMIT');
+    this.pgClient.release();
+    this.pgClient = undefined;
+    console.log('Transaction committed successfully. Postgres client disconnected.');
+  }
+
+  async transactionRollback (): Promise<void> {
+    if (!this.pgClient) {
+      console.warn('No client to rollback transaction with.');
+      return;
+    }
+    await this.pgClient.query('ROLLBACK');
+    this.pgClient.release();
+    this.pgClient = undefined;
+    console.log('Transaction rolled back successfully. Postgres client disconnected.');
+  }
+
   async query<R extends QueryResultRow = any>(query: string, params: any[] = []): Promise<QueryResult<R>> {
+    if (!this.pgClient) {
+      throw new Error('No client to execute query with.');
+    }
     // Automatically manages client connections to pool
-    return await this.pgPool.query<R>(query, params);
+    return await this.pgClient.query<R>(query, params);
   }
 }

--- a/runner/src/pg-client.ts
+++ b/runner/src/pg-client.ts
@@ -28,7 +28,7 @@ export default class PgClient {
     this.format = pgFormat;
   }
 
-  async startConnection (): Promise<void> {
+  async startConnection (functionName: string): Promise<void> {
     try {
       await this.client.connect();
     } catch (error) {
@@ -36,13 +36,13 @@ export default class PgClient {
       throw error;
     }
     await this.client.query('BEGIN');
-    console.log('Postgres client connected. Transaction started successfully.');
+    console.log(`Postgres client connected. Transaction for indexer ${functionName} started successfully.`);
   }
 
-  async endConnection (failedQuery: boolean): Promise<void> {
+  async endConnection (failedQuery: boolean, functionName: string): Promise<void> {
     await this.client.query(failedQuery ? 'ROLLBACK' : 'COMMIT');
     await this.client.end();
-    console.log(`Transaction ${failedQuery ? 'rolled back' : 'comitted'} successfully. Postgres client disconnected.`);
+    console.log(`Transaction for indexer ${functionName} ${failedQuery ? 'rolled back' : 'comitted'} successfully. Postgres client disconnected.`);
   }
 
   async query<R extends QueryResultRow = any>(query: string, params: any[] = []): Promise<QueryResult<R>> {

--- a/runner/src/pg-client.ts
+++ b/runner/src/pg-client.ts
@@ -1,4 +1,4 @@
-import { Client, Pool, type PoolClient, type QueryResult, type QueryResultRow } from 'pg';
+import { Client, type QueryResult, type QueryResultRow } from 'pg';
 import pgFormatModule from 'pg-format';
 
 interface ConnectionParams {
@@ -11,23 +11,12 @@ interface ConnectionParams {
 
 export default class PgClient {
   private readonly client: Client;
-  private readonly pgPool: Pool;
   public format: typeof pgFormatModule;
 
   constructor (
     connectionParams: ConnectionParams,
-    PgPool: typeof Pool = Pool,
     pgFormat: typeof pgFormatModule = pgFormatModule,
   ) {
-    this.pgPool = new PgPool({
-      user: connectionParams.user,
-      password: connectionParams.password,
-      host: connectionParams.host,
-      port: Number(connectionParams.port),
-      database: connectionParams.database,
-      max: 10,
-      idleTimeoutMillis: 30000
-    });
     this.client = new Client({
       user: connectionParams.user,
       password: connectionParams.password,
@@ -58,9 +47,5 @@ export default class PgClient {
 
   async query<R extends QueryResultRow = any>(query: string, params: any[] = []): Promise<QueryResult<R>> {
     return await this.client.query<R>(query, params);
-  }
-
-  async conn (): Promise<PoolClient> {
-    return await this.pgPool.connect();
   }
 }

--- a/runner/src/pg-client.ts
+++ b/runner/src/pg-client.ts
@@ -40,20 +40,15 @@ export default class PgClient {
   }
 
   async startConnection (): Promise<void> {
-    try {
-      await this.client.connect();
-    } catch (error) {
-      console.error('Failed to connect to client');
-      throw error;
-    }
+    await this.client.connect();
     await this.client.query('BEGIN');
-    console.log('Postgres client connected. Transaction started successfully.');
+    console.log('Transaction started successfully. Postgres client connected.');
   }
 
   async endConnection (failedQuery: boolean): Promise<void> {
     await this.client.query(failedQuery ? 'ROLLBACK' : 'COMMIT');
     await this.client.end();
-    console.log(`Transaction ${failedQuery ? 'rolled back' : 'comitted'} successfully. Postgres client disconnected.`);
+    console.log('Transaction committed successfully. Postgres client disconnected.');
   }
 
   async query<R extends QueryResultRow = any>(query: string, params: any[] = []): Promise<QueryResult<R>> {

--- a/runner/src/pg-client.ts
+++ b/runner/src/pg-client.ts
@@ -1,4 +1,4 @@
-import { Client, type QueryResult, type QueryResultRow } from 'pg';
+import { Client, Pool, type PoolClient, type QueryResult, type QueryResultRow } from 'pg';
 import pgFormatModule from 'pg-format';
 
 interface ConnectionParams {
@@ -11,12 +11,23 @@ interface ConnectionParams {
 
 export default class PgClient {
   private readonly client: Client;
+  private readonly pgPool: Pool;
   public format: typeof pgFormatModule;
 
   constructor (
     connectionParams: ConnectionParams,
+    PgPool: typeof Pool = Pool,
     pgFormat: typeof pgFormatModule = pgFormatModule,
   ) {
+    this.pgPool = new PgPool({
+      user: connectionParams.user,
+      password: connectionParams.password,
+      host: connectionParams.host,
+      port: Number(connectionParams.port),
+      database: connectionParams.database,
+      max: 10,
+      idleTimeoutMillis: 30000
+    });
     this.client = new Client({
       user: connectionParams.user,
       password: connectionParams.password,
@@ -47,5 +58,9 @@ export default class PgClient {
 
   async query<R extends QueryResultRow = any>(query: string, params: any[] = []): Promise<QueryResult<R>> {
     return await this.client.query<R>(query, params);
+  }
+
+  async conn (): Promise<PoolClient> {
+    return await this.pgPool.connect();
   }
 }

--- a/runner/src/pg-client.ts
+++ b/runner/src/pg-client.ts
@@ -29,15 +29,20 @@ export default class PgClient {
   }
 
   async startConnection (): Promise<void> {
-    await this.client.connect();
+    try {
+      await this.client.connect();
+    } catch (error) {
+      console.error('Failed to connect to client');
+      throw error;
+    }
     await this.client.query('BEGIN');
-    console.log('Transaction started successfully. Postgres client connected.');
+    console.log('Postgres client connected. Transaction started successfully.');
   }
 
   async endConnection (failedQuery: boolean): Promise<void> {
     await this.client.query(failedQuery ? 'ROLLBACK' : 'COMMIT');
     await this.client.end();
-    console.log('Transaction committed successfully. Postgres client disconnected.');
+    console.log(`Transaction ${failedQuery ? 'rolled back' : 'comitted'} successfully. Postgres client disconnected.`);
   }
 
   async query<R extends QueryResultRow = any>(query: string, params: any[] = []): Promise<QueryResult<R>> {

--- a/runner/src/pg-client.ts
+++ b/runner/src/pg-client.ts
@@ -1,4 +1,4 @@
-import { Pool, type PoolClient, type PoolConfig, type QueryResult, type QueryResultRow } from 'pg';
+import { Client, type QueryResult, type QueryResultRow } from 'pg';
 import pgFormatModule from 'pg-format';
 
 interface ConnectionParams {
@@ -10,60 +10,37 @@ interface ConnectionParams {
 }
 
 export default class PgClient {
-  private readonly pgPool: Pool;
-  private pgClient: PoolClient | undefined;
+  private readonly client: Client;
   public format: typeof pgFormatModule;
 
   constructor (
     connectionParams: ConnectionParams,
-    poolConfig: PoolConfig = { max: 10, idleTimeoutMillis: 30000 },
-    PgPool: typeof Pool = Pool,
     pgFormat: typeof pgFormatModule = pgFormatModule,
   ) {
-    this.pgPool = new PgPool({
+    this.client = new Client({
       user: connectionParams.user,
       password: connectionParams.password,
       host: connectionParams.host,
       port: Number(connectionParams.port),
       database: connectionParams.database,
-      ...poolConfig,
+      idle_in_transaction_session_timeout: 30000,
     });
-    this.pgClient = undefined;
     this.format = pgFormat;
   }
 
-  async transactionStart (): Promise<void> {
-    this.pgClient = await this.pgPool.connect();
-    await this.pgClient.query('BEGIN');
+  async startConnection (): Promise<void> {
+    await this.client.connect();
+    await this.client.query('BEGIN');
     console.log('Transaction started successfully. Postgres client connected.');
   }
 
-  async transactionCommit (): Promise<void> {
-    if (!this.pgClient) {
-      throw new Error('No client to commit transaction with.');
-    }
-    await this.pgClient.query('COMMIT');
-    this.pgClient.release();
-    this.pgClient = undefined;
+  async endConnection (failedQuery: boolean): Promise<void> {
+    await this.client.query(failedQuery ? 'ROLLBACK' : 'COMMIT');
+    await this.client.end();
     console.log('Transaction committed successfully. Postgres client disconnected.');
   }
 
-  async transactionRollback (): Promise<void> {
-    if (!this.pgClient) {
-      console.warn('No client to rollback transaction with.');
-      return;
-    }
-    await this.pgClient.query('ROLLBACK');
-    this.pgClient.release();
-    this.pgClient = undefined;
-    console.log('Transaction rolled back successfully. Postgres client disconnected.');
-  }
-
   async query<R extends QueryResultRow = any>(query: string, params: any[] = []): Promise<QueryResult<R>> {
-    if (!this.pgClient) {
-      throw new Error('No client to execute query with.');
-    }
-    // Automatically manages client connections to pool
-    return await this.pgClient.query<R>(query, params);
+    return await this.client.query<R>(query, params);
   }
 }

--- a/runner/src/pg-client.ts
+++ b/runner/src/pg-client.ts
@@ -40,15 +40,20 @@ export default class PgClient {
   }
 
   async startConnection (): Promise<void> {
-    await this.client.connect();
+    try {
+      await this.client.connect();
+    } catch (error) {
+      console.error('Failed to connect to client');
+      throw error;
+    }
     await this.client.query('BEGIN');
-    console.log('Transaction started successfully. Postgres client connected.');
+    console.log('Postgres client connected. Transaction started successfully.');
   }
 
   async endConnection (failedQuery: boolean): Promise<void> {
     await this.client.query(failedQuery ? 'ROLLBACK' : 'COMMIT');
     await this.client.end();
-    console.log('Transaction committed successfully. Postgres client disconnected.');
+    console.log(`Transaction ${failedQuery ? 'rolled back' : 'comitted'} successfully. Postgres client disconnected.`);
   }
 
   async query<R extends QueryResultRow = any>(query: string, params: any[] = []): Promise<QueryResult<R>> {


### PR DESCRIPTION
Currently, partial failure of database actions is permitted. This can cause non-deterministic behavior depending on the state of the user's database. To help aid with that, we want to wrap all database calls in a transaction and commit the changes only if no errors occurred. 

Users may want to handle errors themselves in some cases, so we only rollback transaction if an uncaught error surfaces to the runner, meaning it was not caught by user code. 

In order to support transactions, each invocation of user code must have all queries go through the same client. After committing, the client should be released. Due to this behavior, we need to do away with pools, as we no longer expect any indexer to use more than one client at any point in time. 

There is a problem that the database can only support up to a certain number of active clients at a time. Thus, frequent and busy transactions can cause competing indexers to throttle. Eventually, the number of active connections will grow high enough to induce throttling. So, we will want to introduce a solution like pgBouncer soon. I was using 'SELECT sum(numbackends) FROM pg_stat_database;' in psql locally and observed as high as 84 active database connections, which is close to my local DB's max of 97. 

I tried my best to reproduce this behavior by backing up many blocks for all indexers as well as having a 90k+ historical backfill for an indexer which makes simple context.db invocations. I did observe a bit of throttling but did not observe any "too many clients' errors. This is probably due to the fact that all indexers don't have their own pool, but instead one client they make connect calls with.