### PR TITLE
fix: Remove throwing of error during intended retry loop

### DIFF
--- a/runner/src/stream-handler/worker.ts
+++ b/runner/src/stream-handler/worker.ts
@@ -135,7 +135,6 @@ async function blockQueueConsumer (workerContext: WorkerContext, streamKey: stri
     } catch (err) {
       await sleep(10000);
       console.log(`Failed: ${indexerName} ${workerContext.streamType} on block ${currBlockHeight}`, err);
-      throw err;
     } finally {
       const unprocessedMessageCount = await workerContext.redisClient.getUnprocessedStreamMessageCount(streamKey);
       METRICS.UNPROCESSED_STREAM_MESSAGES.labels({ indexer: indexerName, type: workerContext.streamType }).set(unprocessedMessageCount);


### PR DESCRIPTION
A line to throw the error was mistakenly added during testing of things. This should not be thrown since it prevents retries. 