### PR TITLE
feat: Toggle Runner Version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,8 @@ services:
       PORT: 9180
       AWS_ACCESS_KEY_ID:
       AWS_SECRET_ACCESS_KEY:
+      RUNNER_HOST: localhost
+      RUNNER_PORT: 7001
 
   redis:
     image: redis

--- a/runner/package-lock.json
+++ b/runner/package-lock.json
@@ -23,7 +23,10 @@
         "prom-client": "^14.2.0",
         "redis": "^4.6.7",
         "verror": "^1.10.1",
-        "vm2": "^3.9.19"
+        "vm2": "^3.9.19",
+        "zipkin": "^0.22.0",
+        "zipkin-context-cls": "^0.22.0",
+        "zipkin-transport-http": "^0.22.0"
       },
       "devDependencies": {
         "@types/express": "^4.17.17",
@@ -34,6 +37,7 @@
         "@types/pg-format": "^1.0.2",
         "@types/pluralize": "^0.0.29",
         "@types/verror": "^1.10.6",
+        "@types/zipkin-context-cls": "^0.11.7",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
         "eslint": "^8.46.0",
@@ -946,15 +950,87 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
-      "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.22.5"
+        "@babel/highlight": "^7.23.4",
+        "chalk": "^2.4.2"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/compat-data": {
@@ -1024,12 +1100,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.9.tgz",
-      "integrity": "sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.5",
+        "@babel/types": "^7.23.6",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -1107,22 +1183,22 @@
       "dev": true
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-      "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-      "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1205,18 +1281,18 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -1246,13 +1322,13 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
-      "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.5",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
       "engines": {
@@ -1331,9 +1407,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
-      "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1519,35 +1595,46 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.23.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.8.tgz",
+      "integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
-      "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.5",
-        "@babel/parser": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.8",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.8.tgz",
-      "integrity": "sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==",
+      "version": "7.23.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
+      "integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.5",
-        "@babel/generator": "^7.22.7",
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-function-name": "^7.22.5",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.6",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.7",
-        "@babel/types": "^7.22.5",
-        "debug": "^4.1.0",
+        "@babel/parser": "^7.23.6",
+        "@babel/types": "^7.23.6",
+        "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -1564,13 +1651,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
-      "integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
+      "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/helper-string-parser": "^7.23.4",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -3642,6 +3729,15 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
+    "node_modules/@types/zipkin-context-cls": {
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/@types/zipkin-context-cls/-/zipkin-context-cls-0.11.7.tgz",
+      "integrity": "sha512-dU8PAwoiLzJzQst46CvtEZ+3WtDRfCPXQ02z6gnCuMg1v9ZabBsfBtfDIwuP7kA1icazLHi9t09w7MIUXw8kKQ==",
+      "dev": true,
+      "dependencies": {
+        "zipkin": ">=0.11.0"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
@@ -4089,6 +4185,37 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/async-hook-jl": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+      "dependencies": {
+        "stack-chain": "^1.3.7"
+      },
+      "engines": {
+        "node": "^4.7 || >=6.9 || >=7.3"
+      }
+    },
+    "node_modules/async-listener": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
+      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
+      "dependencies": {
+        "semver": "^5.3.0",
+        "shimmer": "^1.1.0"
+      },
+      "engines": {
+        "node": "<=0.11.8 || >0.11.10"
+      }
+    },
+    "node_modules/async-listener/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -4203,6 +4330,25 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/big-integer": {
       "version": "1.6.51",
@@ -4500,6 +4646,27 @@
         "node": ">=12"
       }
     },
+    "node_modules/cls-hooked": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+      "dependencies": {
+        "async-hook-jl": "^1.7.6",
+        "emitter-listener": "^1.0.1",
+        "semver": "^5.4.1"
+      },
+      "engines": {
+        "node": "^4.7 || >=6.9 || >=7.3 || >=8.2.1"
+      }
+    },
+    "node_modules/cls-hooked/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
@@ -4575,6 +4742,15 @@
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/continuation-local-storage": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
+      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
+      "dependencies": {
+        "async-listener": "^0.6.0",
+        "emitter-listener": "^1.1.1"
       }
     },
     "node_modules/convert-source-map": {
@@ -4816,6 +4992,14 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.478.tgz",
       "integrity": "sha512-qjTA8djMXd+ruoODDFGnRCRBpID+AAfYWCyGtYTNhsuwxI19s8q19gbjKTwRS5z/LyVf5wICaIiPQGLekmbJbA==",
       "dev": true
+    },
+    "node_modules/emitter-listener": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+      "dependencies": {
+        "shimmer": "^1.2.0"
+      }
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -6398,6 +6582,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -8391,6 +8580,11 @@
         "@redis/time-series": "1.0.4"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
