### PR TITLE
fix: Ensure array is returned to `Promise.all`

### DIFF
--- a/block-server/handler.js
+++ b/block-server/handler.js
@@ -44,7 +44,7 @@ const fetchStreamerMessage = async function(block_height, options) {
     };
 }
 
-const fetchShardsPromises = async function(block_height, number_of_shards, options) {
+const fetchShardsPromises = function(block_height, number_of_shards, options) {
     return ([...Array(number_of_shards).keys()].map((shard_id) =>
         fetchShardPromise(block_height, shard_id, options)));
 }


### PR DESCRIPTION
`fetchShardsPromises` is used within `Promise.all` to fetch all shards simultaneously. The `async` modifier means this function returns a `Promise`. `Promise.all` complains since it's passed a `Promise` rather than an `Array`.

This PR removes the unnecessary `async` modifier so it works with `Promise.all` 