### PR TITLE
fix: Prevent skipping blocks from Redis Stream

### DIFF
--- a/runner/src/stream-handler/worker.ts
+++ b/runner/src/stream-handler/worker.ts
@@ -51,11 +51,6 @@ async function handleStream (workerContext: WorkerContext, streamKey: string): P
   void blockQueueConsumer(workerContext, streamKey);
 }
 
-function incrementId (id: string): string {
-  const [main, sequence] = id.split('-');
-  return `${main}-${Number(sequence) + 1}`;
-}
-
 async function blockQueueProducer (workerContext: WorkerContext, streamKey: string): Promise<void> {
   const HISTORICAL_BATCH_SIZE = parseInt(process.env.PREFETCH_QUEUE_LIMIT ?? '10');
   let streamMessageStartId = '0';
@@ -78,7 +73,7 @@ async function blockQueueProducer (workerContext: WorkerContext, streamKey: stri
         workerContext.queue.push(generateQueueMessage(workerContext, Number(message.block_height), id));
       }
 
-      streamMessageStartId = incrementId(messages[messages.length - 1].id);
+      streamMessageStartId = messages[messages.length - 1].id;
     } catch (err) {
       console.error('Error fetching stream messages', err);
       await sleep(500);


### PR DESCRIPTION
`xread` returns messages _after_ the provided ID, there's no need to increment the ID ourselves. If we increment to an ID that actually exists within the stream, the message will be skipped permanently. e.g. we have messages `1-0` and `1-1`, on first read we get `1-0`, we increment to `1-1`, then on the second read we get nothing.