### PR TITLE
feat: Capture errors thrown within Coordinator

### DIFF
--- a/coordinator/Cargo.lock
+++ b/coordinator/Cargo.lock
@@ -986,6 +986,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "block-streamer",
+ "futures-util",
  "mockall",
  "near-jsonrpc-client",
  "near-jsonrpc-primitives",
@@ -1515,9 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1525,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
@@ -1542,15 +1543,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1559,21 +1560,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/coordinator/Cargo.toml
+++ b/coordinator/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.75"
+futures-util = "0.3.30"
 redis = { version = "0.24", features = ["tokio-comp", "connection-manager"] }
 tokio = "1.28"
 tonic = "0.10.2"

--- a/coordinator/src/block_streams_handler.rs
+++ b/coordinator/src/block_streams_handler.rs
@@ -20,7 +20,7 @@ pub struct BlockStreamsHandlerImpl {
 
 #[cfg_attr(test, mockall::automock)]
 impl BlockStreamsHandlerImpl {
-    pub async fn connect(block_streamer_url: String) -> anyhow::Result<Self> {
+    pub fn connect(block_streamer_url: String) -> anyhow::Result<Self> {
         let channel = Channel::from_shared(block_streamer_url)
             .context("Block Streamer URL is invalid")?
             .connect_lazy();

--- a/coordinator/src/block_streams_handler.rs
+++ b/coordinator/src/block_streams_handler.rs
@@ -105,10 +105,11 @@ impl BlockStreamsHandlerImpl {
                 status: Self::match_status(status),
             }),
             unsupported_rule => {
-                anyhow::bail!(
+                tracing::error!(
                     "Encountered unsupported indexer rule: {:?}",
                     unsupported_rule
-                )
+                );
+                return Ok(());
             }
         };
 

--- a/coordinator/src/block_streams_handler.rs
+++ b/coordinator/src/block_streams_handler.rs
@@ -7,6 +7,8 @@ use block_streamer::{
 use tonic::transport::channel::Channel;
 use tonic::Request;
 
+use crate::utils::exponential_retry;
+
 #[cfg(not(test))]
 pub use BlockStreamsHandlerImpl as BlockStreamsHandler;
 #[cfg(test)]
@@ -28,31 +30,51 @@ impl BlockStreamsHandlerImpl {
     }
 
     pub async fn list(&self) -> anyhow::Result<Vec<StreamInfo>> {
-        let response = self
-            .client
-            .clone()
-            .list_streams(Request::new(ListStreamsRequest {}))
-            .await
-            .context("Failed to list streams")?;
+        exponential_retry(
+            || async {
+                let response = self
+                    .client
+                    .clone()
+                    .list_streams(Request::new(ListStreamsRequest {}))
+                    .await
+                    .context("Failed to list streams")?;
 
-        Ok(response.into_inner().streams)
+                Ok(response.into_inner().streams)
+            },
+            |e: &anyhow::Error| {
+                e.downcast_ref::<tonic::Status>()
+                    .map(|s| s.code() == tonic::Code::Unavailable)
+                    .unwrap_or(false)
+            },
+        )
+        .await
     }
 
     pub async fn stop(&self, stream_id: String) -> anyhow::Result<()> {
-        let request = Request::new(StopStreamRequest {
+        let request = StopStreamRequest {
             stream_id: stream_id.clone(),
-        });
+        };
 
         tracing::debug!("Sending stop stream request: {:#?}", request);
 
-        let _ = self
-            .client
-            .clone()
-            .stop_stream(request)
-            .await
-            .context(format!("Failed to stop stream: {stream_id}"))?;
+        exponential_retry(
+            || async {
+                let _ = self
+                    .client
+                    .clone()
+                    .stop_stream(Request::new(request.clone()))
+                    .await
+                    .context(format!("Failed to stop stream: {stream_id}"))?;
 
-        Ok(())
+                Ok(())
+            },
+            |e: &anyhow::Error| {
+                e.downcast_ref::<tonic::Status>()
+                    .map(|s| s.code() == tonic::Code::Unavailable)
+                    .unwrap_or(false)
+            },
+        )
+        .await
     }
 
     fn match_status(status: &registry_types::Status) -> i32 {
@@ -98,26 +120,36 @@ impl BlockStreamsHandlerImpl {
             }
         };
 
-        let request = Request::new(StartStreamRequest {
+        let request = StartStreamRequest {
             start_block_height,
             version,
             redis_stream,
             account_id: account_id.clone(),
             function_name: function_name.clone(),
             rule: Some(rule),
-        });
+        };
 
         tracing::debug!("Sending start stream request: {:#?}", request);
 
-        let _ = self
-            .client
-            .clone()
-            .start_stream(request)
-            .await
-            .context(format!(
-                "Failed to start stream: {account_id}/{function_name}"
-            ))?;
+        exponential_retry(
+            || async {
+                let _ = self
+                    .client
+                    .clone()
+                    .start_stream(Request::new(request.clone()))
+                    .await
+                    .context(format!(
+                        "Failed to start stream: {account_id}/{function_name}"
+                    ))?;
 
-        Ok(())
+                Ok(())
+            },
+            |e: &anyhow::Error| {
+                e.downcast_ref::<tonic::Status>()
+                    .map(|s| s.code() == tonic::Code::Unavailable)
+                    .unwrap_or(false)
+            },
+        )
+        .await
     }
 }

--- a/coordinator/src/block_streams_handler.rs
+++ b/coordinator/src/block_streams_handler.rs
@@ -30,23 +30,16 @@ impl BlockStreamsHandlerImpl {
     }
 
     pub async fn list(&self) -> anyhow::Result<Vec<StreamInfo>> {
-        exponential_retry(
-            || async {
-                let response = self
-                    .client
-                    .clone()
-                    .list_streams(Request::new(ListStreamsRequest {}))
-                    .await
-                    .context("Failed to list streams")?;
+        exponential_retry(|| async {
+            let response = self
+                .client
+                .clone()
+                .list_streams(Request::new(ListStreamsRequest {}))
+                .await
+                .context("Failed to list streams")?;
 
-                Ok(response.into_inner().streams)
-            },
-            |e: &anyhow::Error| {
-                e.downcast_ref::<tonic::Status>()
-                    .map(|s| s.code() == tonic::Code::Unavailable)
-                    .unwrap_or(false)
-            },
-        )
+            Ok(response.into_inner().streams)
+        })
         .await
     }
 

--- a/coordinator/src/block_streams_handler.rs
+++ b/coordinator/src/block_streams_handler.rs
@@ -27,21 +27,22 @@ impl BlockStreamsHandlerImpl {
         Ok(Self { client })
     }
 
-    pub async fn list(&mut self) -> anyhow::Result<Vec<StreamInfo>> {
+    pub async fn list(&self) -> anyhow::Result<Vec<StreamInfo>> {
         let response = self
             .client
+            .clone()
             .list_streams(Request::new(ListStreamsRequest {}))
             .await?;
 
         Ok(response.into_inner().streams)
     }
 
-    pub async fn stop(&mut self, stream_id: String) -> anyhow::Result<()> {
+    pub async fn stop(&self, stream_id: String) -> anyhow::Result<()> {
         let request = Request::new(StopStreamRequest { stream_id });
 
         tracing::debug!("Sending stop stream request: {:#?}", request);
 
-        let _ = self.client.stop_stream(request).await?;
+        let _ = self.client.clone().stop_stream(request).await?;
 
         Ok(())
     }
@@ -56,7 +57,7 @@ impl BlockStreamsHandlerImpl {
     }
 
     pub async fn start(
-        &mut self,
+        &self,
         start_block_height: u64,
         account_id: String,
         function_name: String,
@@ -100,7 +101,7 @@ impl BlockStreamsHandlerImpl {
 
         tracing::debug!("Sending start stream request: {:#?}", request);
 
-        let _ = self.client.start_stream(request).await?;
+        let _ = self.client.clone().start_stream(request).await?;
 
         Ok(())
     }

--- a/coordinator/src/executors_handler.rs
+++ b/coordinator/src/executors_handler.rs
@@ -24,9 +24,10 @@ impl ExecutorsHandlerImpl {
         Ok(Self { client })
     }
 
-    pub async fn list(&mut self) -> anyhow::Result<Vec<ExecutorInfo>> {
+    pub async fn list(&self) -> anyhow::Result<Vec<ExecutorInfo>> {
         let response = self
             .client
+            .clone()
             .list_executors(Request::new(ListExecutorsRequest {}))
             .await?;
 
@@ -34,7 +35,7 @@ impl ExecutorsHandlerImpl {
     }
 
     pub async fn start(
-        &mut self,
+        &self,
         account_id: String,
         function_name: String,
         code: String,
@@ -53,17 +54,17 @@ impl ExecutorsHandlerImpl {
 
         tracing::debug!("Sending start executor request: {:#?}", request);
 
-        self.client.start_executor(request).await?;
+        self.client.clone().start_executor(request).await?;
 
         Ok(())
     }
 
-    pub async fn stop(&mut self, executor_id: String) -> anyhow::Result<()> {
+    pub async fn stop(&self, executor_id: String) -> anyhow::Result<()> {
         let request = Request::new(StopExecutorRequest { executor_id });
 
         tracing::debug!("Sending stop executor request: {:#?}", request);
 
-        self.client.stop_executor(request).await?;
+        self.client.clone().stop_executor(request).await?;
 
         Ok(())
     }

--- a/coordinator/src/executors_handler.rs
+++ b/coordinator/src/executors_handler.rs
@@ -17,7 +17,7 @@ pub struct ExecutorsHandlerImpl {
 
 #[cfg_attr(test, mockall::automock)]
 impl ExecutorsHandlerImpl {
-    pub async fn connect(runner_url: String) -> anyhow::Result<Self> {
+    pub fn connect(runner_url: String) -> anyhow::Result<Self> {
         let channel = Channel::from_shared(runner_url)
             .context("Runner URL is invalid")?
             .connect_lazy();

--- a/coordinator/src/executors_handler.rs
+++ b/coordinator/src/executors_handler.rs
@@ -27,23 +27,16 @@ impl ExecutorsHandlerImpl {
     }
 
     pub async fn list(&self) -> anyhow::Result<Vec<ExecutorInfo>> {
-        exponential_retry(
-            || async {
-                let response = self
-                    .client
-                    .clone()
-                    .list_executors(Request::new(ListExecutorsRequest {}))
-                    .await
-                    .context("Failed to list executors")?;
+        exponential_retry(|| async {
+            let response = self
+                .client
+                .clone()
+                .list_executors(Request::new(ListExecutorsRequest {}))
+                .await
+                .context("Failed to list executors")?;
 
-                Ok(response.into_inner().executors)
-            },
-            |e: &anyhow::Error| {
-                e.downcast_ref::<tonic::Status>()
-                    .map(|s| s.code() == tonic::Code::Unavailable)
-                    .unwrap_or(false)
-            },
-        )
+            Ok(response.into_inner().executors)
+        })
         .await
     }
 

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -36,8 +36,10 @@ async fn main() -> anyhow::Result<()> {
     loop {
         let indexer_registry = registry.fetch().await?;
 
-        synchronise_executors(&indexer_registry, &executors_handler).await?;
-        synchronise_block_streams(&indexer_registry, &redis_client, &block_streams_handler).await?;
+        tokio::try_join!(
+            synchronise_executors(&indexer_registry, &executors_handler),
+            synchronise_block_streams(&indexer_registry, &redis_client, &block_streams_handler)
+        )?;
     }
 }
 

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -9,6 +9,7 @@ mod block_streams_handler;
 mod executors_handler;
 mod redis;
 mod registry;
+mod utils;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -30,8 +30,8 @@ async fn main() -> anyhow::Result<()> {
 
     let registry = Registry::connect(registry_contract_id, &rpc_url);
     let redis_client = RedisClient::connect(&redis_url).await?;
-    let block_streams_handler = BlockStreamsHandler::connect(block_streamer_url).await?;
-    let executors_handler = ExecutorsHandler::connect(runner_url).await?;
+    let block_streams_handler = BlockStreamsHandler::connect(block_streamer_url)?;
+    let executors_handler = ExecutorsHandler::connect(runner_url)?;
 
     loop {
         let indexer_registry = registry.fetch().await?;

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -29,21 +29,20 @@ async fn main() -> anyhow::Result<()> {
 
     let registry = Registry::connect(registry_contract_id, &rpc_url);
     let redis_client = RedisClient::connect(&redis_url).await?;
-    let mut block_streams_handler = BlockStreamsHandler::connect(block_streamer_url).await?;
-    let mut executors_handler = ExecutorsHandler::connect(runner_url).await?;
+    let block_streams_handler = BlockStreamsHandler::connect(block_streamer_url).await?;
+    let executors_handler = ExecutorsHandler::connect(runner_url).await?;
 
     loop {
         let indexer_registry = registry.fetch().await?;
 
-        synchronise_executors(&indexer_registry, &mut executors_handler).await?;
-        synchronise_block_streams(&indexer_registry, &redis_client, &mut block_streams_handler)
-            .await?;
+        synchronise_executors(&indexer_registry, &executors_handler).await?;
+        synchronise_block_streams(&indexer_registry, &redis_client, &block_streams_handler).await?;
     }
 }
 
 async fn synchronise_executors(
     indexer_registry: &IndexerRegistry,
-    executors_handler: &mut ExecutorsHandler,
+    executors_handler: &ExecutorsHandler,
 ) -> anyhow::Result<()> {
     let mut active_executors = executors_handler.list().await?;
 
@@ -94,7 +93,7 @@ async fn synchronise_executors(
 async fn synchronise_block_streams(
     indexer_registry: &IndexerRegistry,
     redis_client: &RedisClient,
-    block_streams_handler: &mut BlockStreamsHandler,
+    block_streams_handler: &BlockStreamsHandler,
 ) -> anyhow::Result<()> {
     let mut active_block_streams = block_streams_handler.list().await?;
 
@@ -217,7 +216,7 @@ mod tests {
                 )
                 .returning(|_, _, _, _, _, _| Ok(()));
 
-            synchronise_executors(&indexer_registry, &mut executors_handler)
+            synchronise_executors(&indexer_registry, &executors_handler)
                 .await
                 .unwrap();
         }
@@ -277,7 +276,7 @@ mod tests {
                 )
                 .returning(|_, _, _, _, _, _| Ok(()));
 
-            synchronise_executors(&indexer_registry, &mut executors_handler)
+            synchronise_executors(&indexer_registry, &executors_handler)
                 .await
                 .unwrap();
         }
@@ -323,7 +322,7 @@ mod tests {
 
             executors_handler.expect_start().never();
 
-            synchronise_executors(&indexer_registry, &mut executors_handler)
+            synchronise_executors(&indexer_registry, &executors_handler)
                 .await
                 .unwrap();
         }
@@ -349,7 +348,7 @@ mod tests {
                 .returning(|_| Ok(()))
                 .once();
 
-            synchronise_executors(&indexer_registry, &mut executors_handler)
+            synchronise_executors(&indexer_registry, &executors_handler)
                 .await
                 .unwrap();
         }
@@ -407,7 +406,7 @@ mod tests {
                 )
                 .returning(|_, _, _, _, _, _| Ok(()));
 
-            synchronise_block_streams(&indexer_registry, &redis_client, &mut block_stream_handler)
+            synchronise_block_streams(&indexer_registry, &redis_client, &block_stream_handler)
                 .await
                 .unwrap();
         }
@@ -461,7 +460,7 @@ mod tests {
                 )
                 .returning(|_, _, _, _, _, _| Ok(()));
 
-            synchronise_block_streams(&indexer_registry, &redis_client, &mut block_stream_handler)
+            synchronise_block_streams(&indexer_registry, &redis_client, &block_stream_handler)
                 .await
                 .unwrap();
         }
@@ -515,7 +514,7 @@ mod tests {
                 )
                 .returning(|_, _, _, _, _, _| Ok(()));
 
-            synchronise_block_streams(&indexer_registry, &redis_client, &mut block_stream_handler)
+            synchronise_block_streams(&indexer_registry, &redis_client, &block_stream_handler)
                 .await
                 .unwrap();
         }
@@ -544,7 +543,7 @@ mod tests {
                 .returning(|_| Ok(()))
                 .once();
 
-            synchronise_block_streams(&indexer_registry, &redis_client, &mut block_stream_handler)
+            synchronise_block_streams(&indexer_registry, &redis_client, &block_stream_handler)
                 .await
                 .unwrap();
         }
@@ -593,7 +592,7 @@ mod tests {
             block_stream_handler.expect_stop().never();
             block_stream_handler.expect_start().never();
 
-            synchronise_block_streams(&indexer_registry, &redis_client, &mut block_stream_handler)
+            synchronise_block_streams(&indexer_registry, &redis_client, &block_stream_handler)
                 .await
                 .unwrap();
         }
@@ -659,7 +658,7 @@ mod tests {
                 )
                 .returning(|_, _, _, _, _, _| Ok(()));
 
-            synchronise_block_streams(&indexer_registry, &redis_client, &mut block_stream_handler)
+            synchronise_block_streams(&indexer_registry, &redis_client, &block_stream_handler)
                 .await
                 .unwrap();
         }

--- a/coordinator/src/redis.rs
+++ b/coordinator/src/redis.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-pub use redis::RedisError;
+use anyhow::Context;
 use redis::{aio::ConnectionManager, FromRedisValue, ToRedisArgs};
 
 #[cfg(test)]
@@ -14,10 +14,11 @@ pub struct RedisClientImpl {
 
 #[cfg_attr(test, mockall::automock)]
 impl RedisClientImpl {
-    pub async fn connect(redis_url: &str) -> Result<Self, RedisError> {
+    pub async fn connect(redis_url: &str) -> anyhow::Result<Self> {
         let connection = redis::Client::open(redis_url)?
             .get_connection_manager()
-            .await?;
+            .await
+            .context("Unable to connect to Redis")?;
 
         Ok(Self { connection })
     }

--- a/coordinator/src/registry.rs
+++ b/coordinator/src/registry.rs
@@ -8,6 +8,8 @@ use near_primitives::types::{AccountId, BlockReference, Finality, FunctionArgs};
 use near_primitives::views::QueryRequest;
 use registry_types::{AccountOrAllIndexers, IndexerRule};
 
+use crate::utils::exponential_retry;
+
 pub type IndexerRegistry = HashMap<AccountId, HashMap<String, IndexerConfig>>;
 
 #[derive(Debug, Clone)]
@@ -44,6 +46,8 @@ pub struct RegistryImpl {
 
 #[cfg_attr(test, mockall::automock)]
 impl RegistryImpl {
+    const LIST_METHOD: &str = "list_indexer_functions";
+
     pub fn connect(registry_contract_id: AccountId, rpc_url: &str) -> Self {
         let json_rpc_client = JsonRpcClient::connect(rpc_url);
 
@@ -85,28 +89,34 @@ impl RegistryImpl {
     }
 
     pub async fn fetch(&self) -> anyhow::Result<IndexerRegistry> {
-        let response = self
-            .json_rpc_client
-            .call(RpcQueryRequest {
-                block_reference: BlockReference::Finality(Finality::Final),
-                request: QueryRequest::CallFunction {
-                    method_name: "list_indexer_functions".to_string(),
-                    account_id: self.registry_contract_id.clone(),
-                    args: FunctionArgs::from("{}".as_bytes().to_vec()),
-                },
-            })
-            .await
-            .context("Failed to list registry contract")?;
+        exponential_retry(
+            || async {
+                let response = self
+                    .json_rpc_client
+                    .call(RpcQueryRequest {
+                        block_reference: BlockReference::Finality(Finality::Final),
+                        request: QueryRequest::CallFunction {
+                            method_name: Self::LIST_METHOD.to_string(),
+                            account_id: self.registry_contract_id.clone(),
+                            args: FunctionArgs::from("{}".as_bytes().to_vec()),
+                        },
+                    })
+                    .await
+                    .context("Failed to list registry contract")?;
 
-        if let QueryResponseKind::CallResult(call_result) = response.kind {
-            let list_registry_response: AccountOrAllIndexers =
-                serde_json::from_slice(&call_result.result)?;
+                if let QueryResponseKind::CallResult(call_result) = response.kind {
+                    let list_registry_response: AccountOrAllIndexers =
+                        serde_json::from_slice(&call_result.result)?;
 
-            if let AccountOrAllIndexers::All(all_indexers) = list_registry_response {
-                return Ok(self.enrich_indexer_registry(all_indexers));
-            }
-        }
+                    if let AccountOrAllIndexers::All(all_indexers) = list_registry_response {
+                        return Ok(self.enrich_indexer_registry(all_indexers));
+                    }
+                }
 
-        anyhow::bail!("Invalid registry response")
+                anyhow::bail!("Invalid registry response")
+            },
+            |_| true,
+        )
+        .await
     }
 }

--- a/coordinator/src/utils.rs
+++ b/coordinator/src/utils.rs
@@ -1,0 +1,38 @@
+use std::time::Duration;
+
+use futures_util::future::Future;
+
+const INITIAL_DELAY_SECONDS: u64 = 1;
+
+pub async fn exponential_retry<F, R, Fut, T, E>(operation: F, should_retry: R) -> Result<T, E>
+where
+    F: Fn() -> Fut,
+    R: Fn(&E) -> bool,
+    Fut: Future<Output = Result<T, E>>,
+    E: std::fmt::Debug,
+{
+    let mut attempts = 1;
+    let mut delay = Duration::from_secs(INITIAL_DELAY_SECONDS);
+
+    loop {
+        match operation().await {
+            Ok(result) => return Ok(result),
+            Err(error) => {
+                if should_retry(&error) {
+                    if attempts == 1 || attempts % 5 == 0 {
+                        tracing::warn!(
+                            "Encountered error {attempts} time(s). Retrying...\n{error:?}"
+                        )
+                    }
+
+                    tokio::time::sleep(delay).await;
+
+                    attempts += 1;
+                    delay *= 2;
+                } else {
+                    return Err(error);
+                }
+            }
+        }
+    }
+}

--- a/coordinator/src/utils.rs
+++ b/coordinator/src/utils.rs
@@ -4,10 +4,9 @@ use futures_util::future::Future;
 
 const INITIAL_DELAY_SECONDS: u64 = 1;
 
-pub async fn exponential_retry<F, R, Fut, T, E>(operation: F, should_retry: R) -> Result<T, E>
+pub async fn exponential_retry<F, Fut, T, E>(operation: F) -> Result<T, E>
 where
     F: Fn() -> Fut,
-    R: Fn(&E) -> bool,
     Fut: Future<Output = Result<T, E>>,
     E: std::fmt::Debug,
 {
@@ -18,20 +17,14 @@ where
         match operation().await {
             Ok(result) => return Ok(result),
             Err(error) => {
-                if should_retry(&error) {
-                    if attempts == 1 || attempts % 5 == 0 {
-                        tracing::warn!(
-                            "Encountered error {attempts} time(s). Retrying...\n{error:?}"
-                        )
-                    }
-
-                    tokio::time::sleep(delay).await;
-
-                    attempts += 1;
-                    delay *= 2;
-                } else {
-                    return Err(error);
+                if attempts == 1 || attempts % 5 == 0 {
+                    tracing::warn!("Encountered error {attempts} time(s). Retrying...\n{error:?}")
                 }
+
+                tokio::time::sleep(delay).await;
+
+                attempts += 1;
+                delay *= 2;
             }
         }
     }

--- a/coordinator/src/utils.rs
+++ b/coordinator/src/utils.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use futures_util::future::Future;
 
-const INITIAL_DELAY_SECONDS: u64 = 1;
+const INITIAL_DELAY_SECONDS: Duration = Duration::from_secs(1);
 
 pub async fn exponential_retry<F, Fut, T, E>(operation: F) -> Result<T, E>
 where
@@ -11,7 +11,7 @@ where
     E: std::fmt::Debug,
 {
     let mut attempts = 1;
-    let mut delay = Duration::from_secs(INITIAL_DELAY_SECONDS);
+    let mut delay = INITIAL_DELAY_SECONDS;
 
     loop {
         match operation().await {


### PR DESCRIPTION
Currently, errors thrown within Coordinator V2 will bubble up to `main()` and cause the entire application to exit. This PR captures those errors, handling them accordingly. 

Errors are handled in either of the following ways:
1. Exponentially retry - data which is 'critical' to the control, i.e. the indexer registry, executor/stream list, will be continuously retried, blocking the control loop from further progress as it would not make sense to continue without this information.
2. Swallowed - actions such as starting/stopping executors/streams will be logged and swallowed. This is preferable over exponential retries as individual failures will not block the progress of the control loop, therefore allowing other indexers to be acted on. Skipping should be fine in this case as it will be retried in the next loop.

I expect this behaviour to evolve over time as we learn more about the system, the important thing here is that Coordinator will not crash on errors.