### PR TITLE
refactor: Remove hard-coded shard count

### DIFF
--- a/block-server/handler.js
+++ b/block-server/handler.js
@@ -35,16 +35,12 @@ const normalizeBlockHeight = function(block_height) {
 }
 
 const fetchStreamerMessage = async function(block_height, options) {
-    const blockPromise = fetchBlockPromise(block_height, options);
-    // hardcoding 4 shards to test performance
-    const shardsPromises = await fetchShardsPromises(block_height, 4, options); // block.chunks.length)
+    const block = await fetchBlockPromise(block_height, options);
+    const shards = await Promise.all(fetchShardsPromises(block_height, block.chunks.length, options))
 
-    const results = await Promise.all([blockPromise, ...shardsPromises]);
-    const block = results.shift();
-    const shards = results;
     return {
-        block: block,
-        shards: shards,
+        block,
+        shards,
     };
 }
 

--- a/runner/src/lake-client/lake-client.test.ts
+++ b/runner/src/lake-client/lake-client.test.ts
@@ -14,7 +14,7 @@ describe('LakeClient', () => {
       .mockReturnValueOnce({ // block
         Body: {
           transformToString: () => JSON.stringify({
-            chunks: [0],
+            chunks: [0, 1, 2, 3],
             header: {
               height: blockHeight,
               hash: blockHash,
@@ -88,7 +88,7 @@ describe('LakeClient', () => {
       .mockReturnValueOnce({ // block
         Body: {
           transformToString: () => JSON.stringify({
-            chunks: [0],
+            chunks: [0, 1, 2, 3],
             header: {
               height: blockHeight,
               hash: blockHash,
@@ -130,7 +130,7 @@ describe('LakeClient', () => {
       .mockReturnValueOnce({ // block
         Body: {
           transformToString: () => JSON.stringify({
-            chunks: [0],
+            chunks: [0, 1, 2, 3],
             header: {
               height: blockHeight,
               hash: blockHash,


### PR DESCRIPTION
Currently, the `shard`/`chunk` count is hard-coded to 4 so that we can fetch the block header and shards in parallel. This PR removes the hard-coded value by using the chunk count specified in the block header to fetch the relevant shards.