### PR TITLE
fix: Use non-archival RPC to deploy widgets

### DIFF
--- a/.github/workflows/deploy-widgets.yml
+++ b/.github/workflows/deploy-widgets.yml
@@ -60,6 +60,10 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf https://github.com/FroVolod/bos-cli-rs/releases/download/v${{ inputs.cli-version }}/bos-cli-v${{ inputs.cli-version }}-installer.sh | sh
 
+      - run: |
+          mkdir /home/runner/.config/near-cli
+          echo -e "credentials_home_dir = \"/home/runner/.near-credentials\"\n\n[network_connection.mainnet]\nnetwork_name = \"mainnet\"\nrpc_url = \"https://archival-rpc.mainnet.near.org/\"\nwallet_url = \"https://wallet.near.org/\"\nexplorer_transaction_url = \"https://explorer.near.org/transactions/\"\nlinkdrop_account_id = \"near\"\n\n" > /home/runner/.config/near-cli/config.toml
+
       - name: Deploy widgets
         run: |
           for DIR in $(echo $DIRECTORY_PATHS | tr "," "\n")


### PR DESCRIPTION
Archival RPC, the default for near/bos CLI seems to result in transactions expiring. non-RPC does not face the same issue. 
 This PR updates the widget deploy CI to use non-archival RPC.