### PR TITLE
feat: Add "StartBlock::Continue" to registry contract/types

### DIFF
--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -294,7 +294,7 @@ mod tests {
             )
             .unwrap(),
             function_name: "test".to_string(),
-            indexer_rule: registry_types::IndexerRule {
+            indexer_rule: registry_types::OldIndexerRule {
                 indexer_rule_kind: registry_types::IndexerRuleKind::Action,
                 matching_rule: registry_types::MatchingRule::ActionAny {
                     affected_account_id: "queryapi.dataplatform.near".to_string(),

--- a/block-streamer/src/indexer_config.rs
+++ b/block-streamer/src/indexer_config.rs
@@ -2,7 +2,7 @@ use near_lake_framework::near_indexer_primitives::types::AccountId;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
-use registry_types::IndexerRule;
+use registry_types::OldIndexerRule as IndexerRule;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct IndexerConfig {

--- a/block-streamer/src/rules/mod.rs
+++ b/block-streamer/src/rules/mod.rs
@@ -3,7 +3,7 @@ pub mod outcomes_reducer;
 pub mod types;
 
 use near_lake_framework::near_indexer_primitives::StreamerMessage;
-use registry_types::{IndexerRule, MatchingRule};
+use registry_types::{MatchingRule, OldIndexerRule as IndexerRule};
 
 use types::{ChainId, IndexerRuleMatch};
 

--- a/block-streamer/src/rules/outcomes_reducer.rs
+++ b/block-streamer/src/rules/outcomes_reducer.rs
@@ -115,7 +115,7 @@ fn build_indexer_rule_match_payload(
 
 #[cfg(test)]
 mod tests {
-    use registry_types::{IndexerRule, IndexerRuleKind, MatchingRule, Status};
+    use registry_types::{IndexerRuleKind, MatchingRule, OldIndexerRule as IndexerRule, Status};
 
     use crate::rules::outcomes_reducer::reduce_indexer_rule_matches_from_outcomes;
     use crate::rules::types::{ChainId, IndexerRuleMatch};

--- a/block-streamer/src/server/block_streamer_service.rs
+++ b/block-streamer/src/server/block_streamer_service.rs
@@ -6,7 +6,7 @@ use tonic::{Request, Response, Status};
 
 use crate::indexer_config::IndexerConfig;
 use crate::rules::types::ChainId;
-use registry_types::{IndexerRule, IndexerRuleKind, MatchingRule};
+use registry_types::{IndexerRuleKind, MatchingRule, OldIndexerRule as IndexerRule};
 
 use crate::block_stream;
 use crate::server::blockstreamer;

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -255,7 +255,7 @@ mod tests {
     use mockall::predicate;
     use std::collections::HashMap;
 
-    use registry_types::{IndexerRule, IndexerRuleKind, MatchingRule, Status};
+    use registry_types::{IndexerRuleKind, MatchingRule, OldIndexerRule as IndexerRule, Status};
 
     use crate::registry::IndexerConfig;
 

--- a/coordinator/src/migration.rs
+++ b/coordinator/src/migration.rs
@@ -281,7 +281,7 @@ mod tests {
     use std::collections::HashMap;
 
     use mockall::predicate;
-    use registry_types::{IndexerRule, IndexerRuleKind, MatchingRule, Status};
+    use registry_types::{IndexerRuleKind, MatchingRule, OldIndexerRule, Status};
 
     use crate::registry::IndexerConfig;
 
@@ -296,7 +296,7 @@ mod tests {
                     function_name: "test".to_string(),
                     code: String::new(),
                     schema: Some(String::new()),
-                    filter: IndexerRule {
+                    filter: OldIndexerRule {
                         id: None,
                         name: None,
                         indexer_rule_kind: IndexerRuleKind::Action,
@@ -369,7 +369,7 @@ mod tests {
                     function_name: "test".to_string(),
                     code: String::new(),
                     schema: Some(String::new()),
-                    filter: IndexerRule {
+                    filter: OldIndexerRule {
                         id: None,
                         name: None,
                         indexer_rule_kind: IndexerRuleKind::Action,

--- a/coordinator/src/registry.rs
+++ b/coordinator/src/registry.rs
@@ -8,7 +8,9 @@ use near_jsonrpc_client::JsonRpcClient;
 use near_jsonrpc_primitives::types::query::QueryResponseKind;
 use near_primitives::types::{AccountId, BlockReference, Finality, FunctionArgs};
 use near_primitives::views::QueryRequest;
-use registry_types::{AccountOrAllIndexers, IndexerRule};
+use registry_types::{
+    OldAccountOrAllIndexers as AccountOrAllIndexers, OldIndexerRule as IndexerRule,
+};
 
 use crate::utils::exponential_retry;
 
@@ -69,7 +71,7 @@ impl RegistryImpl {
 
     fn enrich_indexer_registry(
         &self,
-        registry: HashMap<AccountId, HashMap<String, registry_types::IndexerConfig>>,
+        registry: HashMap<AccountId, HashMap<String, registry_types::OldIndexerConfig>>,
     ) -> IndexerRegistry {
         registry
             .into_iter()

--- a/registry/contract/src/lib.rs
+++ b/registry/contract/src/lib.rs
@@ -72,7 +72,7 @@ pub struct AccountRole {
 impl Default for Contract {
     fn default() -> Self {
         Self {
-            registry: IndexersByAccount::new(StorageKeys::Registry),
+            registry: IndexersByAccount::new(StorageKeys::RegistryV3),
             account_roles: vec![
                 AccountRole {
                     account_id: "morgs.near".parse().unwrap(),
@@ -297,7 +297,7 @@ impl Contract {
         let account_indexers =
             self.registry
                 .entry(account_id.clone())
-                .or_insert(IndexerConfigByFunctionName::new(StorageKeys::Account(
+                .or_insert(IndexerConfigByFunctionName::new(StorageKeys::AccountV3(
                     env::sha256_array(account_id.as_bytes()),
                 )));
 

--- a/registry/types/src/lib.rs
+++ b/registry/types/src/lib.rs
@@ -73,7 +73,7 @@ pub enum Status {
 
 #[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum IndexerRule {
+pub enum Rule {
     ActionAny {
         affected_account_id: String,
         status: Status,
@@ -107,7 +107,7 @@ pub struct IndexerConfig {
     pub code: String,
     pub start_block: StartBlock,
     pub schema: String,
-    pub filter: IndexerRule,
+    pub rule: Rule,
     pub updated_at_block_height: Option<u64>,
     pub created_at_block_height: u64,
 }

--- a/registry/types/src/lib.rs
+++ b/registry/types/src/lib.rs
@@ -37,7 +37,6 @@ pub enum MatchingRule {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
-#[serde(tag = "kind", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum IndexerRuleKind {
     Action,
     Event,

--- a/registry/types/src/lib.rs
+++ b/registry/types/src/lib.rs
@@ -17,14 +17,6 @@ use serde::{Deserialize, Serialize};
 type FunctionName = String;
 
 #[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum Status {
-    Any,
-    Success,
-    Fail,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 #[serde(tag = "rule", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum MatchingRule {
     ActionAny {
@@ -45,6 +37,7 @@ pub enum MatchingRule {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum IndexerRuleKind {
     Action,
     Event,
@@ -53,14 +46,54 @@ pub enum IndexerRuleKind {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
-pub struct IndexerRule {
+pub struct OldIndexerRule {
     pub indexer_rule_kind: IndexerRuleKind,
     pub matching_rule: MatchingRule,
+    // These are not set, and not used anywhere
     pub id: Option<u32>,
     pub name: Option<String>,
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct OldIndexerConfig {
+    pub code: String,
+    pub start_block_height: Option<u64>,
+    pub schema: Option<String>,
+    pub filter: OldIndexerRule,
+    pub updated_at_block_height: Option<u64>,
+    pub created_at_block_height: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum Status {
+    Any,
+    Success,
+    Fail,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum IndexerRule {
+    ActionAny {
+        affected_account_id: String,
+        status: Status,
+    },
+    ActionFunctionCall {
+        affected_account_id: String,
+        status: Status,
+        function: String,
+    },
+    Event {
+        contract_account_id: String,
+        standard: String,
+        version: String,
+        event: String,
+    },
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum StartBlock {
     /// Specific block height to start indexing from
     Height(u64),
@@ -73,9 +106,8 @@ pub enum StartBlock {
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct IndexerConfig {
     pub code: String,
-    pub start_block_height: Option<u64>,
     pub start_block: StartBlock,
-    pub schema: Option<String>,
+    pub schema: String,
     pub filter: IndexerRule,
     pub updated_at_block_height: Option<u64>,
     pub created_at_block_height: u64,
@@ -83,6 +115,6 @@ pub struct IndexerConfig {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum AccountOrAllIndexers {
-    All(HashMap<AccountId, HashMap<FunctionName, IndexerConfig>>),
-    Account(HashMap<FunctionName, IndexerConfig>),
+    All(HashMap<AccountId, HashMap<FunctionName, OldIndexerConfig>>),
+    Account(HashMap<FunctionName, OldIndexerConfig>),
 }

--- a/registry/types/src/lib.rs
+++ b/registry/types/src/lib.rs
@@ -101,7 +101,7 @@ impl From<IndexerConfig> for OldIndexerConfig {
     fn from(config: IndexerConfig) -> Self {
         let start_block_height = match config.start_block {
             StartBlock::Latest => None,
-            StartBlock::Interruption => None,
+            StartBlock::Continue => None,
             StartBlock::Height(height) => Some(height),
         };
 
@@ -198,12 +198,13 @@ impl From<MatchingRule> for Rule {
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum StartBlock {
-    /// Specific block height to start indexing from
+    /// Specifies the particular block height from which to start indexing from.
     Height(u64),
-    /// Real-time indexing, always taking the latest finalized block to stream
+    /// Starts indexing from the most recently finalized block.
     Latest,
-    /// Starts indexing from the block the Indexer was interrupted last time
-    Interruption,
+    /// Resumes indexing from the block immediately following the last one successfully indexed
+    /// prior to update.
+    Continue,
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/registry/types/src/lib.rs
+++ b/registry/types/src/lib.rs
@@ -61,9 +61,20 @@ pub struct IndexerRule {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum StartBlock {
+    /// Specific block height to start indexing from
+    Height(u64),
+    /// Real-time indexing, always taking the latest finalized block to stream
+    Latest,
+    /// Starts indexing from the block the Indexer was interrupted last time
+    Interruption,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct IndexerConfig {
     pub code: String,
     pub start_block_height: Option<u64>,
+    pub start_block: StartBlock,
     pub schema: Option<String>,
     pub filter: IndexerRule,
     pub updated_at_block_height: Option<u64>,

--- a/registry/types/src/lib.rs
+++ b/registry/types/src/lib.rs
@@ -127,6 +127,12 @@ impl From<IndexerConfig> for OldIndexerConfig {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum OldAccountOrAllIndexers {
+    All(HashMap<AccountId, HashMap<FunctionName, OldIndexerConfig>>),
+    Account(HashMap<FunctionName, OldIndexerConfig>),
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Status {
@@ -226,8 +232,6 @@ impl From<OldIndexerConfig> for IndexerConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub enum AccountOrAllIndexers {
-    All(HashMap<AccountId, HashMap<FunctionName, OldIndexerConfig>>),
-    Account(HashMap<FunctionName, OldIndexerConfig>),
-}
+pub type AccountIndexers = HashMap<FunctionName, IndexerConfig>;
+
+pub type AllIndexers = HashMap<AccountId, AccountIndexers>;


### PR DESCRIPTION
The start block parameter (`start_block_height`) has two states, signifying "Start from block" and "Start from latest" only. With the removal of the continuous "real-time" process, which essentially runs Indexers "From Interruption", the need for a third state arises, representing "Interruption" arises. This PR expands the registry contract/types to accommodate this change. This work was a good opportunity to refactor the existing types, removing unnecessary fields and tailoring it to the new architecture.

## Registry Types Refactoring
- `filter: IndexerRule` -> `rule: Rule`: `IndexerRule` contained a lot of noise/data which was not needed. `id`, `name`, and `indexer_rule_kind` have all been removed. The only useful part here is `MatchingRule` which has been renamed to just `Rule`.
- `schema` is now non-optional: This field is always required so it makes sense to convey that in the code. Having it as an `Option` created lots of unnecessary checks throughout the system.
- `start_block_height` replaced by `start_block`: The latter being an `enum` to represent "From Latest", "From Block", and "From Interruption"

## Public methods/API
To minimise the disruption of the existing contract consumers, the public API remains unchanged, i.e. the core methods (`list_indexer_functions`, `register_indexer_function`, etc.) use/return the same types. As the underlying data will be migrated to the new types, these methods infer the old types from the new ones. New methods have been created to work with the new types (`register`, `list_all`, etc.) allowing clients to move over when possible, as opposed to creating a breaking change.