### PR TITLE
feat: Support Star Contract Filter in Block Streamer

### DIFF
--- a/block-streamer/examples/list_streams.rs
+++ b/block-streamer/examples/list_streams.rs
@@ -5,7 +5,7 @@ use block_streamer::ListStreamsRequest;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = BlockStreamerClient::connect("http://[::1]:10000").await?;
+    let mut client = BlockStreamerClient::connect("http://0.0.0.0:8002").await?;
 
     let response = client
         .list_streams(Request::new(ListStreamsRequest {}))

--- a/block-streamer/examples/start_stream.rs
+++ b/block-streamer/examples/start_stream.rs
@@ -5,7 +5,7 @@ use block_streamer::{start_stream_request::Rule, ActionAnyRule, StartStreamReque
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = BlockStreamerClient::connect("http://[::1]:10000").await?;
+    let mut client = BlockStreamerClient::connect("http://0.0.0.0:8002").await?;
 
     let response = client
         .start_stream(Request::new(StartStreamRequest {
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             version: 0,
             redis_stream: "morgs.near/test:block_stream".to_string(),
             rule: Some(Rule::ActionAnyRule(ActionAnyRule {
-                affected_account_id: "social.near".to_string(),
+                affected_account_id: "*".to_string(),
                 status: Status::Success.into(),
             })),
         }))

--- a/block-streamer/examples/start_stream.rs
+++ b/block-streamer/examples/start_stream.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             version: 0,
             redis_stream: "morgs.near/test:block_stream".to_string(),
             rule: Some(Rule::ActionAnyRule(ActionAnyRule {
-                affected_account_id: "*".to_string(),
+                affected_account_id: "social.near".to_string(),
                 status: Status::Success.into(),
             })),
         }))