@@ -8782,6 +8976,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -8848,6 +9047,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
+    },
+    "node_modules/stack-chain": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug=="
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -9725,6 +9929,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zipkin": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/zipkin/-/zipkin-0.22.0.tgz",
+      "integrity": "sha512-SZgorBAvywnj5R26mqsFP+2MRUsBXGg0B8GLRLw9R0FeE4alMUAfhXYvzeAt2+MvkXne9QdQyziuqO5oXNQ0Sg==",
+      "dependencies": {
+        "base64-js": "^1.1.2",
+        "is-promise": "^2.1.0"
+      }
+    },
+    "node_modules/zipkin-context-cls": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/zipkin-context-cls/-/zipkin-context-cls-0.22.0.tgz",
+      "integrity": "sha512-7xSau/S+H0VJCDVZ4jA2wKMSguIrl8DmVm4YW4s+k+s+bW63usa76IueJIECGvEkOiQQ3dxkY+mi4fHYzb+0tA==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.4",
+        "cls-hooked": "^4.2.2",
+        "continuation-local-storage": "^3.1.7"
+      }
+    },
+    "node_modules/zipkin-transport-http": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/zipkin-transport-http/-/zipkin-transport-http-0.22.0.tgz",
+      "integrity": "sha512-bjM2fm/hurseBuvpyB8mYCBBGOz3gc2f9KUSQl71LGxmgYcUeXvDHJyE9MgzWMhl+3HcD8l5nNn6OmdX63he+g==",
+      "dependencies": {
+        "zipkin": "^0.22.0"
+      },
+      "peerDependencies": {
+        "node-fetch": ">=1.4.0 <3.0.0"
       }
     }
   }

--- a/runner/package-lock.json
+++ b/runner/package-lock.json
@@ -23,10 +23,7 @@
         "prom-client": "^14.2.0",
         "redis": "^4.6.7",
         "verror": "^1.10.1",
-        "vm2": "^3.9.19",
-        "zipkin": "^0.22.0",
-        "zipkin-context-cls": "^0.22.0",
-        "zipkin-transport-http": "^0.22.0"
+        "vm2": "^3.9.19"
       },
       "devDependencies": {
         "@types/express": "^4.17.17",
@@ -37,7 +34,6 @@
         "@types/pg-format": "^1.0.2",
         "@types/pluralize": "^0.0.29",
         "@types/verror": "^1.10.6",
-        "@types/zipkin-context-cls": "^0.11.7",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
         "eslint": "^8.46.0",
@@ -1593,17 +1589,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.23.8",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.8.tgz",
-      "integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -3729,15 +3714,6 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
-    "node_modules/@types/zipkin-context-cls": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@types/zipkin-context-cls/-/zipkin-context-cls-0.11.7.tgz",
-      "integrity": "sha512-dU8PAwoiLzJzQst46CvtEZ+3WtDRfCPXQ02z6gnCuMg1v9ZabBsfBtfDIwuP7kA1icazLHi9t09w7MIUXw8kKQ==",
-      "dev": true,
-      "dependencies": {
-        "zipkin": ">=0.11.0"
-      }
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
@@ -4185,37 +4161,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/async-hook-jl": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
-      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
-      "dependencies": {
-        "stack-chain": "^1.3.7"
-      },
-      "engines": {
-        "node": "^4.7 || >=6.9 || >=7.3"
-      }
-    },
-    "node_modules/async-listener": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
-      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
-      "dependencies": {
-        "semver": "^5.3.0",
-        "shimmer": "^1.1.0"
-      },
-      "engines": {
-        "node": "<=0.11.8 || >0.11.10"
-      }
-    },
-    "node_modules/async-listener/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -4330,25 +4275,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/big-integer": {
       "version": "1.6.51",
@@ -4646,27 +4572,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/cls-hooked": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
-      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
-      "dependencies": {
-        "async-hook-jl": "^1.7.6",
-        "emitter-listener": "^1.0.1",
-        "semver": "^5.4.1"
-      },
-      "engines": {
-        "node": "^4.7 || >=6.9 || >=7.3 || >=8.2.1"
-      }
-    },
-    "node_modules/cls-hooked/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
@@ -4742,15 +4647,6 @@
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/continuation-local-storage": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
-      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
-      "dependencies": {
-        "async-listener": "^0.6.0",
-        "emitter-listener": "^1.1.1"
       }
     },
     "node_modules/convert-source-map": {
@@ -4992,14 +4888,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.478.tgz",
       "integrity": "sha512-qjTA8djMXd+ruoODDFGnRCRBpID+AAfYWCyGtYTNhsuwxI19s8q19gbjKTwRS5z/LyVf5wICaIiPQGLekmbJbA==",
       "dev": true
-    },
-    "node_modules/emitter-listener": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
-      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
-      "dependencies": {
-        "shimmer": "^1.2.0"
-      }
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -6582,11 +6470,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -8580,11 +8463,6 @@
         "@redis/time-series": "1.0.4"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
