### PR TITLE
feat: Add Metrics for Memory Statistics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
       PGPASSWORD: postgrespassword
       PGDATABASE: postgres
       PORT: 9180
+      AWS_REGION: eu-central-1
       AWS_ACCESS_KEY_ID:
       AWS_SECRET_ACCESS_KEY:
       GRPC_SERVER_PORT: 7001

--- a/indexer/queryapi_coordinator/src/main.rs
+++ b/indexer/queryapi_coordinator/src/main.rs
@@ -142,7 +142,7 @@ async fn main() -> anyhow::Result<()> {
 
 async fn fetch_denylist(redis_connection_manager: &ConnectionManager) -> anyhow::Result<Denylist> {
     let raw_denylist: String =
-        storage::get(redis_connection_manager, storage::DENYLIST_KEY).await?;
+        storage::get(redis_connection_manager, storage::DENYLIST_KEY).await.unwrap_or("".to_owned());
     let denylist: Denylist =
         serde_json::from_str(&raw_denylist).context("Failed to parse denylist")?;
 

--- a/indexer/queryapi_coordinator/src/main.rs
+++ b/indexer/queryapi_coordinator/src/main.rs
@@ -141,8 +141,9 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn fetch_denylist(redis_connection_manager: &ConnectionManager) -> anyhow::Result<Denylist> {
-    let raw_denylist: String =
-        storage::get(redis_connection_manager, storage::DENYLIST_KEY).await.unwrap_or("".to_owned());
+    let raw_denylist: String = storage::get(redis_connection_manager, storage::DENYLIST_KEY)
+        .await
+        .unwrap_or("".to_owned());
     let denylist: Denylist =
         serde_json::from_str(&raw_denylist).context("Failed to parse denylist")?;
 

--- a/runner/src/metrics.ts
+++ b/runner/src/metrics.ts
@@ -1,6 +1,24 @@
 import express from 'express';
 import { Gauge, Histogram, Counter, AggregatorRegistry } from 'prom-client';
 
+const HEAP_TOTAL_ALLOCATION = new Gauge({
+  name: 'queryapi_runner_heap_total_allocation_megabytes',
+  help: 'Size of heap allocation for indexer function',
+  labelNames: ['indexer', 'type'],
+});
+
+const HEAP_USED = new Gauge({
+  name: 'queryapi_runner_heap_used_megabytes',
+  help: 'Size of used heap space for indexer function',
+  labelNames: ['indexer', 'type'],
+});
+
+const PREFETCH_QUEUE_COUNT = new Gauge({
+  name: 'queryapi_runner_prefetch_queue_count',
+  help: 'Count of items in prefetch queue for indexer function',
+  labelNames: ['indexer', 'type'],
+});
+
 const BLOCK_WAIT_DURATION = new Histogram({
   name: 'queryapi_runner_block_wait_duration_milliseconds',
   help: 'Time an indexer function waited for a block before processing',
@@ -37,6 +55,9 @@ const EXECUTION_DURATION = new Histogram({
 });
 
 export const METRICS = {
+  HEAP_TOTAL_ALLOCATION,
+  HEAP_USED,
+  PREFETCH_QUEUE_COUNT,
   BLOCK_WAIT_DURATION,
   CACHE_HIT,
   CACHE_MISS,

--- a/runner/src/server/runner-service.ts
+++ b/runner/src/server/runner-service.ts
@@ -107,7 +107,8 @@ function getRunnerService (executors: Map<string, StreamHandler>, StreamHandlerT
               schema: '',
             };
             context = {
-              status: Status.RUNNING
+              status: Status.RUNNING,
+              block_height: 0,
             };
           }
           response.push({

--- a/runner/src/server/runner-service.ts
+++ b/runner/src/server/runner-service.ts
@@ -108,7 +108,7 @@ function getRunnerService (executors: Map<string, StreamHandler>, StreamHandlerT
             };
             context = {
               status: Status.RUNNING,
-              block_height: 0,
+              block_height: context.block_height,
             };
           }
           response.push({

--- a/runner/src/stream-handler/worker.ts
+++ b/runner/src/stream-handler/worker.ts
@@ -85,7 +85,7 @@ async function blockQueueConsumer (workerContext: WorkerContext, streamKey: stri
   const indexer = new Indexer();
   const isHistorical = workerContext.streamType === 'historical';
   let streamMessageId = '';
-  let indexerName = '';
+  let indexerName = streamKey.split(':')[0];
   let currBlockHeight = 0;
 
   while (true) {


### PR DESCRIPTION
Runner has crashed previously due to Out of Memory errors. It's unclear what settings need to be increased to resolve the error, and if the adjustments properly address the underlying problems. To help understand the limits of the Runner service, I've added metrics to capture individual worker heap sizes, which contribute largely to any OOM related problems. In addition to getting each worker's usage, we also can sum them to get overall heap allocation and utilization. I've also logged metrics for the prefetch queue size so that we can understand the relation between prefetch and the memory foot print. 

In addition some smaller tasks were addressed as well:

1. Grafana was also displaying a value for the labels on their own, instead of only under "indexer type". 
2. Coordinator V1 would fail to init if DENY list was missing.
3. The error that caused an indexer to crash was not being logged to the indexer's logs. 
4. Docker compose'd Runner was failing due to Region missing