--- a/block-streamer/examples/stop_stream.rs
+++ b/block-streamer/examples/stop_stream.rs
@@ -5,7 +5,7 @@ use block_streamer::StopStreamRequest;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = BlockStreamerClient::connect("http://[::1]:10000").await?;
+    let mut client = BlockStreamerClient::connect("http://0.0.0.0:8002").await?;
 
     let response = client
         .stop_stream(Request::new(StopStreamRequest {

--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -190,7 +190,7 @@ async fn process_delta_lake_blocks(
                 .any(|account_id| DELTA_LAKE_SKIP_ACCOUNTS.contains(&account_id.trim()))
             {
                 tracing::debug!(
-                    "Skipping fetching index files from delta lake due to wildcard contract filter {}",
+                    "Skipping fetching index files from delta lake due to wildcard contract filter present in {}",
                     affected_account_id
                 );
                 return Ok(start_block_height);

--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -184,6 +184,13 @@ async fn process_delta_lake_blocks(
             affected_account_id,
             ..
         } => {
+            if affected_account_id.eq("*") {
+                tracing::debug!(
+                    "Skipping fetching index files from delta lake due to wildcard contract filter {}",
+                    affected_account_id
+                );
+                return Ok(start_block_height);
+            }
             tracing::debug!(
                 "Fetching block heights starting from {} from delta lake",
                 start_block_height,
@@ -351,6 +358,62 @@ mod tests {
             std::sync::Arc::new(mock_redis_client),
             std::sync::Arc::new(mock_delta_lake_client),
             lake_s3_config,
+            &ChainId::Mainnet,
+            1,
+            "stream key".to_string(),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn skips_delta_lake_for_star_filter() {
+        let mut mock_delta_lake_client = crate::delta_lake_client::DeltaLakeClient::default();
+        mock_delta_lake_client
+            .expect_get_latest_block_metadata()
+            .returning(|| {
+                Ok(crate::delta_lake_client::LatestBlockMetadata {
+                    last_indexed_block: "107503703".to_string(),
+                    processed_at_utc: "".to_string(),
+                    first_indexed_block: "".to_string(),
+                    last_indexed_block_date: "".to_string(),
+                    first_indexed_block_date: "".to_string(),
+                })
+            });
+        mock_delta_lake_client.expect_list_matching_block_heights().times(0);
+
+        let mock_lake_s3_config = crate::test_utils::create_mock_lake_s3_config(&[107503704, 107503705]);
+
+        let mut mock_redis_client = crate::redis::RedisClient::default();
+        mock_redis_client
+            .expect_set::<String, u64>()
+            .returning(|_,_| Ok(()))
+            .times(2);
+        mock_redis_client
+            .expect_xadd::<String, u64>()
+            .returning(|_, fields| {
+                assert!(vec![107503704, 107503705].contains(&fields[0].1));
+                Ok(())
+            })
+            .times(2);
+        
+        let indexer_config = crate::indexer_config::IndexerConfig {
+            account_id: near_indexer_primitives::types::AccountId::try_from(
+                "morgs.near".to_string()
+            ).unwrap(),
+            function_name: "test".to_string(),
+            rule: registry_types::Rule::ActionAny { 
+                affected_account_id: "*".to_string(),
+                status: registry_types::Status::Success,
+            }
+        };
+
+        start_block_stream(
+            107503704,
+            &indexer_config,
+            std::sync::Arc::new(mock_redis_client),
+            std::sync::Arc::new(mock_delta_lake_client),
+            mock_lake_s3_config,
             &ChainId::Mainnet,
             1,
             "stream key".to_string(),

--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -380,9 +380,12 @@ mod tests {
                     first_indexed_block_date: "".to_string(),
                 })
             });
-        mock_delta_lake_client.expect_list_matching_block_heights().times(0);
+        mock_delta_lake_client
+            .expect_list_matching_block_heights()
+            .times(0);
 
-        let mock_lake_s3_config = crate::test_utils::create_mock_lake_s3_config(&[107503704, 107503705]);
+        let mock_lake_s3_config =
+            crate::test_utils::create_mock_lake_s3_config(&[107503704, 107503705]);
 
         let mut mock_redis_client = crate::redis::RedisClient::default();
         mock_redis_client
@@ -399,16 +402,17 @@ mod tests {
                 Ok(())
             })
             .times(2);
-        
+
         let indexer_config = crate::indexer_config::IndexerConfig {
             account_id: near_indexer_primitives::types::AccountId::try_from(
-                "morgs.near".to_string()
-            ).unwrap(),
+                "morgs.near".to_string(),
+            )
+            .unwrap(),
             function_name: "test".to_string(),
-            rule: registry_types::Rule::ActionAny { 
+            rule: registry_types::Rule::ActionAny {
                 affected_account_id: "*".to_string(),
                 status: registry_types::Status::Success,
-            }
+            },
         };
 
         start_block_stream(

--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -373,7 +373,7 @@ mod tests {
             .expect_get_latest_block_metadata()
             .returning(|| {
                 Ok(crate::delta_lake_client::LatestBlockMetadata {
-                    last_indexed_block: "107503703".to_string(),
+                    last_indexed_block: "107503700".to_string(),
                     processed_at_utc: "".to_string(),
                     first_indexed_block: "".to_string(),
                     last_indexed_block_date: "".to_string(),
@@ -387,7 +387,10 @@ mod tests {
         let mut mock_redis_client = crate::redis::RedisClient::default();
         mock_redis_client
             .expect_set::<String, u64>()
-            .returning(|_,_| Ok(()))
+            .returning(|_, fields| {
+                assert!(vec![107503704, 107503705].contains(&fields));
+                Ok(())
+            })
             .times(2);
         mock_redis_client
             .expect_xadd::<String, u64>()

--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -185,7 +185,7 @@ async fn process_delta_lake_blocks(
             ..
         } => {
             if affected_account_id.eq("*") {
-                tracing::debug!(
+                tracing::info!(
                     "Skipping fetching index files from delta lake due to wildcard contract filter {}",
                     affected_account_id
                 );


### PR DESCRIPTION
Block Streamer will fail to process a * contract filter as it will try to fetch index files for all account IDs. This is not only extremely inefficient since we aren't planning to skip anything, but will also fail as we limit the number of accounts fetched as a sanity check. 

Block Streamer, if the filter is "*" specifically, now skips fetching index files and begins reading from Lake directly instead.

This retains the behavior of block streamer reading block data before pushing the height to Redis. There is an intended migration of Runner's prefetch into Block Streamer. This change works well towards that goal. However, obviously there is double work performed here: We fetch the block, only to just put the height into Redis. If, in the short term and before we migrate prefetch from Runner to Block Streamer, we need to speed things up, we can list files form S3 instead. However, this work would be removed after the mentioned migration of work.  