@@ -8976,11 +8854,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
-    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -9047,11 +8920,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
-    },
-    "node_modules/stack-chain": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-      "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug=="
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -9929,36 +9797,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zipkin": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/zipkin/-/zipkin-0.22.0.tgz",
-      "integrity": "sha512-SZgorBAvywnj5R26mqsFP+2MRUsBXGg0B8GLRLw9R0FeE4alMUAfhXYvzeAt2+MvkXne9QdQyziuqO5oXNQ0Sg==",
-      "dependencies": {
-        "base64-js": "^1.1.2",
-        "is-promise": "^2.1.0"
-      }
-    },
-    "node_modules/zipkin-context-cls": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/zipkin-context-cls/-/zipkin-context-cls-0.22.0.tgz",
-      "integrity": "sha512-7xSau/S+H0VJCDVZ4jA2wKMSguIrl8DmVm4YW4s+k+s+bW63usa76IueJIECGvEkOiQQ3dxkY+mi4fHYzb+0tA==",
-      "dependencies": {
-        "@babel/runtime": "^7.8.4",
-        "cls-hooked": "^4.2.2",
-        "continuation-local-storage": "^3.1.7"
-      }
-    },
-    "node_modules/zipkin-transport-http": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/zipkin-transport-http/-/zipkin-transport-http-0.22.0.tgz",
-      "integrity": "sha512-bjM2fm/hurseBuvpyB8mYCBBGOz3gc2f9KUSQl71LGxmgYcUeXvDHJyE9MgzWMhl+3HcD8l5nNn6OmdX63he+g==",
-      "dependencies": {
-        "zipkin": "^0.22.0"
-      },
-      "peerDependencies": {
-        "node-fetch": ">=1.4.0 <3.0.0"
       }
     }
   }

--- a/runner/package.json
+++ b/runner/package.json
@@ -12,7 +12,7 @@
     "start": "npm run build && node dist/index.js",
     "start:dev": "ts-node ./src/index.ts",
     "start:docker": "node dist/index.js",
-    "test": "npm run codegen && node --experimental-vm-modules ./node_modules/.bin/jest",
+    "test": "node --experimental-vm-modules ./node_modules/.bin/jest",
     "lint": "eslint -c .eslintrc.js"
   },
   "keywords": [],

--- a/runner/package.json
+++ b/runner/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "rm -rf ./dist && npm run codegen && tsc",
-    "codegen": "rm -rf ./src/generated && proto-loader-gen-types --longs=String --enums=String --defaults --oneofs --grpcLib=@grpc/grpc-js --outDir=src/generated/ protos/runner.proto",
+    "codegen": "proto-loader-gen-types --longs=String --enums=String --defaults --oneofs --grpcLib=@grpc/grpc-js --outDir=src/generated/ protos/runner.proto",
     "start": "npm run build && node dist/index.js",
     "start:dev": "ts-node ./src/index.ts",
     "start:docker": "node dist/index.js",

--- a/runner/package.json
+++ b/runner/package.json
@@ -12,7 +12,7 @@
     "start": "npm run build && node dist/index.js",
     "start:dev": "ts-node ./src/index.ts",
     "start:docker": "node dist/index.js",
-    "test": "node --experimental-vm-modules ./node_modules/.bin/jest",
+    "test": "npm run codegen && node --experimental-vm-modules ./node_modules/.bin/jest",
     "lint": "eslint -c .eslintrc.js"
   },
   "keywords": [],

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -3,8 +3,6 @@ import RedisClient from './redis-client';
 import startRunnerServer from './server/runner-server';
 import StreamHandler from './stream-handler';
 
-const STREAM_HANDLER_THROTTLE_MS = 500;
-
 const redisClient = new RedisClient();
 let runnerServer;
 
