### PR TITLE
fix: Increase timeout of VM run function

### DIFF
--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -90,7 +90,7 @@ export default class Indexer {
         }
 
         await this.setStatus(functionName, blockHeight, 'RUNNING');
-        const vm = new VM({ timeout: 3000, allowAsync: true });
+        const vm = new VM({ timeout: 20000, allowAsync: true });
         const context = this.buildContext(indexerFunction.schema, functionName, blockHeight, hasuraRoleName);
 
         vm.freeze(block, 'block');


### PR DESCRIPTION
Some indexers such as eduohe.near/access_keys potentially exceeds the timeout of the VM while running. This may be due to latency of DB calls, which is the heaviest parts of the code. We are planning to drive down the latency of these calls, but this is a stopgap to allow indexers to continue running in the mean time. 