### PR TITLE
fix: Prune Unnecessary Logs

### DIFF
--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -37,9 +37,6 @@ export default class DmlHandler {
     const query = `INSERT INTO ${schemaName}."${tableName}" (${keys.join(', ')}) VALUES %L RETURNING *`;
 
     const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query, values), []), `Failed to execute '${query}' on ${schemaName}."${tableName}".`);
-    if (result.rows?.length === 0) {
-      console.log('No rows were inserted.');
-    }
     return result.rows;
   }
 
@@ -53,9 +50,6 @@ export default class DmlHandler {
     }
 
     const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query), values), `Failed to execute '${query}' on ${schemaName}."${tableName}".`);
-    if (!(result.rows && result.rows.length > 0)) {
-      console.log('No rows were selected.');
-    }
     return result.rows;
   }
 
@@ -69,9 +63,6 @@ export default class DmlHandler {
     const query = `UPDATE ${schemaName}."${tableName}" SET ${updateParam} WHERE ${whereParam} RETURNING *`;
 
     const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query), queryValues), `Failed to execute '${query}' on ${schemaName}."${tableName}".`);
-    if (!(result.rows && result.rows.length > 0)) {
-      console.log('No rows were selected.');
-    }
     return result.rows;
   }
 
@@ -87,9 +78,6 @@ export default class DmlHandler {
     const query = `INSERT INTO ${schemaName}."${tableName}" (${keys.join(', ')}) VALUES %L ON CONFLICT (${conflictColumns.join(', ')}) DO UPDATE SET ${updatePlaceholders} RETURNING *`;
 
     const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query, values), []), `Failed to execute '${query}' on ${schemaName}."${tableName}".`);
-    if (result.rows?.length === 0) {
-      console.log('No rows were inserted or updated.');
-    }
     return result.rows;
   }
 
@@ -100,9 +88,6 @@ export default class DmlHandler {
     const query = `DELETE FROM ${schemaName}."${tableName}" WHERE ${param} RETURNING *`;
 
     const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query), values), `Failed to execute '${query}' on ${schemaName}."${tableName}".`);
-    if (!(result.rows && result.rows.length > 0)) {
-      console.log('No rows were deleted.');
-    }
     return result.rows;
   }
 }

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -65,7 +65,7 @@ export default class Indexer {
         const indexerFunction = functions[functionName];
 
         const runningMessage = `Running function ${functionName} on block ${blockHeight}` + (isHistorical ? ' historical backfill' : `, lag is: ${lag?.toString()}ms from block timestamp`);
-        console.log(runningMessage); // Print the running message to the console (Lambda logs)
+        console.log(runningMessage); // Print the running message to the console
 
         simultaneousPromises.push(this.writeLog(functionName, blockHeight, runningMessage));
 
@@ -192,7 +192,6 @@ export default class Indexer {
     }
 
     const tableNamesArray = Array.from(tableNames);
-    console.log('Retrieved the following table names from schema: ', tableNamesArray);
     return Array.from(tableNamesArray);
   }
 

--- a/runner/src/stream-handler/worker.ts
+++ b/runner/src/stream-handler/worker.ts
@@ -68,7 +68,6 @@ async function blockQueueProducer (workerContext: WorkerContext, streamKey: stri
       streamMessageStartId = '0';
       continue;
     }
-    console.log(`Fetched ${messages?.length} messages from stream ${streamKey}`);
 
     for (const streamMessage of messages) {
       const { id, message } = streamMessage;


### PR DESCRIPTION
Logs are causing machine to run out of space, leading to crashes. I've removed some logs which are not particularly helpful for debugging problems anymore. These logs also tend to run basically every single iteration, bloating logs both on machine and in GCP. 