@@ -17,10 +15,12 @@ type StreamHandlers = Record<string, StreamHandler>;
 void (async function main () {
   try {
     const streamHandlers: StreamHandlers = {};
+    let STREAM_HANDLER_THROTTLE_MS = 500;
 
     const version = process.env.RUNNER_VERSION ?? 'V1';
     if (version === 'V2') {
       console.log('Starting Runner in V2 mode.');
+      STREAM_HANDLER_THROTTLE_MS = 360000; // 1 hour
       runnerServer = startRunnerServer();
     } else if (version === 'V1') {
       console.log('Starting Runner in V1 mode.');

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -3,45 +3,31 @@ import RedisClient from './redis-client';
 import startRunnerServer from './server/runner-server';
 import StreamHandler from './stream-handler';
 
+const executors = new Map<string, StreamHandler>();
 const redisClient = new RedisClient();
+const grpcServer = startRunnerServer(executors);
 
 startMetricsServer().catch((err) => {
   console.error('Failed to start metrics server', err);
 });
 
-type StreamHandlers = Record<string, StreamHandler>;
-
 void (async function main () {
   try {
-    const version = process.env.RUNNER_VERSION ?? 'V1';
-
-    if (version === 'V2') {
-      console.log('Starting Runner in V2 mode.');
-      startRunnerServer();
-    } else if (version === 'V1') {
-      console.log('Starting Runner in V1 mode.');
-      const streamHandlers: StreamHandlers = {};
-      const STREAM_HANDLER_THROTTLE_MS = 500;
-
-      while (true) {
-        const streamKeys = await redisClient.getStreams();
-        streamKeys.forEach((streamKey) => {
-          if (streamHandlers[streamKey] !== undefined) {
-            return;
-          }
+    const STREAM_HANDLER_THROTTLE_MS = 500;
+    while (true) {
+      const streamKeys = await redisClient.getStreams();
+      streamKeys.forEach((streamKey) => {
+        if (executors.get(streamKey) === undefined) {
           const streamHandler = new StreamHandler(streamKey);
-          streamHandlers[streamKey] = streamHandler;
-        });
-
-        await new Promise((resolve) =>
-          setTimeout(resolve, STREAM_HANDLER_THROTTLE_MS),
-        );
-      }
-    } else {
-      console.error('Unknown version', version);
-      process.exit(1);
+          executors.set(streamKey, streamHandler);
+        }
+      });
+      await new Promise((resolve) =>
+        setTimeout(resolve, STREAM_HANDLER_THROTTLE_MS),
+      );
     }
   } finally {
     await redisClient.disconnect();
+    grpcServer.forceShutdown();
   }
 })();

--- a/runner/src/server/runner-server.ts
+++ b/runner/src/server/runner-server.ts
@@ -2,18 +2,18 @@ import * as grpc from '@grpc/grpc-js';
 import * as protoLoader from '@grpc/proto-loader';
 import getRunnerService from './runner-service';
 import { type ProtoGrpcType } from '../generated/runner';
-import StreamHandler from '../stream-handler/stream-handler';
+import type StreamHandler from '../stream-handler/stream-handler';
 
 const PROTO_PATH = 'protos/runner.proto';
 
-export default function startRunnerServer (): grpc.Server {
+export default function startRunnerServer (executors: Map<string, StreamHandler>): grpc.Server {
   const packageDefinition = protoLoader.loadSync(PROTO_PATH);
   const runnerProto = (grpc.loadPackageDefinition(
     packageDefinition
   ) as unknown) as ProtoGrpcType;
 
   const server = new grpc.Server();
-  server.addService(runnerProto.runner.Runner.service, getRunnerService(StreamHandler));
+  server.addService(runnerProto.runner.Runner.service, getRunnerService(executors));
   const credentials = grpc.ServerCredentials;
 
   server.bindAsync(

--- a/runner/src/server/runner-server.ts
+++ b/runner/src/server/runner-server.ts
@@ -17,7 +17,7 @@ export default function startRunnerServer (executors: Map<string, StreamHandler>
   const credentials = grpc.ServerCredentials;
 
   server.bindAsync(
-    '0.0.0.0:50007', // TODO: Read port from ENV
+    `${process.env.RUNNER_HOST ?? 'undefined'}:${process.env.RUNNER_PORT ?? 'undefined'}`,
     credentials.createInsecure(), // TODO: Use secure credentials with allow for Coordinator
     (err: Error | null, port: number) => {
       if (err) {

--- a/runner/src/server/runner-server.ts
+++ b/runner/src/server/runner-server.ts
@@ -3,6 +3,7 @@ import * as protoLoader from '@grpc/proto-loader';
 import getRunnerService from './runner-service';
 import { type ProtoGrpcType } from '../generated/runner';
 import type StreamHandler from '../stream-handler/stream-handler';
+import assert from 'assert';
 
 const PROTO_PATH = 'protos/runner.proto';
 
@@ -16,8 +17,11 @@ export default function startRunnerServer (executors: Map<string, StreamHandler>
   server.addService(runnerProto.runner.Runner.service, getRunnerService(executors));
   const credentials = grpc.ServerCredentials;
 
+  assert(process.env.RUNNER_HOST, 'RUNNER_HOST is not defined');
+  assert(process.env.RUNNER_PORT, 'RUNNER_PORT is not defined');
+
   server.bindAsync(
-    `${process.env.RUNNER_HOST ?? 'undefined'}:${process.env.RUNNER_PORT ?? 'undefined'}`,
+    `${process.env.RUNNER_HOST}:${process.env.RUNNER_PORT}`,
     credentials.createInsecure(), // TODO: Use secure credentials with allow for Coordinator
     (err: Error | null, port: number) => {
       if (err) {

--- a/runner/src/server/runner-server.ts
+++ b/runner/src/server/runner-server.ts
@@ -23,7 +23,7 @@ export default function startRunnerServer (): grpc.Server {
       if (err) {
         console.error(`Server error: ${err.message}`);
       } else {
-        console.log(`Server bound on port: ${port}`);
+        console.log(`gRPC server bound on port: ${port}`);
         server.start();
       }
     }

--- a/runner/src/server/runner-service.test.ts
+++ b/runner/src/server/runner-service.test.ts
@@ -16,7 +16,7 @@ const BASIC_INDEXER_CONFIG = {
   function_name: BASIC_FUNCTION_NAME,
   code: BASIC_CODE,
   schema: BASIC_SCHEMA,
-  version: BASIC_VERSION
+  version: BASIC_VERSION,
   status: Status.RUNNING
 };
 
@@ -212,7 +212,9 @@ describe('Runner gRPC Service', () => {
     const streamHandlerType = jest.fn().mockImplementation((_, indexerConfig) => {
       return {
         stop,
-        indexerConfig: { account_id: indexerConfig.account_id, function_name: indexerConfig.function_name, version: indexerConfig.version }
+        getIndexerConfig: jest.fn().mockReturnValue(
+          { account_id: indexerConfig.account_id, function_name: indexerConfig.function_name, status: indexerConfig.status, version: indexerConfig.version }
+        )
       };
     });
     const service = getRunnerService(streamHandlerType);

--- a/runner/src/server/runner-service.test.ts
+++ b/runner/src/server/runner-service.test.ts
@@ -1,4 +1,5 @@
 import type StreamHandler from '../stream-handler/stream-handler';
+import { Status } from '../stream-handler/stream-handler';
 import getRunnerService from './runner-service';
 import * as grpc from '@grpc/grpc-js';
 
@@ -16,6 +17,7 @@ const BASIC_INDEXER_CONFIG = {
   code: BASIC_CODE,
   schema: BASIC_SCHEMA,
   version: BASIC_VERSION
+  status: Status.RUNNING
 };
 
 describe('Runner gRPC Service', () => {
@@ -203,7 +205,7 @@ describe('Runner gRPC Service', () => {
     });
   });
 
-  it('valid list executor request lists executors correctly', async () => {
+  it('valid list executor request lists executors correctly, with stopped indexer', async () => {
     const stop = jest.fn().mockImplementation(async () => {
       await Promise.resolve();
     });

--- a/runner/src/server/runner-service.test.ts
+++ b/runner/src/server/runner-service.test.ts
@@ -169,7 +169,7 @@ describe('Runner gRPC Service', () => {
 
     service.StopExecutor({ request: { executorId: 'non-existant' } } as any, (err) => {
       expect(err).toEqual({
-        code: grpc.status.INVALID_ARGUMENT,
+        code: grpc.status.NOT_FOUND,
         message: 'Executor non-existant cannot be stopped as it does not exist.'
       });
       expect(stop).toHaveBeenCalledTimes(0);

--- a/runner/src/server/runner-service.test.ts
+++ b/runner/src/server/runner-service.test.ts
@@ -213,9 +213,12 @@ describe('Runner gRPC Service', () => {
     const streamHandlerType = jest.fn().mockImplementation((_, indexerConfig) => {
       return {
         stop,
-        getIndexerConfig: jest.fn().mockReturnValue(
-          { account_id: indexerConfig.account_id, function_name: indexerConfig.function_name, status: indexerConfig.status, version: indexerConfig.version }
-        )
+        indexerConfig: {
+          account_id: indexerConfig.account_id,
+          function_name: indexerConfig.function_name,
+          status: indexerConfig.status,
+          version: indexerConfig.version
+        }
       };
     });
     const service = getRunnerService(new Map(), streamHandlerType);

--- a/runner/src/server/runner-service.test.ts
+++ b/runner/src/server/runner-service.test.ts
@@ -17,7 +17,9 @@ const BASIC_INDEXER_CONFIG = {
   code: BASIC_CODE,
   schema: BASIC_SCHEMA,
   version: BASIC_VERSION,
-  status: Status.RUNNING
+};
+const BASIC_EXECUTOR_CONTEXT = {
+  status: Status.RUNNING,
 };
 
 describe('Runner gRPC Service', () => {
@@ -215,9 +217,9 @@ describe('Runner gRPC Service', () => {
         indexerConfig: {
           account_id: indexerConfig.account_id,
           function_name: indexerConfig.function_name,
-          status: indexerConfig.status,
           version: indexerConfig.version
-        }
+        },
+        executorContext: BASIC_EXECUTOR_CONTEXT
       };
     });
     const service = getRunnerService(new Map(), streamHandlerType);
@@ -238,7 +240,7 @@ describe('Runner gRPC Service', () => {
             executorId: BASIC_EXECUTOR_ID,
             accountId: BASIC_INDEXER_CONFIG.account_id,
             functionName: BASIC_INDEXER_CONFIG.function_name,
-            status: 'RUNNING',
+            status: Status.RUNNING,
             version: '1'
           }]
         });

--- a/runner/src/server/runner-service.test.ts
+++ b/runner/src/server/runner-service.test.ts
@@ -23,7 +23,6 @@ const BASIC_INDEXER_CONFIG = {
 describe('Runner gRPC Service', () => {
   let genericStreamHandlerType: typeof StreamHandler;
   beforeEach(() => {
-    process.env.RUNNER_VERSION = 'V2';
     genericStreamHandlerType = jest.fn().mockImplementation((...args) => {
       return {
         updateIndexerConfig: jest.fn(),

--- a/runner/src/server/runner-service.test.ts
+++ b/runner/src/server/runner-service.test.ts
@@ -32,7 +32,7 @@ describe('Runner gRPC Service', () => {
   });
 
   it('starts a executor with correct settings', () => {
-    const service = getRunnerService(genericStreamHandlerType);
+    const service = getRunnerService(new Map(), genericStreamHandlerType);
     const mockCallback = jest.fn() as unknown as any;
     const request = generateRequest(BASIC_REDIS_STREAM, BASIC_ACCOUNT_ID, BASIC_FUNCTION_NAME, BASIC_CODE, BASIC_SCHEMA, BASIC_VERSION);
 
@@ -43,7 +43,7 @@ describe('Runner gRPC Service', () => {
   });
 
   it('Invalid start executor request with missing redis stream Id parameter', () => {
-    const service = getRunnerService(genericStreamHandlerType);
+    const service = getRunnerService(new Map(), genericStreamHandlerType);
     const mockCallback = jest.fn() as unknown as any;
     const request = generateRequest(undefined, BASIC_ACCOUNT_ID, BASIC_FUNCTION_NAME, BASIC_CODE, BASIC_SCHEMA);
 
@@ -57,7 +57,7 @@ describe('Runner gRPC Service', () => {
   });
 
   it('Invalid start executor request with missing config parameters', () => {
-    const service = getRunnerService(genericStreamHandlerType);
+    const service = getRunnerService(new Map(), genericStreamHandlerType);
     const mockCallback = jest.fn() as unknown as any;
     let request = generateRequest(BASIC_REDIS_STREAM, undefined, BASIC_FUNCTION_NAME, BASIC_CODE, BASIC_SCHEMA);
     service.StartExecutor(request, mockCallback);
@@ -93,7 +93,7 @@ describe('Runner gRPC Service', () => {
   });
 
   it('starts a executor twice with correct settings, gets error second time', () => {
-    const service = getRunnerService(genericStreamHandlerType);
+    const service = getRunnerService(new Map(), genericStreamHandlerType);
     const mockCallback = jest.fn() as unknown as any;
     const startRequest = generateRequest(BASIC_REDIS_STREAM, BASIC_ACCOUNT_ID, BASIC_FUNCTION_NAME, BASIC_CODE, BASIC_SCHEMA, BASIC_VERSION);
 
@@ -118,7 +118,7 @@ describe('Runner gRPC Service', () => {
     const streamHandlerType = jest.fn().mockImplementation(() => {
       return { stop };
     });
-    const service = getRunnerService(streamHandlerType);
+    const service = getRunnerService(new Map(), streamHandlerType);
     const mockCallback = jest.fn() as unknown as any;
     const requestA = generateRequest(BASIC_REDIS_STREAM, BASIC_ACCOUNT_ID, BASIC_FUNCTION_NAME, BASIC_CODE, BASIC_SCHEMA);
 
@@ -145,7 +145,7 @@ describe('Runner gRPC Service', () => {
     const streamHandlerType = jest.fn().mockImplementation(() => {
       return { stop };
     });
-    const service = getRunnerService(streamHandlerType);
+    const service = getRunnerService(new Map(), streamHandlerType);
     const mockCallback = jest.fn() as unknown as any;
     const request = generateRequest('');
 
@@ -165,7 +165,7 @@ describe('Runner gRPC Service', () => {
     const streamHandlerType = jest.fn().mockImplementation(() => {
       return { stop };
     });
-    const service = getRunnerService(streamHandlerType);
+    const service = getRunnerService(new Map(), streamHandlerType);
 
     service.StopExecutor({ request: { executorId: 'non-existant' } } as any, (err) => {
       expect(err).toEqual({
@@ -185,7 +185,7 @@ describe('Runner gRPC Service', () => {
     const streamHandlerType = jest.fn().mockImplementation(() => {
       return { stop };
     });
-    const service = getRunnerService(streamHandlerType);
+    const service = getRunnerService(new Map(), streamHandlerType);
     const mockCallback = jest.fn() as unknown as any;
     const startRequest = generateRequest(BASIC_REDIS_STREAM, BASIC_ACCOUNT_ID, BASIC_FUNCTION_NAME, BASIC_CODE, BASIC_SCHEMA);
 
@@ -217,7 +217,7 @@ describe('Runner gRPC Service', () => {
         )
       };
     });
-    const service = getRunnerService(streamHandlerType);
+    const service = getRunnerService(new Map(), streamHandlerType);
     const request = generateRequest(BASIC_REDIS_STREAM + '-A', BASIC_ACCOUNT_ID, BASIC_FUNCTION_NAME, BASIC_CODE, BASIC_SCHEMA, BASIC_VERSION);
 
     await new Promise((resolve, reject) => {

--- a/runner/src/server/runner-service.test.ts
+++ b/runner/src/server/runner-service.test.ts
@@ -23,6 +23,7 @@ const BASIC_INDEXER_CONFIG = {
 describe('Runner gRPC Service', () => {
   let genericStreamHandlerType: typeof StreamHandler;
   beforeEach(() => {
+    process.env.RUNNER_VERSION = 'V2';
     genericStreamHandlerType = jest.fn().mockImplementation((...args) => {
       return {
         updateIndexerConfig: jest.fn(),

--- a/runner/src/server/runner-service.ts
+++ b/runner/src/server/runner-service.ts
@@ -98,9 +98,10 @@ function getRunnerService (executors: Map<string, StreamHandler>, StreamHandlerT
           let context = handler.executorContext;
           if (config === undefined) {
             // TODO: Throw error instead when V1 is deprecated
+            const [accountId, functionName] = executorId.substring(0, executorId.indexOf(':')).split('/', 2);
             config = {
-              account_id: '',
-              function_name: '',
+              account_id: accountId,
+              function_name: functionName,
               version: -1, // Ensure Coordinator V2 sees version mismatch
               code: '',
               schema: '',

--- a/runner/src/server/runner-service.ts
+++ b/runner/src/server/runner-service.ts
@@ -52,7 +52,6 @@ function getRunnerService (executors: Map<string, StreamHandler>, StreamHandlerT
           version: Number(version),
           code,
           schema,
-          status: Status.RUNNING
         });
         executors.set(executorId, streamHandler);
         callback(null, { executorId });
@@ -96,6 +95,7 @@ function getRunnerService (executors: Map<string, StreamHandler>, StreamHandlerT
       try {
         executors.forEach((handler, executorId) => {
           let config = handler.indexerConfig;
+          let context = handler.executorContext;
           if (config === undefined) {
             // TODO: Throw error instead when V1 is deprecated
             config = {
@@ -104,6 +104,8 @@ function getRunnerService (executors: Map<string, StreamHandler>, StreamHandlerT
               version: -1, // Ensure Coordinator V2 sees version mismatch
               code: '',
               schema: '',
+            };
+            context = {
               status: Status.RUNNING
             };
           }
@@ -112,7 +114,7 @@ function getRunnerService (executors: Map<string, StreamHandler>, StreamHandlerT
             accountId: config.account_id,
             functionName: config.function_name,
             version: config.version.toString(),
-            status: config.status
+            status: context.status
           });
         });
         callback(null, {

--- a/runner/src/server/runner-service.ts
+++ b/runner/src/server/runner-service.ts
@@ -29,16 +29,6 @@ function getRunnerService (executors: Map<string, StreamHandler>, StreamHandlerT
         return;
       }
 
-      // TODO: Remove toggle after full V2 migration
-      if (process.env.RUNNER_VERSION !== 'V2') {
-        const notEnabledError = {
-          code: grpc.status.FAILED_PRECONDITION,
-          message: 'Runner V2 is not enabled.'
-        };
-        callback(notEnabledError, null);
-        return;
-      }
-
       const { accountId, functionName, code, schema, redisStream, version } = call.request;
       const executorId = hashString(`${accountId}/${functionName}`);
 
@@ -88,16 +78,6 @@ function getRunnerService (executors: Map<string, StreamHandler>, StreamHandlerT
         return;
       }
 
-      // TODO: Remove toggle after full V2 migration
-      if (process.env.RUNNER_VERSION !== 'V2') {
-        const notEnabledError = {
-          code: grpc.status.FAILED_PRECONDITION,
-          message: 'Runner V2 is not enabled.'
-        };
-        callback(notEnabledError, null);
-        return;
-      }
-
       console.log('Stopping executor: ', { executorId });
 
       // Handle request
@@ -115,7 +95,7 @@ function getRunnerService (executors: Map<string, StreamHandler>, StreamHandlerT
       const response: ExecutorInfo__Output[] = [];
       try {
         executors.forEach((handler, executorId) => {
-          let config = handler.getIndexerConfig();
+          let config = handler.indexerConfig;
           if (config === undefined) {
             // TODO: Throw error instead when V1 is deprecated
             config = {

--- a/runner/src/server/runner-service.ts
+++ b/runner/src/server/runner-service.ts
@@ -29,6 +29,16 @@ function getRunnerService (executors: Map<string, StreamHandler>, StreamHandlerT
         return;
       }
 
+      // TODO: Remove toggle after full V2 migration
+      if (process.env.RUNNER_VERSION !== 'V2') {
+        const notEnabledError = {
+          code: grpc.status.FAILED_PRECONDITION,
+          message: 'Runner V2 is not enabled.'
+        };
+        callback(notEnabledError, null);
+        return;
+      }
+
       const { accountId, functionName, code, schema, redisStream, version } = call.request;
       const executorId = hashString(`${accountId}/${functionName}`);
 
@@ -75,6 +85,16 @@ function getRunnerService (executors: Map<string, StreamHandler>, StreamHandlerT
           message: `Executor ${executorId} cannot be stopped as it does not exist.`
         };
         callback(notFoundError, null);
+        return;
+      }
+
+      // TODO: Remove toggle after full V2 migration
+      if (process.env.RUNNER_VERSION !== 'V2') {
+        const notEnabledError = {
+          code: grpc.status.FAILED_PRECONDITION,
+          message: 'Runner V2 is not enabled.'
+        };
+        callback(notEnabledError, null);
         return;
       }
 

--- a/runner/src/server/runner-service.ts
+++ b/runner/src/server/runner-service.ts
@@ -56,7 +56,7 @@ function getRunnerService (StreamHandlerType: typeof StreamHandler): RunnerHandl
           function_name: functionName,
           version: Number(version),
           code,
-          schema,,
+          schema,
           status: Status.RUNNING
         });
         streamHandlers.set(executorId, streamHandler);
@@ -100,7 +100,7 @@ function getRunnerService (StreamHandlerType: typeof StreamHandler): RunnerHandl
             executorId,
             accountId: config.account_id,
             functionName: config.function_name,
-            version: handler.indexerConfig?.version.toString(),
+            version: config.version.toString(),
             status: config.status
           });
         });

--- a/runner/src/server/runner-service.ts
+++ b/runner/src/server/runner-service.ts
@@ -78,6 +78,8 @@ function getRunnerService (executors: Map<string, StreamHandler>, StreamHandlerT
         return;
       }
 
+      console.log('Stopping executor: ', { executorId });
+
       // Handle request
       executors.get(executorId)?.stop()
         .then(() => {
@@ -93,9 +95,17 @@ function getRunnerService (executors: Map<string, StreamHandler>, StreamHandlerT
       const response: ExecutorInfo__Output[] = [];
       try {
         executors.forEach((handler, executorId) => {
-          const config = handler.getIndexerConfig();
+          let config = handler.getIndexerConfig();
           if (config === undefined) {
-            throw new Error(`Stream handler ${executorId} has no indexer config.`);
+            // TODO: Throw error instead when V1 is deprecated
+            config = {
+              account_id: '',
+              function_name: '',
+              version: -1, // Ensure Coordinator V2 sees version mismatch
+              code: '',
+              schema: '',
+              status: Status.RUNNING
+            };
           }
           response.push({
             executorId,

--- a/runner/src/stream-handler/stream-handler.ts
+++ b/runner/src/stream-handler/stream-handler.ts
@@ -21,7 +21,7 @@ export default class StreamHandler {
 
   constructor (
     public readonly streamKey: string,
-    private readonly indexerConfig: IndexerConfig | undefined = undefined
+    public readonly indexerConfig: IndexerConfig | undefined = undefined
   ) {
     if (isMainThread) {
       this.worker = new Worker(path.join(__dirname, 'worker.js'), {
@@ -36,10 +36,6 @@ export default class StreamHandler {
     } else {
       throw new Error('StreamHandler should not be instantiated in a worker thread');
     }
-  }
-
-  getIndexerConfig (): IndexerConfig | undefined {
-    return this.indexerConfig;
   }
 
   async stop (): Promise<void> {

--- a/runner/src/stream-handler/worker.ts
+++ b/runner/src/stream-handler/worker.ts
@@ -96,6 +96,7 @@ async function blockQueueConsumer (workerContext: WorkerContext, streamKey: stri
         continue;
       }
       const startTime = performance.now();
+      // Indexer config will not be updated by Redis storage if it is passed in as workerData
       const indexerConfig = config ?? await workerContext.redisClient.getStreamStorage(streamKey);
       indexerName = `${indexerConfig.account_id}/${indexerConfig.function_name}`;
       const functions = {


### PR DESCRIPTION
Runner will need the ability to start using V1 (Polling Redis to start streams) or V2 (Starting streams upon receiving calls to gRPC server) depending on an environment variable we set before deployment. This way, we can make the migration from V1 to V2 and roll that back without too much difficulty. 

In order to do this, the main thread needs to have a separate map of stream handlers owned by the grpc server. The server needs to be spun up only in V2 mode. And Redis polling should only happen in V1 mode. In addition, the worker thread needs to only poll Redis stream storage for indexer config in V1 mode. To do so, only V2 will pass in the config into the worker upon executor init. This provides version control over indexer config as well. 

Finally, I addressed some remaining TODOs leftover. Mainly returning more information, tracking status of executors, and returning all. information available when listing executors. 

For now, I've defaulted the version to V1, if the env variable is not set. 