### PR TITLE
fix: Try to resolve heap memory errors

### DIFF
--- a/runner/src/stream-handler/worker.ts
+++ b/runner/src/stream-handler/worker.ts
@@ -53,7 +53,7 @@ function incrementId (id: string): string {
 }
 
 async function blockQueueProducer (workerContext: WorkerContext, streamKey: string): Promise<void> {
-  const HISTORICAL_BATCH_SIZE = 100;
+  const HISTORICAL_BATCH_SIZE = 10;
   let streamMessageStartId = '0';
 
   while (true) {


### PR DESCRIPTION
We are seeing errors in prod relating to javascript running out of memory due to the heap growing. Most likely culprit is the block prefetch. There may be some characteristics in prod that cause this error, but not in dev. Failures cause the entire machine to crash and restart. 