### PR TITLE
feat: Cache Database Credentials

### DIFF
--- a/runner/src/dml-handler/dml-handler.test.ts
+++ b/runner/src/dml-handler/dml-handler.test.ts
@@ -1,149 +1,149 @@
-import pgFormat from 'pg-format';
-import DmlHandler from './dml-handler';
+// import pgFormat from 'pg-format';
+// import DmlHandler from './dml-handler';
 
-describe('DML Handler tests', () => {
-  const hasuraClient: any = {
-    getDbConnectionParameters: jest.fn().mockReturnValue({
-      database: 'test_near',
-      host: 'postgres',
-      password: 'test_pass',
-      port: 5432,
-      username: 'test_near'
-    })
-  };
-  let PgClient: any;
-  let query: any;
+// describe('DML Handler tests', () => {
+//   const hasuraClient: any = {
+//     getDbConnectionParameters: jest.fn().mockReturnValue({
+//       database: 'test_near',
+//       host: 'postgres',
+//       password: 'test_pass',
+//       port: 5432,
+//       username: 'test_near'
+//     })
+//   };
+//   let PgClient: any;
+//   let query: any;
 
-  const ACCOUNT = 'test_near';
-  const SCHEMA = 'test_schema';
-  const TABLE_NAME = 'test_table';
+//   const ACCOUNT = 'test_near';
+//   const SCHEMA = 'test_schema';
+//   const TABLE_NAME = 'test_table';
 
-  beforeEach(() => {
-    query = jest.fn().mockReturnValue({ rows: [] });
-    PgClient = jest.fn().mockImplementation(() => {
-      return { query, format: pgFormat };
-    });
-  });
+//   beforeEach(() => {
+//     query = jest.fn().mockReturnValue({ rows: [] });
+//     PgClient = jest.fn().mockImplementation(() => {
+//       return { query, format: pgFormat };
+//     });
+//   });
 
-  test('Test valid insert one with array', async () => {
-    const inputObj = {
-      account_id: 'test_acc_near',
-      block_height: 999,
-      block_timestamp: 'UTC',
-      content: 'test_content',
-      receipt_id: 111,
-      accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
-    };
+//   test('Test valid insert one with array', async () => {
+//     const inputObj = {
+//       account_id: 'test_acc_near',
+//       block_height: 999,
+//       block_timestamp: 'UTC',
+//       content: 'test_content',
+//       receipt_id: 111,
+//       accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
+//     };
 
-    const dmlHandler = DmlHandler.createLazy(ACCOUNT, hasuraClient, PgClient);
+//     const dmlHandler = DmlHandler.createLazy(ACCOUNT, hasuraClient, PgClient);
 
-    await dmlHandler.insert(SCHEMA, TABLE_NAME, [inputObj]);
-    expect(query.mock.calls).toEqual([
-      ['INSERT INTO test_schema."test_table" (account_id, block_height, block_timestamp, content, receipt_id, accounts_liked) VALUES (\'test_acc_near\', \'999\', \'UTC\', \'test_content\', \'111\', \'["cwpuzzles.near","devbose.near"]\') RETURNING *', []]
-    ]);
-  });
+//     await dmlHandler.insert(SCHEMA, TABLE_NAME, [inputObj]);
+//     expect(query.mock.calls).toEqual([
+//       ['INSERT INTO test_schema."test_table" (account_id, block_height, block_timestamp, content, receipt_id, accounts_liked) VALUES (\'test_acc_near\', \'999\', \'UTC\', \'test_content\', \'111\', \'["cwpuzzles.near","devbose.near"]\') RETURNING *', []]
+//     ]);
+//   });
 
-  test('Test valid insert multiple rows with array', async () => {
-    const inputObj = [{
-      account_id: 'morgs_near',
-      block_height: 1,
-      receipt_id: 'abc',
-    },
-    {
-      account_id: 'morgs_near',
-      block_height: 2,
-      receipt_id: 'abc',
-    }];
+//   test('Test valid insert multiple rows with array', async () => {
+//     const inputObj = [{
+//       account_id: 'morgs_near',
+//       block_height: 1,
+//       receipt_id: 'abc',
+//     },
+//     {
+//       account_id: 'morgs_near',
+//       block_height: 2,
+//       receipt_id: 'abc',
+//     }];
 
-    const dmlHandler = DmlHandler.createLazy(ACCOUNT, hasuraClient, PgClient);
+//     const dmlHandler = DmlHandler.createLazy(ACCOUNT, hasuraClient, PgClient);
 
-    await dmlHandler.insert(SCHEMA, TABLE_NAME, inputObj);
-    expect(query.mock.calls).toEqual([
-      ['INSERT INTO test_schema."test_table" (account_id, block_height, receipt_id) VALUES (\'morgs_near\', \'1\', \'abc\'), (\'morgs_near\', \'2\', \'abc\') RETURNING *', []]
-    ]);
-  });
+//     await dmlHandler.insert(SCHEMA, TABLE_NAME, inputObj);
+//     expect(query.mock.calls).toEqual([
+//       ['INSERT INTO test_schema."test_table" (account_id, block_height, receipt_id) VALUES (\'morgs_near\', \'1\', \'abc\'), (\'morgs_near\', \'2\', \'abc\') RETURNING *', []]
+//     ]);
+//   });
 
-  test('Test valid select on two fields', async () => {
-    const inputObj = {
-      account_id: 'test_acc_near',
-      block_height: 999,
-    };
+//   test('Test valid select on two fields', async () => {
+//     const inputObj = {
+//       account_id: 'test_acc_near',
+//       block_height: 999,
+//     };
 
-    const dmlHandler = DmlHandler.createLazy(ACCOUNT, hasuraClient, PgClient);
+//     const dmlHandler = DmlHandler.createLazy(ACCOUNT, hasuraClient, PgClient);
 
-    await dmlHandler.select(SCHEMA, TABLE_NAME, inputObj);
-    expect(query.mock.calls).toEqual([
-      ['SELECT * FROM test_schema."test_table" WHERE account_id=$1 AND block_height=$2', Object.values(inputObj)]
-    ]);
-  });
+//     await dmlHandler.select(SCHEMA, TABLE_NAME, inputObj);
+//     expect(query.mock.calls).toEqual([
+//       ['SELECT * FROM test_schema."test_table" WHERE account_id=$1 AND block_height=$2', Object.values(inputObj)]
+//     ]);
+//   });
 
-  test('Test valid select on two fields with limit', async () => {
-    const inputObj = {
-      account_id: 'test_acc_near',
-      block_height: 999,
-    };
+//   test('Test valid select on two fields with limit', async () => {
+//     const inputObj = {
+//       account_id: 'test_acc_near',
+//       block_height: 999,
+//     };
 
-    const dmlHandler = DmlHandler.createLazy(ACCOUNT, hasuraClient, PgClient);
+//     const dmlHandler = DmlHandler.createLazy(ACCOUNT, hasuraClient, PgClient);
 
-    await dmlHandler.select(SCHEMA, TABLE_NAME, inputObj, 1);
-    expect(query.mock.calls).toEqual([
-      ['SELECT * FROM test_schema."test_table" WHERE account_id=$1 AND block_height=$2 LIMIT 1', Object.values(inputObj)]
-    ]);
-  });
+//     await dmlHandler.select(SCHEMA, TABLE_NAME, inputObj, 1);
+//     expect(query.mock.calls).toEqual([
+//       ['SELECT * FROM test_schema."test_table" WHERE account_id=$1 AND block_height=$2 LIMIT 1', Object.values(inputObj)]
+//     ]);
+//   });
 
-  test('Test valid update on two fields', async () => {
-    const whereObj = {
-      account_id: 'test_acc_near',
-      block_height: 999,
-    };
+//   test('Test valid update on two fields', async () => {
+//     const whereObj = {
+//       account_id: 'test_acc_near',
+//       block_height: 999,
+//     };
 
-    const updateObj = {
-      content: 'test_content',
-      receipt_id: 111,
-    };
+//     const updateObj = {
+//       content: 'test_content',
+//       receipt_id: 111,
+//     };
 
-    const dmlHandler = DmlHandler.createLazy(ACCOUNT, hasuraClient, PgClient);
+//     const dmlHandler = DmlHandler.createLazy(ACCOUNT, hasuraClient, PgClient);
 
-    await dmlHandler.update(SCHEMA, TABLE_NAME, whereObj, updateObj);
-    expect(query.mock.calls).toEqual([
-      ['UPDATE test_schema."test_table" SET content=$1, receipt_id=$2 WHERE account_id=$3 AND block_height=$4 RETURNING *', [...Object.values(updateObj), ...Object.values(whereObj)]]
-    ]);
-  });
+//     await dmlHandler.update(SCHEMA, TABLE_NAME, whereObj, updateObj);
+//     expect(query.mock.calls).toEqual([
+//       ['UPDATE test_schema."test_table" SET content=$1, receipt_id=$2 WHERE account_id=$3 AND block_height=$4 RETURNING *', [...Object.values(updateObj), ...Object.values(whereObj)]]
+//     ]);
+//   });
 
-  test('Test valid upsert on two fields', async () => {
-    const inputObj = [{
-      account_id: 'morgs_near',
-      block_height: 1,
-      receipt_id: 'abc'
-    },
-    {
-      account_id: 'morgs_near',
-      block_height: 2,
-      receipt_id: 'abc'
-    }];
+//   test('Test valid upsert on two fields', async () => {
+//     const inputObj = [{
+//       account_id: 'morgs_near',
+//       block_height: 1,
+//       receipt_id: 'abc'
+//     },
+//     {
+//       account_id: 'morgs_near',
+//       block_height: 2,
+//       receipt_id: 'abc'
+//     }];
 
-    const conflictCol = ['account_id', 'block_height'];
-    const updateCol = ['receipt_id'];
+//     const conflictCol = ['account_id', 'block_height'];
+//     const updateCol = ['receipt_id'];
 
-    const dmlHandler = DmlHandler.createLazy(ACCOUNT, hasuraClient, PgClient);
+//     const dmlHandler = DmlHandler.createLazy(ACCOUNT, hasuraClient, PgClient);
 
-    await dmlHandler.upsert(SCHEMA, TABLE_NAME, inputObj, conflictCol, updateCol);
-    expect(query.mock.calls).toEqual([
-      ['INSERT INTO test_schema."test_table" (account_id, block_height, receipt_id) VALUES (\'morgs_near\', \'1\', \'abc\'), (\'morgs_near\', \'2\', \'abc\') ON CONFLICT (account_id, block_height) DO UPDATE SET receipt_id = excluded.receipt_id RETURNING *', []]
-    ]);
-  });
+//     await dmlHandler.upsert(SCHEMA, TABLE_NAME, inputObj, conflictCol, updateCol);
+//     expect(query.mock.calls).toEqual([
+//       ['INSERT INTO test_schema."test_table" (account_id, block_height, receipt_id) VALUES (\'morgs_near\', \'1\', \'abc\'), (\'morgs_near\', \'2\', \'abc\') ON CONFLICT (account_id, block_height) DO UPDATE SET receipt_id = excluded.receipt_id RETURNING *', []]
+//     ]);
+//   });
 
-  test('Test valid delete on two fields', async () => {
-    const inputObj = {
-      account_id: 'test_acc_near',
-      block_height: 999,
-    };
+//   test('Test valid delete on two fields', async () => {
+//     const inputObj = {
+//       account_id: 'test_acc_near',
+//       block_height: 999,
+//     };
 
-    const dmlHandler = DmlHandler.createLazy(ACCOUNT, hasuraClient, PgClient);
+//     const dmlHandler = DmlHandler.createLazy(ACCOUNT, hasuraClient, PgClient);
 
-    await dmlHandler.delete(SCHEMA, TABLE_NAME, inputObj);
-    expect(query.mock.calls).toEqual([
-      ['DELETE FROM test_schema."test_table" WHERE account_id=$1 AND block_height=$2 RETURNING *', Object.values(inputObj)]
-    ]);
-  });
-});
+//     await dmlHandler.delete(SCHEMA, TABLE_NAME, inputObj);
+//     expect(query.mock.calls).toEqual([
+//       ['DELETE FROM test_schema."test_table" WHERE account_id=$1 AND block_height=$2 RETURNING *', Object.values(inputObj)]
+//     ]);
+//   });
+// });

--- a/runner/src/dml-handler/dml-handler.test.ts
+++ b/runner/src/dml-handler/dml-handler.test.ts
@@ -1,149 +1,148 @@
-// import pgFormat from 'pg-format';
-// import DmlHandler from './dml-handler';
+import pgFormat from 'pg-format';
+import DmlHandler from './dml-handler';
+import PgClient from '../pg-client';
 
-// describe('DML Handler tests', () => {
-//   const hasuraClient: any = {
-//     getDbConnectionParameters: jest.fn().mockReturnValue({
-//       database: 'test_near',
-//       host: 'postgres',
-//       password: 'test_pass',
-//       port: 5432,
-//       username: 'test_near'
-//     })
-//   };
-//   let PgClient: any;
-//   let query: any;
+describe('DML Handler tests', () => {
+  const getDbConnectionParameters = {
+    database: 'test_near',
+    host: 'postgres',
+    password: 'test_pass',
+    port: 5432,
+    username: 'test_near'
+  };
+  let pgClient: PgClient;
+  let query: any;
 
-//   const ACCOUNT = 'test_near';
-//   const SCHEMA = 'test_schema';
-//   const TABLE_NAME = 'test_table';
+  const SCHEMA = 'test_schema';
+  const TABLE_NAME = 'test_table';
 
-//   beforeEach(() => {
-//     query = jest.fn().mockReturnValue({ rows: [] });
-//     PgClient = jest.fn().mockImplementation(() => {
-//       return { query, format: pgFormat };
-//     });
-//   });
+  beforeEach(() => {
+    query = jest.fn().mockReturnValue({ rows: [] });
+    pgClient = {
+      query: query, 
+      format: pgFormat
+    } as unknown as PgClient;
+  });
 
-//   test('Test valid insert one with array', async () => {
-//     const inputObj = {
-//       account_id: 'test_acc_near',
-//       block_height: 999,
-//       block_timestamp: 'UTC',
-//       content: 'test_content',
-//       receipt_id: 111,
-//       accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
-//     };
+  test('Test valid insert one with array', async () => {
+    const inputObj = {
+      account_id: 'test_acc_near',
+      block_height: 999,
+      block_timestamp: 'UTC',
+      content: 'test_content',
+      receipt_id: 111,
+      accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
+    };
 
-//     const dmlHandler = DmlHandler.createLazy(ACCOUNT, hasuraClient, PgClient);
+    const dmlHandler = DmlHandler.create(getDbConnectionParameters, pgClient);
 
-//     await dmlHandler.insert(SCHEMA, TABLE_NAME, [inputObj]);
-//     expect(query.mock.calls).toEqual([
-//       ['INSERT INTO test_schema."test_table" (account_id, block_height, block_timestamp, content, receipt_id, accounts_liked) VALUES (\'test_acc_near\', \'999\', \'UTC\', \'test_content\', \'111\', \'["cwpuzzles.near","devbose.near"]\') RETURNING *', []]
-//     ]);
-//   });
+    await dmlHandler.insert(SCHEMA, TABLE_NAME, [inputObj]);
+    expect(query.mock.calls).toEqual([
+      ['INSERT INTO test_schema."test_table" (account_id, block_height, block_timestamp, content, receipt_id, accounts_liked) VALUES (\'test_acc_near\', \'999\', \'UTC\', \'test_content\', \'111\', \'["cwpuzzles.near","devbose.near"]\') RETURNING *', []]
+    ]);
+  });
 
-//   test('Test valid insert multiple rows with array', async () => {
-//     const inputObj = [{
-//       account_id: 'morgs_near',
-//       block_height: 1,
-//       receipt_id: 'abc',
-//     },
-//     {
-//       account_id: 'morgs_near',
-//       block_height: 2,
-//       receipt_id: 'abc',
-//     }];
+  test('Test valid insert multiple rows with array', async () => {
+    const inputObj = [{
+      account_id: 'morgs_near',
+      block_height: 1,
+      receipt_id: 'abc',
+    },
+    {
+      account_id: 'morgs_near',
+      block_height: 2,
+      receipt_id: 'abc',
+    }];
 
-//     const dmlHandler = DmlHandler.createLazy(ACCOUNT, hasuraClient, PgClient);
+    const dmlHandler = DmlHandler.create(getDbConnectionParameters, pgClient);
 
-//     await dmlHandler.insert(SCHEMA, TABLE_NAME, inputObj);
-//     expect(query.mock.calls).toEqual([
-//       ['INSERT INTO test_schema."test_table" (account_id, block_height, receipt_id) VALUES (\'morgs_near\', \'1\', \'abc\'), (\'morgs_near\', \'2\', \'abc\') RETURNING *', []]
-//     ]);
-//   });
+    await dmlHandler.insert(SCHEMA, TABLE_NAME, inputObj);
+    expect(query.mock.calls).toEqual([
+      ['INSERT INTO test_schema."test_table" (account_id, block_height, receipt_id) VALUES (\'morgs_near\', \'1\', \'abc\'), (\'morgs_near\', \'2\', \'abc\') RETURNING *', []]
+    ]);
+  });
 
-//   test('Test valid select on two fields', async () => {
-//     const inputObj = {
-//       account_id: 'test_acc_near',
-//       block_height: 999,
-//     };
+  test('Test valid select on two fields', async () => {
+    const inputObj = {
+      account_id: 'test_acc_near',
+      block_height: 999,
+    };
 
-//     const dmlHandler = DmlHandler.createLazy(ACCOUNT, hasuraClient, PgClient);
+    const dmlHandler = DmlHandler.create(getDbConnectionParameters, pgClient);
 
-//     await dmlHandler.select(SCHEMA, TABLE_NAME, inputObj);
-//     expect(query.mock.calls).toEqual([
-//       ['SELECT * FROM test_schema."test_table" WHERE account_id=$1 AND block_height=$2', Object.values(inputObj)]
-//     ]);
-//   });
+    await dmlHandler.select(SCHEMA, TABLE_NAME, inputObj);
+    expect(query.mock.calls).toEqual([
+      ['SELECT * FROM test_schema."test_table" WHERE account_id=$1 AND block_height=$2', Object.values(inputObj)]
+    ]);
+  });
 
-//   test('Test valid select on two fields with limit', async () => {
-//     const inputObj = {
-//       account_id: 'test_acc_near',
-//       block_height: 999,
-//     };
+  test('Test valid select on two fields with limit', async () => {
+    const inputObj = {
+      account_id: 'test_acc_near',
+      block_height: 999,
+    };
 
-//     const dmlHandler = DmlHandler.createLazy(ACCOUNT, hasuraClient, PgClient);
+    const dmlHandler = DmlHandler.create(getDbConnectionParameters, pgClient);
 
-//     await dmlHandler.select(SCHEMA, TABLE_NAME, inputObj, 1);
-//     expect(query.mock.calls).toEqual([
-//       ['SELECT * FROM test_schema."test_table" WHERE account_id=$1 AND block_height=$2 LIMIT 1', Object.values(inputObj)]
-//     ]);
-//   });
+    await dmlHandler.select(SCHEMA, TABLE_NAME, inputObj, 1);
+    expect(query.mock.calls).toEqual([
+      ['SELECT * FROM test_schema."test_table" WHERE account_id=$1 AND block_height=$2 LIMIT 1', Object.values(inputObj)]
+    ]);
+  });
 
-//   test('Test valid update on two fields', async () => {
-//     const whereObj = {
-//       account_id: 'test_acc_near',
-//       block_height: 999,
-//     };
+  test('Test valid update on two fields', async () => {
+    const whereObj = {
+      account_id: 'test_acc_near',
+      block_height: 999,
+    };
 
-//     const updateObj = {
-//       content: 'test_content',
-//       receipt_id: 111,
-//     };
+    const updateObj = {
+      content: 'test_content',
+      receipt_id: 111,
+    };
 
-//     const dmlHandler = DmlHandler.createLazy(ACCOUNT, hasuraClient, PgClient);
+    const dmlHandler = DmlHandler.create(getDbConnectionParameters, pgClient);
 
-//     await dmlHandler.update(SCHEMA, TABLE_NAME, whereObj, updateObj);
-//     expect(query.mock.calls).toEqual([
-//       ['UPDATE test_schema."test_table" SET content=$1, receipt_id=$2 WHERE account_id=$3 AND block_height=$4 RETURNING *', [...Object.values(updateObj), ...Object.values(whereObj)]]
-//     ]);
-//   });
+    await dmlHandler.update(SCHEMA, TABLE_NAME, whereObj, updateObj);
+    expect(query.mock.calls).toEqual([
+      ['UPDATE test_schema."test_table" SET content=$1, receipt_id=$2 WHERE account_id=$3 AND block_height=$4 RETURNING *', [...Object.values(updateObj), ...Object.values(whereObj)]]
+    ]);
+  });
 
-//   test('Test valid upsert on two fields', async () => {
-//     const inputObj = [{
-//       account_id: 'morgs_near',
-//       block_height: 1,
-//       receipt_id: 'abc'
-//     },
-//     {
-//       account_id: 'morgs_near',
-//       block_height: 2,
-//       receipt_id: 'abc'
-//     }];
+  test('Test valid upsert on two fields', async () => {
+    const inputObj = [{
+      account_id: 'morgs_near',
+      block_height: 1,
+      receipt_id: 'abc'
+    },
+    {
+      account_id: 'morgs_near',
+      block_height: 2,
+      receipt_id: 'abc'
+    }];
 
-//     const conflictCol = ['account_id', 'block_height'];
-//     const updateCol = ['receipt_id'];
+    const conflictCol = ['account_id', 'block_height'];
+    const updateCol = ['receipt_id'];
 
-//     const dmlHandler = DmlHandler.createLazy(ACCOUNT, hasuraClient, PgClient);
+    const dmlHandler = DmlHandler.create(getDbConnectionParameters, pgClient);
 
-//     await dmlHandler.upsert(SCHEMA, TABLE_NAME, inputObj, conflictCol, updateCol);
-//     expect(query.mock.calls).toEqual([
-//       ['INSERT INTO test_schema."test_table" (account_id, block_height, receipt_id) VALUES (\'morgs_near\', \'1\', \'abc\'), (\'morgs_near\', \'2\', \'abc\') ON CONFLICT (account_id, block_height) DO UPDATE SET receipt_id = excluded.receipt_id RETURNING *', []]
-//     ]);
-//   });
+    await dmlHandler.upsert(SCHEMA, TABLE_NAME, inputObj, conflictCol, updateCol);
+    expect(query.mock.calls).toEqual([
+      ['INSERT INTO test_schema."test_table" (account_id, block_height, receipt_id) VALUES (\'morgs_near\', \'1\', \'abc\'), (\'morgs_near\', \'2\', \'abc\') ON CONFLICT (account_id, block_height) DO UPDATE SET receipt_id = excluded.receipt_id RETURNING *', []]
+    ]);
+  });
 
-//   test('Test valid delete on two fields', async () => {
-//     const inputObj = {
-//       account_id: 'test_acc_near',
-//       block_height: 999,
-//     };
+  test('Test valid delete on two fields', async () => {
+    const inputObj = {
+      account_id: 'test_acc_near',
+      block_height: 999,
+    };
 
-//     const dmlHandler = DmlHandler.createLazy(ACCOUNT, hasuraClient, PgClient);
+    const dmlHandler = DmlHandler.create(getDbConnectionParameters, pgClient);
 
-//     await dmlHandler.delete(SCHEMA, TABLE_NAME, inputObj);
-//     expect(query.mock.calls).toEqual([
-//       ['DELETE FROM test_schema."test_table" WHERE account_id=$1 AND block_height=$2 RETURNING *', Object.values(inputObj)]
-//     ]);
-//   });
-// });
+    await dmlHandler.delete(SCHEMA, TABLE_NAME, inputObj);
+    expect(query.mock.calls).toEqual([
+      ['DELETE FROM test_schema."test_table" WHERE account_id=$1 AND block_height=$2 RETURNING *', Object.values(inputObj)]
+    ]);
+  });
+});

--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -1,47 +1,27 @@
 import { wrapError } from '../utility';
-import PgClientModule from '../pg-client';
-import HasuraClient from '../hasura-client/hasura-client';
+import PgClient from '../pg-client';
 
 export default class DmlHandler {
   validTableNameRegex = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
-  getPgClientPromise: Promise<PgClientModule> | null = null;
 
   private constructor (
-    private readonly account: string,
-    private readonly hasuraClient: HasuraClient,
-    private readonly PgClient: typeof PgClientModule
+    private readonly pgClient: PgClient
   ) {}
 
-  static createLazy (
-    account: string,
-    hasuraClient: HasuraClient = new HasuraClient(),
-    PgClient = PgClientModule
+  static create (
+    database_connection_parameters: any,
   ): DmlHandler {
-    return new DmlHandler(account, hasuraClient, PgClient);
-  }
-
-  async initialize (): Promise<PgClientModule> {
-    if (!this.getPgClientPromise) {
-      this.getPgClientPromise = this.getPgClient();
-    }
-    return await this.getPgClientPromise;
-  }
-
-  async getPgClient (): Promise<PgClientModule> {
-    const connectionParameters = await this.hasuraClient.getDbConnectionParameters(this.account);
-    const pgClient = new this.PgClient({
-      user: connectionParameters.username,
-      password: connectionParameters.password,
+    const pgClient = new PgClient({
+      user: database_connection_parameters.username,
+      password: database_connection_parameters.password,
       host: process.env.PGHOST,
-      port: Number(connectionParameters.port),
-      database: connectionParameters.database,
+      port: Number(database_connection_parameters.port),
+      database: database_connection_parameters.database,
     });
-
-    return pgClient;
+    return new DmlHandler(pgClient);
   }
 
   async insert (schemaName: string, tableName: string, objects: any[]): Promise<any[]> {
-    const pgClient = await this.initialize();
     if (!objects?.length) {
       return [];
     }
@@ -51,13 +31,11 @@ export default class DmlHandler {
     const values = objects.map(obj => keys.map(key => obj[key]));
     const query = `INSERT INTO ${schemaName}."${tableName}" (${keys.join(', ')}) VALUES %L RETURNING *`;
 
-    const result = await wrapError(async () => await pgClient.query(pgClient.format(query, values), []), `Failed to execute '${query}' on ${schemaName}."${tableName}".`);
+    const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query, values), []), `Failed to execute '${query}' on ${schemaName}."${tableName}".`);
     return result.rows;
   }
 
   async select (schemaName: string, tableName: string, object: any, limit: number | null = null): Promise<any[]> {
-    const pgClient = await this.initialize();
-
     const keys = Object.keys(object);
     const values = Object.values(object);
     const param = Array.from({ length: keys.length }, (_, index) => `${keys[index]}=$${index + 1}`).join(' AND ');
@@ -66,13 +44,11 @@ export default class DmlHandler {
       query = query.concat(' LIMIT ', Math.round(limit).toString());
     }
 
-    const result = await wrapError(async () => await pgClient.query(pgClient.format(query), values), `Failed to execute '${query}' on ${schemaName}."${tableName}".`);
+    const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query), values), `Failed to execute '${query}' on ${schemaName}."${tableName}".`);
     return result.rows;
   }
 
   async update (schemaName: string, tableName: string, whereObject: any, updateObject: any): Promise<any[]> {
-    const pgClient = await this.initialize();
-
     const updateKeys = Object.keys(updateObject);
     const updateParam = Array.from({ length: updateKeys.length }, (_, index) => `${updateKeys[index]}=$${index + 1}`).join(', ');
     const whereKeys = Object.keys(whereObject);
@@ -81,12 +57,11 @@ export default class DmlHandler {
     const queryValues = [...Object.values(updateObject), ...Object.values(whereObject)];
     const query = `UPDATE ${schemaName}."${tableName}" SET ${updateParam} WHERE ${whereParam} RETURNING *`;
 
-    const result = await wrapError(async () => await pgClient.query(pgClient.format(query), queryValues), `Failed to execute '${query}' on ${schemaName}."${tableName}".`);
+    const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query), queryValues), `Failed to execute '${query}' on ${schemaName}."${tableName}".`);
     return result.rows;
   }
 
   async upsert (schemaName: string, tableName: string, objects: any[], conflictColumns: string[], updateColumns: string[]): Promise<any[]> {
-    const pgClient = await this.initialize();
     if (!objects?.length) {
       return [];
     }
@@ -97,19 +72,17 @@ export default class DmlHandler {
     const updatePlaceholders = updateColumns.map(col => `${col} = excluded.${col}`).join(', ');
     const query = `INSERT INTO ${schemaName}."${tableName}" (${keys.join(', ')}) VALUES %L ON CONFLICT (${conflictColumns.join(', ')}) DO UPDATE SET ${updatePlaceholders} RETURNING *`;
 
-    const result = await wrapError(async () => await pgClient.query(pgClient.format(query, values), []), `Failed to execute '${query}' on ${schemaName}."${tableName}".`);
+    const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query, values), []), `Failed to execute '${query}' on ${schemaName}."${tableName}".`);
     return result.rows;
   }
 
   async delete (schemaName: string, tableName: string, object: any): Promise<any[]> {
-    const pgClient = await this.initialize();
-
     const keys = Object.keys(object);
     const values = Object.values(object);
     const param = Array.from({ length: keys.length }, (_, index) => `${keys[index]}=$${index + 1}`).join(' AND ');
     const query = `DELETE FROM ${schemaName}."${tableName}" WHERE ${param} RETURNING *`;
 
-    const result = await wrapError(async () => await pgClient.query(pgClient.format(query), values), `Failed to execute '${query}' on ${schemaName}."${tableName}".`);
+    const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query), values), `Failed to execute '${query}' on ${schemaName}."${tableName}".`);
     return result.rows;
   }
 }

--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -10,8 +10,9 @@ export default class DmlHandler {
 
   static create (
     database_connection_parameters: any,
+    pgClientInstance: PgClient | undefined = undefined
   ): DmlHandler {
-    const pgClient = new PgClient({
+    const pgClient = pgClientInstance ?? new PgClient({
       user: database_connection_parameters.username,
       password: database_connection_parameters.password,
       host: process.env.PGHOST,

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -1,33 +1,12 @@
 import { startServer as startMetricsServer } from './metrics';
-import RedisClient from './redis-client';
 import startRunnerServer from './server/runner-server';
 import StreamHandler from './stream-handler';
 
 const executors = new Map<string, StreamHandler>();
-const redisClient = new RedisClient();
-const grpcServer = startRunnerServer(executors);
+startRunnerServer(executors);
 
 startMetricsServer().catch((err) => {
   console.error('Failed to start metrics server', err);
 });
 
-void (async function main () {
-  try {
-    const STREAM_HANDLER_THROTTLE_MS = 500;
-    while (true) {
-      const streamKeys = await redisClient.getStreams();
-      streamKeys.forEach((streamKey) => {
-        if (executors.get(streamKey) === undefined) {
-          const streamHandler = new StreamHandler(streamKey);
-          executors.set(streamKey, streamHandler);
-        }
-      });
-      await new Promise((resolve) =>
-        setTimeout(resolve, STREAM_HANDLER_THROTTLE_MS),
-      );
-    }
-  } finally {
-    await redisClient.disconnect();
-    grpcServer.forceShutdown();
-  }
-})();
+void (async function main () {})();

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -8,5 +8,3 @@ startRunnerServer(executors);
 startMetricsServer().catch((err) => {
   console.error('Failed to start metrics server', err);
 });
-
-void (async function main () {})();

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -1,1114 +1,1114 @@
-import { Block, type StreamerMessage } from '@near-lake/primitives';
-import type fetch from 'node-fetch';
-
-import Indexer from './indexer';
-import { VM } from 'vm2';
-import DmlHandler from '../dml-handler/dml-handler';
-import type PgClient from '../pg-client';
-
-describe('Indexer unit tests', () => {
-  const oldEnv = process.env;
-
-  const HASURA_ENDPOINT = 'mock-hasura-endpoint';
-  const HASURA_ADMIN_SECRET = 'mock-hasura-secret';
-  const HASURA_ROLE = 'morgs_near';
-  const INVALID_HASURA_ROLE = 'other_near';
-
-  const INDEXER_NAME = 'morgs.near/test_fn';
-
-  const SIMPLE_SCHEMA = `CREATE TABLE
-    "posts" (
-      "id" SERIAL NOT NULL,
-      "account_id" VARCHAR NOT NULL,
-      "block_height" DECIMAL(58, 0) NOT NULL,
-      "receipt_id" VARCHAR NOT NULL,
-      "content" TEXT NOT NULL,
-      "block_timestamp" DECIMAL(20, 0) NOT NULL,
-      "accounts_liked" JSONB NOT NULL DEFAULT '[]',
-      "last_comment_timestamp" DECIMAL(20, 0),
-      CONSTRAINT "posts_pkey" PRIMARY KEY ("id")
-    );`;
-
-  const SOCIAL_SCHEMA = `
-    CREATE TABLE
-      "posts" (
-        "id" SERIAL NOT NULL,
-        "account_id" VARCHAR NOT NULL,
-        "block_height" DECIMAL(58, 0) NOT NULL,
-        "receipt_id" VARCHAR NOT NULL,
-        "content" TEXT NOT NULL,
-        "block_timestamp" DECIMAL(20, 0) NOT NULL,
-        "accounts_liked" JSONB NOT NULL DEFAULT '[]',
-        "last_comment_timestamp" DECIMAL(20, 0),
-        CONSTRAINT "posts_pkey" PRIMARY KEY ("id")
-      );
-
-    CREATE TABLE
-      "comments" (
-        "id" SERIAL NOT NULL,
-        "post_id" SERIAL NOT NULL,
-        "account_id" VARCHAR NOT NULL,
-        "block_height" DECIMAL(58, 0) NOT NULL,
-        "content" TEXT NOT NULL,
-        "block_timestamp" DECIMAL(20, 0) NOT NULL,
-        "receipt_id" VARCHAR NOT NULL,
-        CONSTRAINT "comments_pkey" PRIMARY KEY ("id")
-      );
-
-    CREATE TABLE
-      "post_likes" (
-        "post_id" SERIAL NOT NULL,
-        "account_id" VARCHAR NOT NULL,
-        "block_height" DECIMAL(58, 0),
-        "block_timestamp" DECIMAL(20, 0) NOT NULL,
-        "receipt_id" VARCHAR NOT NULL,
-        CONSTRAINT "post_likes_pkey" PRIMARY KEY ("post_id", "account_id")
-      );`;
-
-  const STRESS_TEST_SCHEMA = `
-CREATE TABLE creator_quest (
-    account_id VARCHAR PRIMARY KEY,
-    num_components_created INTEGER NOT NULL DEFAULT 0,
-    completed BOOLEAN NOT NULL DEFAULT FALSE
-  );
-
-CREATE TABLE
-  composer_quest (
-    account_id VARCHAR PRIMARY KEY,
-    num_widgets_composed INTEGER NOT NULL DEFAULT 0,
-    completed BOOLEAN NOT NULL DEFAULT FALSE
-  );
-
-CREATE TABLE
-  "contractor - quest" (
-    account_id VARCHAR PRIMARY KEY,
-    num_contracts_deployed INTEGER NOT NULL DEFAULT 0,
-    completed BOOLEAN NOT NULL DEFAULT FALSE
-  );
-
-CREATE TABLE
-  "posts" (
-    "id" SERIAL NOT NULL,
-    "account_id" VARCHAR NOT NULL,
-    "block_height" DECIMAL(58, 0) NOT NULL,
-    "receipt_id" VARCHAR NOT NULL,
-    "content" TEXT NOT NULL,
-    "block_timestamp" DECIMAL(20, 0) NOT NULL,
-    "accounts_liked" JSONB NOT NULL DEFAULT '[]',
-    "last_comment_timestamp" DECIMAL(20, 0),
-    CONSTRAINT "posts_pkey" PRIMARY KEY ("id")
-  );
-
-CREATE TABLE
-  "comments" (
-    "id" SERIAL NOT NULL,
-    "post_id" SERIAL NOT NULL,
-    "account_id" VARCHAR NOT NULL,
-    "block_height" DECIMAL(58, 0) NOT NULL,
-    "content" TEXT NOT NULL,
-    "block_timestamp" DECIMAL(20, 0) NOT NULL,
-    "receipt_id" VARCHAR NOT NULL,
-    CONSTRAINT "comments_pkey" PRIMARY KEY ("id")
-  );
-
-CREATE TABLE
-  "post_likes" (
-    "post_id" SERIAL NOT NULL,
-    "account_id" VARCHAR NOT NULL,
-    "block_height" DECIMAL(58, 0),
-    "block_timestamp" DECIMAL(20, 0) NOT NULL,
-    "receipt_id" VARCHAR NOT NULL,
-    CONSTRAINT "post_likes_pkey" PRIMARY KEY ("post_id", "account_id")
-  );
-
-CREATE UNIQUE INDEX "posts_account_id_block_height_key" ON "posts" ("account_id" ASC, "block_height" ASC);
-
-CREATE UNIQUE INDEX "comments_post_id_account_id_block_height_key" ON "comments" (
-  "post_id" ASC,
-  "account_id" ASC,
-  "block_height" ASC
-);
-
-CREATE INDEX
-  "posts_last_comment_timestamp_idx" ON "posts" ("last_comment_timestamp" DESC);
-
-ALTER TABLE
-  "comments"
-ADD
-  CONSTRAINT "comments_post_id_fkey" FOREIGN KEY ("post_id") REFERENCES "posts" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION;
-
-ALTER TABLE
-  "post_likes"
-ADD
-  CONSTRAINT "post_likes_post_id_fkey" FOREIGN KEY ("post_id") REFERENCES "posts" ("id") ON DELETE CASCADE ON UPDATE NO ACTION;
-
-CREATE TABLE IF NOT EXISTS
-  "My Table1" (id serial PRIMARY KEY);
-
-CREATE TABLE
-  "Another-Table" (id serial PRIMARY KEY);
-
-CREATE TABLE
-IF NOT EXISTS
-  "Third-Table" (id serial PRIMARY KEY);
-
-CREATE TABLE
-  yet_another_table (id serial PRIMARY KEY);
-`;
-  const genericMockFetch = jest.fn()
-    .mockResolvedValue({
-      status: 200,
-      json: async () => ({
-        data: 'mock',
-      }),
-    });
-  const genericMockDmlHandler: any = {
-    createLazy: jest.fn()
-  } as unknown as DmlHandler;
-
-  beforeEach(() => {
-    process.env = {
-      ...oldEnv,
-      HASURA_ENDPOINT,
-      HASURA_ADMIN_SECRET
-    };
-  });
-
-  afterAll(() => {
-    process.env = oldEnv;
-  });
-
-  test('Indexer.runFunctions() should execute all functions against the current block', async () => {
-    const mockFetch = jest.fn(() => ({
-      status: 200,
-      json: async () => ({
-        errors: null,
-      }),
-    }));
-    const blockHeight = 456;
-    const mockBlock = Block.fromStreamerMessage({
-      block: {
-        chunks: [],
-        header: {
-          height: blockHeight
-        }
-      },
-      shards: {}
-    } as unknown as StreamerMessage) as unknown as Block;
-
-    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
-
-    const functions: Record<string, any> = {};
-    functions['buildnear.testnet/test'] = {
-      code: `
-            const foo = 3;
-            block.result = context.graphql(\`mutation { set(functionName: "buildnear.testnet/test", key: "height", data: "\${block.blockHeight}")}\`);
-        `,
-      schema: SIMPLE_SCHEMA
-    };
-    await indexer.runFunctions(mockBlock, functions, false);
-
-    expect(mockFetch.mock.calls).toMatchSnapshot();
-  });
-
-  test('Indexer.transformIndexerFunction() applies the necessary transformations', () => {
-    const indexer = new Indexer();
-
-    const transformedFunction = indexer.transformIndexerFunction('console.log(\'hello\')');
-
-    expect(transformedFunction).toEqual(`
-            async function f(){
-                console.log('hello')
-            };
-            f();
-    `);
-  });
-
-  test('Indexer.buildContext() allows execution of arbitrary GraphQL operations', async () => {
-    const mockFetch = jest.fn()
-      .mockResolvedValueOnce({
-        status: 200,
-        json: async () => ({
-          data: {
-            greet: 'hello'
-          }
-        })
-      })
-      .mockResolvedValueOnce({
-        status: 200,
-        json: async () => ({
-          data: {
-            newGreeting: {
-              success: true
-            }
-          }
-        })
-      });
-    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
-
-    const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, HASURA_ROLE);
-
-    const query = `
-            query {
-                greet()
-            }
-        `;
-    const { greet } = await context.graphql(query) as { greet: string };
-
-    const mutation = `
-            mutation {
-                newGreeting(greeting: "${greet} morgan") {
-                    success
-                }
-            }
-        `;
-    const { newGreeting: { success } } = await context.graphql(mutation);
-
-    expect(greet).toEqual('hello');
-    expect(success).toEqual(true);
-    expect(mockFetch.mock.calls[0]).toEqual([
-            `${HASURA_ENDPOINT}/v1/graphql`,
-            {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-                'X-Hasura-Use-Backend-Only-Permissions': 'true',
-                'X-Hasura-Role': 'morgs_near',
-                'X-Hasura-Admin-Secret': HASURA_ADMIN_SECRET
-              },
-              body: JSON.stringify({ query })
-            }
-    ]);
-    expect(mockFetch.mock.calls[1]).toEqual([
-            `${HASURA_ENDPOINT}/v1/graphql`,
-            {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-                'X-Hasura-Use-Backend-Only-Permissions': 'true',
-                'X-Hasura-Role': 'morgs_near',
-                'X-Hasura-Admin-Secret': HASURA_ADMIN_SECRET
-              },
-              body: JSON.stringify({ query: mutation })
-            }
-    ]);
-  });
-
-  test('Indexer.buildContext() can fetch from the near social api', async () => {
-    const mockFetch = jest.fn();
-    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
-
-    const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, HASURA_ROLE);
-
-    await context.fetchFromSocialApi('/index', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        action: 'post',
-        key: 'main',
-        options: {
-          limit: 1,
-          order: 'desc'
-        }
-      })
-    });
-
-    expect(mockFetch.mock.calls).toMatchSnapshot();
-  });
-
-  test('Indexer.buildContext() throws when a GraphQL response contains errors', async () => {
-    const mockFetch = jest.fn()
-      .mockResolvedValue({
-        json: async () => ({
-          errors: ['boom']
-        })
-      });
-    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
-
-    const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, INVALID_HASURA_ROLE);
-
-    await expect(async () => await context.graphql('query { hello }')).rejects.toThrow('boom');
-  });
-
-  test('Indexer.buildContext() handles GraphQL variables', async () => {
-    const mockFetch = jest.fn()
-      .mockResolvedValue({
-        status: 200,
-        json: async () => ({
-          data: 'mock',
-        }),
-      });
-    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
-
-    const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, HASURA_ROLE);
-
-    const query = 'query($name: String) { hello(name: $name) }';
-    const variables = { name: 'morgan' };
-    await context.graphql(query, variables);
-
-    expect(mockFetch.mock.calls[0]).toEqual([
-            `${HASURA_ENDPOINT}/v1/graphql`,
-            {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-                'X-Hasura-Use-Backend-Only-Permissions': 'true',
-                'X-Hasura-Role': 'morgs_near',
-                'X-Hasura-Admin-Secret': HASURA_ADMIN_SECRET
-              },
-              body: JSON.stringify({
-                query,
-                variables,
-              }),
-            },
-    ]);
-  });
-
-  test('GetTables works for a variety of input schemas', async () => {
-    const indexer = new Indexer();
-
-    const simpleSchemaTables = indexer.getTableNames(SIMPLE_SCHEMA);
-    expect(simpleSchemaTables).toStrictEqual(['posts']);
-
-    const socialSchemaTables = indexer.getTableNames(SOCIAL_SCHEMA);
-    expect(socialSchemaTables).toStrictEqual(['posts', 'comments', 'post_likes']);
-
-    const stressTestSchemaTables = indexer.getTableNames(STRESS_TEST_SCHEMA);
-    expect(stressTestSchemaTables).toStrictEqual([
-      'creator_quest',
-      'composer_quest',
-      'contractor - quest',
-      'posts',
-      'comments',
-      'post_likes',
-      'My Table1',
-      'Another-Table',
-      'Third-Table',
-      'yet_another_table']);
-
-    // Test that duplicate table names throw an error
-    const duplicateTableSchema = `CREATE TABLE
-    "posts" (
-      "id" SERIAL NOT NULL
-    );
-    CREATE TABLE posts (
-      "id" SERIAL NOT NULL
-    );`;
-    expect(() => {
-      indexer.getTableNames(duplicateTableSchema);
-    }).toThrow('Table posts already exists in schema. Table names must be unique. Quotes are not allowed as a differentiator between table names.');
-
-    // Test that schema with no tables throws an error
-    expect(() => {
-      indexer.getTableNames('');
-    }).toThrow('Schema does not have any tables. There should be at least one table.');
-  });
-
-  test('SanitizeTableName works properly on many test cases', async () => {
-    const indexer = new Indexer();
-
-    expect(indexer.sanitizeTableName('table_name')).toStrictEqual('TableName');
-    expect(indexer.sanitizeTableName('tablename')).toStrictEqual('Tablename'); // name is not capitalized
-    expect(indexer.sanitizeTableName('table name')).toStrictEqual('TableName');
-    expect(indexer.sanitizeTableName('table!name!')).toStrictEqual('TableName');
-    expect(indexer.sanitizeTableName('123TABle')).toStrictEqual('_123TABle'); // underscore at beginning
-    expect(indexer.sanitizeTableName('123_tABLE')).toStrictEqual('_123TABLE'); // underscore at beginning, capitalization
-    expect(indexer.sanitizeTableName('some-table_name')).toStrictEqual('SomeTableName');
-    expect(indexer.sanitizeTableName('!@#$%^&*()table@)*&(%#')).toStrictEqual('Table'); // All special characters removed
-    expect(indexer.sanitizeTableName('T_name')).toStrictEqual('TName');
-    expect(indexer.sanitizeTableName('_table')).toStrictEqual('Table'); // Starting underscore was removed
-  });
-
-  test('indexer fails to build context.db due to collision on sanitized table names', async () => {
-    const indexer = new Indexer({ DmlHandler: genericMockDmlHandler });
-
-    const schemaWithDuplicateSanitizedTableNames = `CREATE TABLE
-    "test table" (
-      "id" SERIAL NOT NULL
-    );
-    CREATE TABLE "test!table" (
-      "id" SERIAL NOT NULL
-    );`;
-
-    // Does not outright throw an error but instead returns an empty object
-    expect(indexer.buildDatabaseContext('test_account', 'test_schema_name', schemaWithDuplicateSanitizedTableNames, 1))
-      .toStrictEqual({});
-  });
-
-  test('indexer builds context and inserts an objects into existing table', async () => {
-    const mockDmlHandler: any = {
-      createLazy: jest.fn().mockImplementation(() => {
-        return { insert: jest.fn().mockReturnValue([{ colA: 'valA' }, { colA: 'valA' }]) };
-      })
-    };
-
-    const indexer = new Indexer({
-      fetch: genericMockFetch as unknown as typeof fetch,
-      DmlHandler: mockDmlHandler
-    });
-    const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
-
-    const objToInsert = [{
-      account_id: 'morgs_near',
-      block_height: 1,
-      receipt_id: 'abc',
-      content: 'test',
-      block_timestamp: 800,
-      accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
-    },
-    {
-      account_id: 'morgs_near',
-      block_height: 2,
-      receipt_id: 'abc',
-      content: 'test',
-      block_timestamp: 801,
-      accounts_liked: JSON.stringify(['cwpuzzles.near'])
-    }];
-
-    const result = await context.db.Posts.insert(objToInsert);
-    expect(result.length).toEqual(2);
-  });
-
-  test('indexer builds context and does simultaneous upserts', async () => {
-    const dmlHandlerInstance = DmlHandler.createLazy('test_account');
-    const mockGetPgClient = jest.spyOn(dmlHandlerInstance, 'getPgClient').mockImplementation(async () => {
-      return {
-        query: jest.fn().mockReturnValue({ rows: [] }),
-        format: jest.fn().mockReturnValue('mock')
-      } as unknown as PgClient;
-    });
-    const initializeSpy = jest.spyOn(dmlHandlerInstance, 'initialize');
-    const upsertSpy = jest.spyOn(dmlHandlerInstance, 'upsert');
-    const mockDmlHandler: any = {
-      createLazy: jest.fn().mockReturnValue(dmlHandlerInstance)
-    };
-    const indexer = new Indexer({
-      fetch: genericMockFetch as unknown as typeof fetch,
-      DmlHandler: mockDmlHandler
-    });
-    const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
-    const promises = [];
-
-    for (let i = 1; i <= 100; i++) {
-      const promise = context.db.Posts.upsert(
-        {
-          account_id: 'morgs_near',
-          block_height: i,
-          receipt_id: 'abc',
-          content: 'test_content',
-          block_timestamp: 800,
-          accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
-        },
-        ['account_id', 'block_height'],
-        ['content', 'block_timestamp']
-      );
-      promises.push(promise);
-    }
-    await Promise.all(promises);
-
-    expect(initializeSpy).toHaveBeenCalledTimes(100);
-    expect(upsertSpy).toHaveBeenCalledTimes(100);
-    expect(mockGetPgClient).toHaveBeenCalledTimes(1);
-  });
-
-  test('indexer builds context handles simultaneous initialize errors', async () => {
-    const dmlHandlerInstance = DmlHandler.createLazy('test_account');
-    const mockGetPgClient = jest.spyOn(dmlHandlerInstance, 'getPgClient').mockImplementation(async () => {
-      throw new Error('upstream timeout');
-    });
-    const initializeSpy = jest.spyOn(dmlHandlerInstance, 'initialize');
-    const upsertSpy = jest.spyOn(dmlHandlerInstance, 'upsert');
-    const mockDmlHandler: any = {
-      createLazy: jest.fn().mockReturnValue(dmlHandlerInstance)
-    };
-    const indexer = new Indexer({
-      fetch: genericMockFetch as unknown as typeof fetch,
-      DmlHandler: mockDmlHandler
-    });
-    const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
-    const promises = [];
-
-    for (let i = 1; i <= 100; i++) {
-      const promise = context.db.Posts.upsert(
-        {
-          account_id: 'morgs_near',
-          block_height: i,
-          receipt_id: 'abc',
-          content: 'test_content',
-          block_timestamp: 800,
-          accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
-        },
-        ['account_id', 'block_height'],
-        ['content', 'block_timestamp']
-      );
-      promises.push(promise);
-    }
-    await expect(Promise.all(promises)).rejects.toThrow('upstream timeout');
-
-    expect(initializeSpy).toHaveBeenCalled();
-    expect(upsertSpy).toHaveBeenCalled();
-    expect(mockGetPgClient).toHaveBeenCalledTimes(1);
-  });
-
-  test('indexer builds context and selects objects from existing table', async () => {
-    const selectFn = jest.fn();
-    selectFn.mockImplementation((...args) => {
-      // Expects limit to be last parameter
-      return args[args.length - 1] === null ? [{ colA: 'valA' }, { colA: 'valA' }] : [{ colA: 'valA' }];
-    });
-    const mockDmlHandler: any = {
-      createLazy: jest.fn().mockImplementation(() => {
-        return { select: selectFn };
-      })
-    };
-
-    const indexer = new Indexer({
-      fetch: genericMockFetch as unknown as typeof fetch,
-      DmlHandler: mockDmlHandler
-    });
-    const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
-
-    const objToSelect = {
-      account_id: 'morgs_near',
-      receipt_id: 'abc',
-    };
-    const result = await context.db.Posts.select(objToSelect);
-    expect(result.length).toEqual(2);
-    const resultLimit = await context.db.Posts.select(objToSelect, 1);
-    expect(resultLimit.length).toEqual(1);
-  });
-
-  test('indexer builds context and updates multiple objects from existing table', async () => {
-    const mockDmlHandler: any = {
-      createLazy: jest.fn().mockImplementation(() => {
-        return {
-          update: jest.fn().mockImplementation((_, __, whereObj, updateObj) => {
-            if (whereObj.account_id === 'morgs_near' && updateObj.content === 'test_content') {
-              return [{ colA: 'valA' }, { colA: 'valA' }];
-            }
-            return [{}];
-          })
-        };
-      })
-    };
-
-    const indexer = new Indexer({
-      fetch: genericMockFetch as unknown as typeof fetch,
-      DmlHandler: mockDmlHandler
-    });
-    const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
-
-    const whereObj = {
-      account_id: 'morgs_near',
-      receipt_id: 'abc',
-    };
-    const updateObj = {
-      content: 'test_content',
-      block_timestamp: 805,
-    };
-    const result = await context.db.Posts.update(whereObj, updateObj);
-    expect(result.length).toEqual(2);
-  });
-
-  test('indexer builds context and upserts on existing table', async () => {
-    const mockDmlHandler: any = {
-      createLazy: jest.fn().mockImplementation(() => {
-        return {
-          upsert: jest.fn().mockImplementation((_, __, objects, conflict, update) => {
-            if (objects.length === 2 && conflict.includes('account_id') && update.includes('content')) {
-              return [{ colA: 'valA' }, { colA: 'valA' }];
-            } else if (objects.length === 1 && conflict.includes('account_id') && update.includes('content')) {
-              return [{ colA: 'valA' }];
-            }
-            return [{}];
-          })
-        };
-      })
-    };
-
-    const indexer = new Indexer({
-      fetch: genericMockFetch as unknown as typeof fetch,
-      DmlHandler: mockDmlHandler
-    });
-    const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
-
-    const objToInsert = [{
-      account_id: 'morgs_near',
-      block_height: 1,
-      receipt_id: 'abc',
-      content: 'test',
-      block_timestamp: 800,
-      accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
-    },
-    {
-      account_id: 'morgs_near',
-      block_height: 2,
-      receipt_id: 'abc',
-      content: 'test',
-      block_timestamp: 801,
-      accounts_liked: JSON.stringify(['cwpuzzles.near'])
-    }];
-
-    let result = await context.db.Posts.upsert(objToInsert, ['account_id', 'block_height'], ['content', 'block_timestamp']);
-    expect(result.length).toEqual(2);
-    result = await context.db.Posts.upsert(objToInsert[0], ['account_id', 'block_height'], ['content', 'block_timestamp']);
-    expect(result.length).toEqual(1);
-  });
-
-  test('indexer builds context and deletes objects from existing table', async () => {
-    const mockDmlHandler: any = {
-      createLazy: jest.fn().mockImplementation(() => {
-        return { delete: jest.fn().mockReturnValue([{ colA: 'valA' }, { colA: 'valA' }]) };
-      })
-    };
-
-    const indexer = new Indexer({
-      fetch: genericMockFetch as unknown as typeof fetch,
-      DmlHandler: mockDmlHandler
-    });
-    const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
-
-    const deleteFilter = {
-      account_id: 'morgs_near',
-      receipt_id: 'abc',
-    };
-    const result = await context.db.Posts.delete(deleteFilter);
-    expect(result.length).toEqual(2);
-  });
-
-  test('indexer builds context and verifies all methods generated', async () => {
-    const mockDmlHandler: any = {
-      createLazy: jest.fn()
-    };
-
-    const indexer = new Indexer({
-      fetch: genericMockFetch as unknown as typeof fetch,
-      DmlHandler: mockDmlHandler
-    });
-    const context = indexer.buildContext(STRESS_TEST_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
-
-    expect(Object.keys(context.db)).toStrictEqual([
-      'CreatorQuest',
-      'ComposerQuest',
-      'ContractorQuest',
-      'Posts',
-      'Comments',
-      'PostLikes',
-      'MyTable1',
-      'AnotherTable',
-      'ThirdTable',
-      'YetAnotherTable']);
-    expect(Object.keys(context.db.CreatorQuest)).toStrictEqual([
-      'insert',
-      'select',
-      'update',
-      'upsert',
-      'delete']);
-    expect(Object.keys(context.db.PostLikes)).toStrictEqual([
-      'insert',
-      'select',
-      'update',
-      'upsert',
-      'delete']);
-    expect(Object.keys(context.db.MyTable1)).toStrictEqual([
-      'insert',
-      'select',
-      'update',
-      'upsert',
-      'delete']);
-  });
-
-  test('indexer builds context and returns empty array if failed to generate db methods', async () => {
-    const mockDmlHandler: any = {
-      createLazy: jest.fn()
-    };
-
-    const indexer = new Indexer({
-      fetch: genericMockFetch as unknown as typeof fetch,
-      DmlHandler: mockDmlHandler
-    });
-    const context = indexer.buildContext('', 'morgs.near/social_feed1', 1, 'postgres');
-
-    expect(Object.keys(context.db)).toStrictEqual([]);
-  });
-
-  test('Indexer.runFunctions() allows imperative execution of GraphQL operations', async () => {
-    const postId = 1;
-    const commentId = 2;
-    const blockHeight = 82699904;
-    const mockFetch = jest.fn()
-      .mockReturnValueOnce({ // starting log
-        status: 200,
-        json: async () => ({
-          data: {
-            indexer_log_store: [
-              {
-                id: '12345',
-              },
-            ],
-          },
-        }),
-      })
-      .mockReturnValueOnce({
-        status: 200,
-        json: async () => ({
-          errors: null,
-        }),
-      })
-      .mockReturnValueOnce({ // query
-        status: 200,
-        json: async () => ({
-          data: {
-            posts: [
-              {
-                id: postId,
-              },
-            ],
-          },
-        }),
-      })
-      .mockReturnValueOnce({ // mutation
-        status: 200,
-        json: async () => ({
-          data: {
-            insert_comments: {
-              returning: {
-                id: commentId,
-              },
-            },
-          },
-        }),
-      })
-      .mockReturnValueOnce({
-        status: 200,
-        json: async () => ({
-          errors: null,
-        }),
-      });
-
-    const mockBlock = Block.fromStreamerMessage({
-      block: {
-        chunks: [0],
-        header: {
-          height: blockHeight
-        }
-      },
-      shards: {}
-    } as unknown as StreamerMessage) as unknown as Block;
-    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
-
-    const functions: Record<string, any> = {};
-    functions['buildnear.testnet/test'] = {
-      code: `
-            const { posts } = await context.graphql(\`
-                query {
-                    posts(where: { id: { _eq: 1 } }) {
-                        id
-                    }
-                }
-            \`);
-
-            if (!posts || posts.length === 0) {
-                return;
-            }
-
-            const [post] = posts;
-
-            const { insert_comments: { returning: { id } } } = await context.graphql(\`
-                mutation {
-                    insert_comments(
-                        objects: {account_id: "morgs.near", block_height: \${block.blockHeight}, content: "cool post", post_id: \${post.id}}
-                    ) {
-                        returning {
-                            id
-                        }
-                    }
-                }
-            \`);
-
-            return (\`Created comment \${id} on post \${post.id}\`)
-        `,
-      schema: SIMPLE_SCHEMA
-    };
-
-    await indexer.runFunctions(mockBlock, functions, false);
-
-    expect(mockFetch.mock.calls).toMatchSnapshot();
-  });
-
-  test('Indexer.runFunctions() console.logs', async () => {
-    const logs: string[] = [];
-    const context = {
-      log: (...m: string[]) => {
-        logs.push(...m);
-      }
-    };
-    const vm = new VM();
-    vm.freeze(context, 'context');
-    vm.freeze(context, 'console');
-    await vm.run('console.log("hello", "brave new"); context.log("world")');
-    expect(logs).toEqual(['hello', 'brave new', 'world']);
-  });
-
-  test('Errors thrown in VM can be caught outside the VM', async () => {
-    const vm = new VM();
-    expect(() => {
-      vm.run("throw new Error('boom')");
-    }).toThrow('boom');
-  });
-
-  test('Indexer.runFunctions() catches errors', async () => {
-    const mockFetch = jest.fn(() => ({
-      status: 200,
-      json: async () => ({
-        errors: null,
-      }),
-    }));
-    const blockHeight = 456;
-    const mockBlock = Block.fromStreamerMessage({
-      block: {
-        chunks: [0],
-        header: {
-          height: blockHeight
-        }
-      },
-      shards: {}
-    } as unknown as StreamerMessage) as unknown as Block;
-    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
-
-    const functions: Record<string, any> = {};
-    functions['buildnear.testnet/test'] = {
-      code: `
-            throw new Error('boom');
-        `,
-      schema: SIMPLE_SCHEMA
-    };
-
-    await expect(indexer.runFunctions(mockBlock, functions, false)).rejects.toThrow(new Error('boom'));
-    expect(mockFetch.mock.calls).toMatchSnapshot();
-  });
-
-  test('Indexer.runFunctions() provisions a GraphQL endpoint with the specified schema', async () => {
-    const blockHeight = 82699904;
-    const mockFetch = jest.fn(() => ({
-      status: 200,
-      json: async () => ({
-        errors: null,
-      }),
-    }));
-    const mockBlock = Block.fromStreamerMessage({
-      block: {
-        chunks: [0],
-        header: {
-          height: blockHeight
-        }
-      },
-      shards: {}
-    } as unknown as StreamerMessage) as unknown as Block;
-    const provisioner: any = {
-      isUserApiProvisioned: jest.fn().mockReturnValue(false),
-      provisionUserApi: jest.fn(),
-    };
-    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, provisioner, DmlHandler: genericMockDmlHandler });
-
-    const functions = {
-      'morgs.near/test': {
-        account_id: 'morgs.near',
-        function_name: 'test',
-        code: '',
-        schema: SIMPLE_SCHEMA,
-      }
-    };
-    await indexer.runFunctions(mockBlock, functions, false, { provision: true });
-
-    expect(provisioner.isUserApiProvisioned).toHaveBeenCalledWith('morgs.near', 'test');
-    expect(provisioner.provisionUserApi).toHaveBeenCalledTimes(1);
-    expect(provisioner.provisionUserApi).toHaveBeenCalledWith(
-      'morgs.near',
-      'test',
-      SIMPLE_SCHEMA
-    );
-  });
-
-  test('Indexer.runFunctions() skips provisioning if the endpoint exists', async () => {
-    const blockHeight = 82699904;
-    const mockFetch = jest.fn(() => ({
-      status: 200,
-      json: async () => ({
-        errors: null,
-      }),
-    }));
-    const mockBlock = Block.fromStreamerMessage({
-      block: {
-        chunks: [0],
-        header: {
-          height: blockHeight
-        }
-      },
-      shards: {}
-    } as unknown as StreamerMessage) as unknown as Block;
-    const provisioner: any = {
-      isUserApiProvisioned: jest.fn().mockReturnValue(true),
-      provisionUserApi: jest.fn(),
-    };
-    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, provisioner, DmlHandler: genericMockDmlHandler });
-
-    const functions: Record<string, any> = {
-      'morgs.near/test': {
-        code: '',
-        schema: SIMPLE_SCHEMA,
-      }
-    };
-    await indexer.runFunctions(mockBlock, functions, false, { provision: true });
-
-    expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
-  });
-
-  test('Indexer.runFunctions() supplies the required role to the GraphQL endpoint', async () => {
-    const blockHeight = 82699904;
-    const mockFetch = jest.fn(() => ({
-      status: 200,
-      json: async () => ({
-        errors: null,
-      }),
-    }));
-    const mockBlock = Block.fromStreamerMessage({
-      block: {
-        chunks: [0],
-        header: {
-          height: blockHeight
-        }
-      },
-      shards: {}
-    } as unknown as StreamerMessage) as unknown as Block;
-    const provisioner: any = {
-      isUserApiProvisioned: jest.fn().mockReturnValue(true),
-      provisionUserApi: jest.fn(),
-    };
-    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, provisioner, DmlHandler: genericMockDmlHandler });
-
-    const functions: Record<string, any> = {
-      'morgs.near/test': {
-        code: `
-                    context.graphql(\`mutation { set(functionName: "buildnear.testnet/test", key: "height", data: "\${block.blockHeight}")}\`);
-                `,
-        schema: SIMPLE_SCHEMA,
-      }
-    };
-    await indexer.runFunctions(mockBlock, functions, false, { provision: true });
-
-    expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
-    expect(mockFetch.mock.calls).toMatchSnapshot();
-  });
-
-  test('Indexer.runFunctions() logs provisioning failures', async () => {
-    const blockHeight = 82699904;
-    const mockFetch = jest.fn(() => ({
-      status: 200,
-      json: async () => ({
-        errors: null,
-      }),
-    }));
-    const mockBlock = Block.fromStreamerMessage({
-      block: {
-        chunks: [0],
-        header: {
-          height: blockHeight
-        }
-      },
-      shards: {}
-    } as unknown as StreamerMessage) as unknown as Block;
-    const error = new Error('something went wrong with provisioning');
-    const provisioner: any = {
-      isUserApiProvisioned: jest.fn().mockReturnValue(false),
-      provisionUserApi: jest.fn().mockRejectedValue(error),
-    };
-    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, provisioner, DmlHandler: genericMockDmlHandler });
-
-    const functions: Record<string, any> = {
-      'morgs.near/test': {
-        code: `
-                    context.graphql(\`mutation { set(functionName: "buildnear.testnet/test", key: "height", data: "\${block.blockHeight}")}\`);
-                `,
-        schema: 'schema',
-      }
-    };
-
-    await expect(indexer.runFunctions(mockBlock, functions, false, { provision: true })).rejects.toThrow(error);
-    expect(mockFetch.mock.calls).toMatchSnapshot();
-  });
-
-  test('does not attach the hasura admin secret header when no role specified', async () => {
-    const mockFetch = jest.fn()
-      .mockResolvedValueOnce({
-        status: 200,
-        json: async () => ({
-          data: {}
-        })
-      });
-    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
-    // @ts-expect-error legacy test
-    const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, null);
-
-    const mutation = `
-            mutation {
-                newGreeting(greeting: "howdy") {
-                    success
-                }
-            }
-        `;
-
-    await context.graphql(mutation);
-
-    expect(mockFetch.mock.calls[0]).toEqual([
-            `${HASURA_ENDPOINT}/v1/graphql`,
-            {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-                'X-Hasura-Use-Backend-Only-Permissions': 'true',
-              },
-              body: JSON.stringify({ query: mutation })
-            }
-    ]);
-  });
-
-  test('attaches the backend only header to requests to hasura', async () => {
-    const mockFetch = jest.fn()
-      .mockResolvedValueOnce({
-        status: 200,
-        json: async () => ({
-          data: {}
-        })
-      });
-    const role = 'morgs_near';
-    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
-    const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, HASURA_ROLE);
-
-    const mutation = `
-            mutation {
-                newGreeting(greeting: "howdy") {
-                    success
-                }
-            }
-        `;
-
-    await context.graphql(mutation);
-
-    expect(mockFetch.mock.calls[0]).toEqual([
-            `${HASURA_ENDPOINT}/v1/graphql`,
-            {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-                'X-Hasura-Use-Backend-Only-Permissions': 'true',
-                'X-Hasura-Role': role,
-                'X-Hasura-Admin-Secret': HASURA_ADMIN_SECRET
-              },
-              body: JSON.stringify({ query: mutation })
-            }
-    ]);
-  });
-});
+// import { Block, type StreamerMessage } from '@near-lake/primitives';
+// import type fetch from 'node-fetch';
+
+// import Indexer from './indexer';
+// import { VM } from 'vm2';
+// import DmlHandler from '../dml-handler/dml-handler';
+// import type PgClient from '../pg-client';
+
+// describe('Indexer unit tests', () => {
+//   const oldEnv = process.env;
+
+//   const HASURA_ENDPOINT = 'mock-hasura-endpoint';
+//   const HASURA_ADMIN_SECRET = 'mock-hasura-secret';
+//   const HASURA_ROLE = 'morgs_near';
+//   const INVALID_HASURA_ROLE = 'other_near';
+
+//   const INDEXER_NAME = 'morgs.near/test_fn';
+
+//   const SIMPLE_SCHEMA = `CREATE TABLE
+//     "posts" (
+//       "id" SERIAL NOT NULL,
+//       "account_id" VARCHAR NOT NULL,
+//       "block_height" DECIMAL(58, 0) NOT NULL,
+//       "receipt_id" VARCHAR NOT NULL,
+//       "content" TEXT NOT NULL,
+//       "block_timestamp" DECIMAL(20, 0) NOT NULL,
+//       "accounts_liked" JSONB NOT NULL DEFAULT '[]',
+//       "last_comment_timestamp" DECIMAL(20, 0),
+//       CONSTRAINT "posts_pkey" PRIMARY KEY ("id")
+//     );`;
+
+//   const SOCIAL_SCHEMA = `
+//     CREATE TABLE
+//       "posts" (
+//         "id" SERIAL NOT NULL,
+//         "account_id" VARCHAR NOT NULL,
+//         "block_height" DECIMAL(58, 0) NOT NULL,
+//         "receipt_id" VARCHAR NOT NULL,
+//         "content" TEXT NOT NULL,
+//         "block_timestamp" DECIMAL(20, 0) NOT NULL,
+//         "accounts_liked" JSONB NOT NULL DEFAULT '[]',
+//         "last_comment_timestamp" DECIMAL(20, 0),
+//         CONSTRAINT "posts_pkey" PRIMARY KEY ("id")
+//       );
+
+//     CREATE TABLE
+//       "comments" (
+//         "id" SERIAL NOT NULL,
+//         "post_id" SERIAL NOT NULL,
+//         "account_id" VARCHAR NOT NULL,
+//         "block_height" DECIMAL(58, 0) NOT NULL,
+//         "content" TEXT NOT NULL,
+//         "block_timestamp" DECIMAL(20, 0) NOT NULL,
+//         "receipt_id" VARCHAR NOT NULL,
+//         CONSTRAINT "comments_pkey" PRIMARY KEY ("id")
+//       );
+
+//     CREATE TABLE
+//       "post_likes" (
+//         "post_id" SERIAL NOT NULL,
+//         "account_id" VARCHAR NOT NULL,
+//         "block_height" DECIMAL(58, 0),
+//         "block_timestamp" DECIMAL(20, 0) NOT NULL,
+//         "receipt_id" VARCHAR NOT NULL,
+//         CONSTRAINT "post_likes_pkey" PRIMARY KEY ("post_id", "account_id")
+//       );`;
+
+//   const STRESS_TEST_SCHEMA = `
+// CREATE TABLE creator_quest (
+//     account_id VARCHAR PRIMARY KEY,
+//     num_components_created INTEGER NOT NULL DEFAULT 0,
+//     completed BOOLEAN NOT NULL DEFAULT FALSE
+//   );
+
+// CREATE TABLE
+//   composer_quest (
+//     account_id VARCHAR PRIMARY KEY,
+//     num_widgets_composed INTEGER NOT NULL DEFAULT 0,
+//     completed BOOLEAN NOT NULL DEFAULT FALSE
+//   );
+
+// CREATE TABLE
+//   "contractor - quest" (
+//     account_id VARCHAR PRIMARY KEY,
+//     num_contracts_deployed INTEGER NOT NULL DEFAULT 0,
+//     completed BOOLEAN NOT NULL DEFAULT FALSE
+//   );
+
+// CREATE TABLE
+//   "posts" (
+//     "id" SERIAL NOT NULL,
+//     "account_id" VARCHAR NOT NULL,
+//     "block_height" DECIMAL(58, 0) NOT NULL,
+//     "receipt_id" VARCHAR NOT NULL,
+//     "content" TEXT NOT NULL,
+//     "block_timestamp" DECIMAL(20, 0) NOT NULL,
+//     "accounts_liked" JSONB NOT NULL DEFAULT '[]',
+//     "last_comment_timestamp" DECIMAL(20, 0),
+//     CONSTRAINT "posts_pkey" PRIMARY KEY ("id")
+//   );
+
+// CREATE TABLE
+//   "comments" (
+//     "id" SERIAL NOT NULL,
+//     "post_id" SERIAL NOT NULL,
+//     "account_id" VARCHAR NOT NULL,
+//     "block_height" DECIMAL(58, 0) NOT NULL,
+//     "content" TEXT NOT NULL,
+//     "block_timestamp" DECIMAL(20, 0) NOT NULL,
+//     "receipt_id" VARCHAR NOT NULL,
+//     CONSTRAINT "comments_pkey" PRIMARY KEY ("id")
+//   );
+
+// CREATE TABLE
+//   "post_likes" (
+//     "post_id" SERIAL NOT NULL,
+//     "account_id" VARCHAR NOT NULL,
+//     "block_height" DECIMAL(58, 0),
+//     "block_timestamp" DECIMAL(20, 0) NOT NULL,
+//     "receipt_id" VARCHAR NOT NULL,
+//     CONSTRAINT "post_likes_pkey" PRIMARY KEY ("post_id", "account_id")
+//   );
+
+// CREATE UNIQUE INDEX "posts_account_id_block_height_key" ON "posts" ("account_id" ASC, "block_height" ASC);
+
+// CREATE UNIQUE INDEX "comments_post_id_account_id_block_height_key" ON "comments" (
+//   "post_id" ASC,
+//   "account_id" ASC,
+//   "block_height" ASC
+// );
+
+// CREATE INDEX
+//   "posts_last_comment_timestamp_idx" ON "posts" ("last_comment_timestamp" DESC);
+
+// ALTER TABLE
+//   "comments"
+// ADD
+//   CONSTRAINT "comments_post_id_fkey" FOREIGN KEY ("post_id") REFERENCES "posts" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+// ALTER TABLE
+//   "post_likes"
+// ADD
+//   CONSTRAINT "post_likes_post_id_fkey" FOREIGN KEY ("post_id") REFERENCES "posts" ("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+// CREATE TABLE IF NOT EXISTS
+//   "My Table1" (id serial PRIMARY KEY);
+
+// CREATE TABLE
+//   "Another-Table" (id serial PRIMARY KEY);
+
+// CREATE TABLE
+// IF NOT EXISTS
+//   "Third-Table" (id serial PRIMARY KEY);
+
+// CREATE TABLE
+//   yet_another_table (id serial PRIMARY KEY);
+// `;
+//   const genericMockFetch = jest.fn()
+//     .mockResolvedValue({
+//       status: 200,
+//       json: async () => ({
+//         data: 'mock',
+//       }),
+//     });
+//   const genericMockDmlHandler: any = {
+//     createLazy: jest.fn()
+//   } as unknown as DmlHandler;
+
+//   beforeEach(() => {
+//     process.env = {
+//       ...oldEnv,
+//       HASURA_ENDPOINT,
+//       HASURA_ADMIN_SECRET
+//     };
+//   });
+
+//   afterAll(() => {
+//     process.env = oldEnv;
+//   });
+
+//   test('Indexer.runFunctions() should execute all functions against the current block', async () => {
+//     const mockFetch = jest.fn(() => ({
+//       status: 200,
+//       json: async () => ({
+//         errors: null,
+//       }),
+//     }));
+//     const blockHeight = 456;
+//     const mockBlock = Block.fromStreamerMessage({
+//       block: {
+//         chunks: [],
+//         header: {
+//           height: blockHeight
+//         }
+//       },
+//       shards: {}
+//     } as unknown as StreamerMessage) as unknown as Block;
+
+//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
+
+//     const functions: Record<string, any> = {};
+//     functions['buildnear.testnet/test'] = {
+//       code: `
+//             const foo = 3;
+//             block.result = context.graphql(\`mutation { set(functionName: "buildnear.testnet/test", key: "height", data: "\${block.blockHeight}")}\`);
+//         `,
+//       schema: SIMPLE_SCHEMA
+//     };
+//     await indexer.runFunctions(mockBlock, functions, false);
+
+//     expect(mockFetch.mock.calls).toMatchSnapshot();
+//   });
+
+//   test('Indexer.transformIndexerFunction() applies the necessary transformations', () => {
+//     const indexer = new Indexer();
+
+//     const transformedFunction = indexer.transformIndexerFunction('console.log(\'hello\')');
+
+//     expect(transformedFunction).toEqual(`
+//             async function f(){
+//                 console.log('hello')
+//             };
+//             f();
+//     `);
+//   });
+
+//   test('Indexer.buildContext() allows execution of arbitrary GraphQL operations', async () => {
+//     const mockFetch = jest.fn()
+//       .mockResolvedValueOnce({
+//         status: 200,
+//         json: async () => ({
+//           data: {
+//             greet: 'hello'
+//           }
+//         })
+//       })
+//       .mockResolvedValueOnce({
+//         status: 200,
+//         json: async () => ({
+//           data: {
+//             newGreeting: {
+//               success: true
+//             }
+//           }
+//         })
+//       });
+//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
+
+//     const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, HASURA_ROLE);
+
+//     const query = `
+//             query {
+//                 greet()
+//             }
+//         `;
+//     const { greet } = await context.graphql(query) as { greet: string };
+
+//     const mutation = `
+//             mutation {
+//                 newGreeting(greeting: "${greet} morgan") {
+//                     success
+//                 }
+//             }
+//         `;
+//     const { newGreeting: { success } } = await context.graphql(mutation);
+
+//     expect(greet).toEqual('hello');
+//     expect(success).toEqual(true);
+//     expect(mockFetch.mock.calls[0]).toEqual([
+//             `${HASURA_ENDPOINT}/v1/graphql`,
+//             {
+//               method: 'POST',
+//               headers: {
+//                 'Content-Type': 'application/json',
+//                 'X-Hasura-Use-Backend-Only-Permissions': 'true',
+//                 'X-Hasura-Role': 'morgs_near',
+//                 'X-Hasura-Admin-Secret': HASURA_ADMIN_SECRET
+//               },
+//               body: JSON.stringify({ query })
+//             }
+//     ]);
+//     expect(mockFetch.mock.calls[1]).toEqual([
+//             `${HASURA_ENDPOINT}/v1/graphql`,
+//             {
+//               method: 'POST',
+//               headers: {
+//                 'Content-Type': 'application/json',
+//                 'X-Hasura-Use-Backend-Only-Permissions': 'true',
+//                 'X-Hasura-Role': 'morgs_near',
+//                 'X-Hasura-Admin-Secret': HASURA_ADMIN_SECRET
+//               },
+//               body: JSON.stringify({ query: mutation })
+//             }
+//     ]);
+//   });
+
+//   test('Indexer.buildContext() can fetch from the near social api', async () => {
+//     const mockFetch = jest.fn();
+//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
+
+//     const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, HASURA_ROLE);
+
+//     await context.fetchFromSocialApi('/index', {
+//       method: 'POST',
+//       headers: {
+//         'Content-Type': 'application/json',
+//       },
+//       body: JSON.stringify({
+//         action: 'post',
+//         key: 'main',
+//         options: {
+//           limit: 1,
+//           order: 'desc'
+//         }
+//       })
+//     });
+
+//     expect(mockFetch.mock.calls).toMatchSnapshot();
+//   });
+
+//   test('Indexer.buildContext() throws when a GraphQL response contains errors', async () => {
+//     const mockFetch = jest.fn()
+//       .mockResolvedValue({
+//         json: async () => ({
+//           errors: ['boom']
+//         })
+//       });
+//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
+
+//     const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, INVALID_HASURA_ROLE);
+
+//     await expect(async () => await context.graphql('query { hello }')).rejects.toThrow('boom');
+//   });
+
+//   test('Indexer.buildContext() handles GraphQL variables', async () => {
+//     const mockFetch = jest.fn()
+//       .mockResolvedValue({
+//         status: 200,
+//         json: async () => ({
+//           data: 'mock',
+//         }),
+//       });
+//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
+
+//     const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, HASURA_ROLE);
+
+//     const query = 'query($name: String) { hello(name: $name) }';
+//     const variables = { name: 'morgan' };
+//     await context.graphql(query, variables);
+
+//     expect(mockFetch.mock.calls[0]).toEqual([
+//             `${HASURA_ENDPOINT}/v1/graphql`,
+//             {
+//               method: 'POST',
+//               headers: {
+//                 'Content-Type': 'application/json',
+//                 'X-Hasura-Use-Backend-Only-Permissions': 'true',
+//                 'X-Hasura-Role': 'morgs_near',
+//                 'X-Hasura-Admin-Secret': HASURA_ADMIN_SECRET
+//               },
+//               body: JSON.stringify({
+//                 query,
+//                 variables,
+//               }),
+//             },
+//     ]);
+//   });
+
+//   test('GetTables works for a variety of input schemas', async () => {
+//     const indexer = new Indexer();
+
+//     const simpleSchemaTables = indexer.getTableNames(SIMPLE_SCHEMA);
+//     expect(simpleSchemaTables).toStrictEqual(['posts']);
+
+//     const socialSchemaTables = indexer.getTableNames(SOCIAL_SCHEMA);
+//     expect(socialSchemaTables).toStrictEqual(['posts', 'comments', 'post_likes']);
+
+//     const stressTestSchemaTables = indexer.getTableNames(STRESS_TEST_SCHEMA);
+//     expect(stressTestSchemaTables).toStrictEqual([
+//       'creator_quest',
+//       'composer_quest',
+//       'contractor - quest',
+//       'posts',
+//       'comments',
+//       'post_likes',
+//       'My Table1',
+//       'Another-Table',
+//       'Third-Table',
+//       'yet_another_table']);
+
+//     // Test that duplicate table names throw an error
+//     const duplicateTableSchema = `CREATE TABLE
+//     "posts" (
+//       "id" SERIAL NOT NULL
+//     );
+//     CREATE TABLE posts (
+//       "id" SERIAL NOT NULL
+//     );`;
+//     expect(() => {
+//       indexer.getTableNames(duplicateTableSchema);
+//     }).toThrow('Table posts already exists in schema. Table names must be unique. Quotes are not allowed as a differentiator between table names.');
+
+//     // Test that schema with no tables throws an error
+//     expect(() => {
+//       indexer.getTableNames('');
+//     }).toThrow('Schema does not have any tables. There should be at least one table.');
+//   });
+
+//   test('SanitizeTableName works properly on many test cases', async () => {
+//     const indexer = new Indexer();
+
+//     expect(indexer.sanitizeTableName('table_name')).toStrictEqual('TableName');
+//     expect(indexer.sanitizeTableName('tablename')).toStrictEqual('Tablename'); // name is not capitalized
+//     expect(indexer.sanitizeTableName('table name')).toStrictEqual('TableName');
+//     expect(indexer.sanitizeTableName('table!name!')).toStrictEqual('TableName');
+//     expect(indexer.sanitizeTableName('123TABle')).toStrictEqual('_123TABle'); // underscore at beginning
+//     expect(indexer.sanitizeTableName('123_tABLE')).toStrictEqual('_123TABLE'); // underscore at beginning, capitalization
+//     expect(indexer.sanitizeTableName('some-table_name')).toStrictEqual('SomeTableName');
+//     expect(indexer.sanitizeTableName('!@#$%^&*()table@)*&(%#')).toStrictEqual('Table'); // All special characters removed
+//     expect(indexer.sanitizeTableName('T_name')).toStrictEqual('TName');
+//     expect(indexer.sanitizeTableName('_table')).toStrictEqual('Table'); // Starting underscore was removed
+//   });
+
+//   test('indexer fails to build context.db due to collision on sanitized table names', async () => {
+//     const indexer = new Indexer({ DmlHandler: genericMockDmlHandler });
+
+//     const schemaWithDuplicateSanitizedTableNames = `CREATE TABLE
+//     "test table" (
+//       "id" SERIAL NOT NULL
+//     );
+//     CREATE TABLE "test!table" (
+//       "id" SERIAL NOT NULL
+//     );`;
+
+//     // Does not outright throw an error but instead returns an empty object
+//     expect(indexer.buildDatabaseContext('test_account', 'test_schema_name', schemaWithDuplicateSanitizedTableNames, 1))
+//       .toStrictEqual({});
+//   });
+
+//   test('indexer builds context and inserts an objects into existing table', async () => {
+//     const mockDmlHandler: any = {
+//       createLazy: jest.fn().mockImplementation(() => {
+//         return { insert: jest.fn().mockReturnValue([{ colA: 'valA' }, { colA: 'valA' }]) };
+//       })
+//     };
+
+//     const indexer = new Indexer({
+//       fetch: genericMockFetch as unknown as typeof fetch,
+//       DmlHandler: mockDmlHandler
+//     });
+//     const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
+
+//     const objToInsert = [{
+//       account_id: 'morgs_near',
+//       block_height: 1,
+//       receipt_id: 'abc',
+//       content: 'test',
+//       block_timestamp: 800,
+//       accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
+//     },
+//     {
+//       account_id: 'morgs_near',
+//       block_height: 2,
+//       receipt_id: 'abc',
+//       content: 'test',
+//       block_timestamp: 801,
+//       accounts_liked: JSON.stringify(['cwpuzzles.near'])
+//     }];
+
+//     const result = await context.db.Posts.insert(objToInsert);
+//     expect(result.length).toEqual(2);
+//   });
+
+//   test('indexer builds context and does simultaneous upserts', async () => {
+//     const dmlHandlerInstance = DmlHandler.createLazy('test_account');
+//     const mockGetPgClient = jest.spyOn(dmlHandlerInstance, 'getPgClient').mockImplementation(async () => {
+//       return {
+//         query: jest.fn().mockReturnValue({ rows: [] }),
+//         format: jest.fn().mockReturnValue('mock')
+//       } as unknown as PgClient;
+//     });
+//     const initializeSpy = jest.spyOn(dmlHandlerInstance, 'initialize');
+//     const upsertSpy = jest.spyOn(dmlHandlerInstance, 'upsert');
+//     const mockDmlHandler: any = {
+//       createLazy: jest.fn().mockReturnValue(dmlHandlerInstance)
+//     };
+//     const indexer = new Indexer({
+//       fetch: genericMockFetch as unknown as typeof fetch,
+//       DmlHandler: mockDmlHandler
+//     });
+//     const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
+//     const promises = [];
+
+//     for (let i = 1; i <= 100; i++) {
+//       const promise = context.db.Posts.upsert(
+//         {
+//           account_id: 'morgs_near',
+//           block_height: i,
+//           receipt_id: 'abc',
+//           content: 'test_content',
+//           block_timestamp: 800,
+//           accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
+//         },
+//         ['account_id', 'block_height'],
+//         ['content', 'block_timestamp']
+//       );
+//       promises.push(promise);
+//     }
+//     await Promise.all(promises);
+
+//     expect(initializeSpy).toHaveBeenCalledTimes(100);
+//     expect(upsertSpy).toHaveBeenCalledTimes(100);
+//     expect(mockGetPgClient).toHaveBeenCalledTimes(1);
+//   });
+
+//   test('indexer builds context handles simultaneous initialize errors', async () => {
+//     const dmlHandlerInstance = DmlHandler.createLazy('test_account');
+//     const mockGetPgClient = jest.spyOn(dmlHandlerInstance, 'getPgClient').mockImplementation(async () => {
+//       throw new Error('upstream timeout');
+//     });
+//     const initializeSpy = jest.spyOn(dmlHandlerInstance, 'initialize');
+//     const upsertSpy = jest.spyOn(dmlHandlerInstance, 'upsert');
+//     const mockDmlHandler: any = {
+//       createLazy: jest.fn().mockReturnValue(dmlHandlerInstance)
+//     };
+//     const indexer = new Indexer({
+//       fetch: genericMockFetch as unknown as typeof fetch,
+//       DmlHandler: mockDmlHandler
+//     });
+//     const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
+//     const promises = [];
+
+//     for (let i = 1; i <= 100; i++) {
+//       const promise = context.db.Posts.upsert(
+//         {
+//           account_id: 'morgs_near',
+//           block_height: i,
+//           receipt_id: 'abc',
+//           content: 'test_content',
+//           block_timestamp: 800,
+//           accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
+//         },
+//         ['account_id', 'block_height'],
+//         ['content', 'block_timestamp']
+//       );
+//       promises.push(promise);
+//     }
+//     await expect(Promise.all(promises)).rejects.toThrow('upstream timeout');
+
+//     expect(initializeSpy).toHaveBeenCalled();
+//     expect(upsertSpy).toHaveBeenCalled();
+//     expect(mockGetPgClient).toHaveBeenCalledTimes(1);
+//   });
+
+//   test('indexer builds context and selects objects from existing table', async () => {
+//     const selectFn = jest.fn();
+//     selectFn.mockImplementation((...args) => {
+//       // Expects limit to be last parameter
+//       return args[args.length - 1] === null ? [{ colA: 'valA' }, { colA: 'valA' }] : [{ colA: 'valA' }];
+//     });
+//     const mockDmlHandler: any = {
+//       createLazy: jest.fn().mockImplementation(() => {
+//         return { select: selectFn };
+//       })
+//     };
+
+//     const indexer = new Indexer({
+//       fetch: genericMockFetch as unknown as typeof fetch,
+//       DmlHandler: mockDmlHandler
+//     });
+//     const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
+
+//     const objToSelect = {
+//       account_id: 'morgs_near',
+//       receipt_id: 'abc',
+//     };
+//     const result = await context.db.Posts.select(objToSelect);
+//     expect(result.length).toEqual(2);
+//     const resultLimit = await context.db.Posts.select(objToSelect, 1);
+//     expect(resultLimit.length).toEqual(1);
+//   });
+
+//   test('indexer builds context and updates multiple objects from existing table', async () => {
+//     const mockDmlHandler: any = {
+//       createLazy: jest.fn().mockImplementation(() => {
+//         return {
+//           update: jest.fn().mockImplementation((_, __, whereObj, updateObj) => {
+//             if (whereObj.account_id === 'morgs_near' && updateObj.content === 'test_content') {
+//               return [{ colA: 'valA' }, { colA: 'valA' }];
+//             }
+//             return [{}];
+//           })
+//         };
+//       })
+//     };
+
+//     const indexer = new Indexer({
+//       fetch: genericMockFetch as unknown as typeof fetch,
+//       DmlHandler: mockDmlHandler
+//     });
+//     const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
+
+//     const whereObj = {
+//       account_id: 'morgs_near',
+//       receipt_id: 'abc',
+//     };
+//     const updateObj = {
+//       content: 'test_content',
+//       block_timestamp: 805,
+//     };
+//     const result = await context.db.Posts.update(whereObj, updateObj);
+//     expect(result.length).toEqual(2);
+//   });
+
+//   test('indexer builds context and upserts on existing table', async () => {
+//     const mockDmlHandler: any = {
+//       createLazy: jest.fn().mockImplementation(() => {
+//         return {
+//           upsert: jest.fn().mockImplementation((_, __, objects, conflict, update) => {
+//             if (objects.length === 2 && conflict.includes('account_id') && update.includes('content')) {
+//               return [{ colA: 'valA' }, { colA: 'valA' }];
+//             } else if (objects.length === 1 && conflict.includes('account_id') && update.includes('content')) {
+//               return [{ colA: 'valA' }];
+//             }
+//             return [{}];
+//           })
+//         };
+//       })
+//     };
+
+//     const indexer = new Indexer({
+//       fetch: genericMockFetch as unknown as typeof fetch,
+//       DmlHandler: mockDmlHandler
+//     });
+//     const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
+
+//     const objToInsert = [{
+//       account_id: 'morgs_near',
+//       block_height: 1,
+//       receipt_id: 'abc',
+//       content: 'test',
+//       block_timestamp: 800,
+//       accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
+//     },
+//     {
+//       account_id: 'morgs_near',
+//       block_height: 2,
+//       receipt_id: 'abc',
+//       content: 'test',
+//       block_timestamp: 801,
+//       accounts_liked: JSON.stringify(['cwpuzzles.near'])
+//     }];
+
+//     let result = await context.db.Posts.upsert(objToInsert, ['account_id', 'block_height'], ['content', 'block_timestamp']);
+//     expect(result.length).toEqual(2);
+//     result = await context.db.Posts.upsert(objToInsert[0], ['account_id', 'block_height'], ['content', 'block_timestamp']);
+//     expect(result.length).toEqual(1);
+//   });
+
+//   test('indexer builds context and deletes objects from existing table', async () => {
+//     const mockDmlHandler: any = {
+//       createLazy: jest.fn().mockImplementation(() => {
+//         return { delete: jest.fn().mockReturnValue([{ colA: 'valA' }, { colA: 'valA' }]) };
+//       })
+//     };
+
+//     const indexer = new Indexer({
+//       fetch: genericMockFetch as unknown as typeof fetch,
+//       DmlHandler: mockDmlHandler
+//     });
+//     const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
+
+//     const deleteFilter = {
+//       account_id: 'morgs_near',
+//       receipt_id: 'abc',
+//     };
+//     const result = await context.db.Posts.delete(deleteFilter);
+//     expect(result.length).toEqual(2);
+//   });
+
+//   test('indexer builds context and verifies all methods generated', async () => {
+//     const mockDmlHandler: any = {
+//       createLazy: jest.fn()
+//     };
+
+//     const indexer = new Indexer({
+//       fetch: genericMockFetch as unknown as typeof fetch,
+//       DmlHandler: mockDmlHandler
+//     });
+//     const context = indexer.buildContext(STRESS_TEST_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
+
+//     expect(Object.keys(context.db)).toStrictEqual([
+//       'CreatorQuest',
+//       'ComposerQuest',
+//       'ContractorQuest',
+//       'Posts',
+//       'Comments',
+//       'PostLikes',
+//       'MyTable1',
+//       'AnotherTable',
+//       'ThirdTable',
+//       'YetAnotherTable']);
+//     expect(Object.keys(context.db.CreatorQuest)).toStrictEqual([
+//       'insert',
+//       'select',
+//       'update',
+//       'upsert',
+//       'delete']);
+//     expect(Object.keys(context.db.PostLikes)).toStrictEqual([
+//       'insert',
+//       'select',
+//       'update',
+//       'upsert',
+//       'delete']);
+//     expect(Object.keys(context.db.MyTable1)).toStrictEqual([
+//       'insert',
+//       'select',
+//       'update',
+//       'upsert',
+//       'delete']);
+//   });
+
+//   test('indexer builds context and returns empty array if failed to generate db methods', async () => {
+//     const mockDmlHandler: any = {
+//       createLazy: jest.fn()
+//     };
+
+//     const indexer = new Indexer({
+//       fetch: genericMockFetch as unknown as typeof fetch,
+//       DmlHandler: mockDmlHandler
+//     });
+//     const context = indexer.buildContext('', 'morgs.near/social_feed1', 1, 'postgres');
+
+//     expect(Object.keys(context.db)).toStrictEqual([]);
+//   });
+
+//   test('Indexer.runFunctions() allows imperative execution of GraphQL operations', async () => {
+//     const postId = 1;
+//     const commentId = 2;
+//     const blockHeight = 82699904;
+//     const mockFetch = jest.fn()
+//       .mockReturnValueOnce({ // starting log
+//         status: 200,
+//         json: async () => ({
+//           data: {
+//             indexer_log_store: [
+//               {
+//                 id: '12345',
+//               },
+//             ],
+//           },
+//         }),
+//       })
+//       .mockReturnValueOnce({
+//         status: 200,
+//         json: async () => ({
+//           errors: null,
+//         }),
+//       })
+//       .mockReturnValueOnce({ // query
+//         status: 200,
+//         json: async () => ({
+//           data: {
+//             posts: [
+//               {
+//                 id: postId,
+//               },
+//             ],
+//           },
+//         }),
+//       })
+//       .mockReturnValueOnce({ // mutation
+//         status: 200,
+//         json: async () => ({
+//           data: {
+//             insert_comments: {
+//               returning: {
+//                 id: commentId,
+//               },
+//             },
+//           },
+//         }),
+//       })
+//       .mockReturnValueOnce({
+//         status: 200,
+//         json: async () => ({
+//           errors: null,
+//         }),
+//       });
+
+//     const mockBlock = Block.fromStreamerMessage({
+//       block: {
+//         chunks: [0],
+//         header: {
+//           height: blockHeight
+//         }
+//       },
+//       shards: {}
+//     } as unknown as StreamerMessage) as unknown as Block;
+//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
+
+//     const functions: Record<string, any> = {};
+//     functions['buildnear.testnet/test'] = {
+//       code: `
+//             const { posts } = await context.graphql(\`
+//                 query {
+//                     posts(where: { id: { _eq: 1 } }) {
+//                         id
+//                     }
+//                 }
+//             \`);
+
+//             if (!posts || posts.length === 0) {
+//                 return;
+//             }
+
+//             const [post] = posts;
+
+//             const { insert_comments: { returning: { id } } } = await context.graphql(\`
+//                 mutation {
+//                     insert_comments(
+//                         objects: {account_id: "morgs.near", block_height: \${block.blockHeight}, content: "cool post", post_id: \${post.id}}
+//                     ) {
+//                         returning {
+//                             id
+//                         }
+//                     }
+//                 }
+//             \`);
+
+//             return (\`Created comment \${id} on post \${post.id}\`)
+//         `,
+//       schema: SIMPLE_SCHEMA
+//     };
+
+//     await indexer.runFunctions(mockBlock, functions, false);
+
+//     expect(mockFetch.mock.calls).toMatchSnapshot();
+//   });
+
+//   test('Indexer.runFunctions() console.logs', async () => {
+//     const logs: string[] = [];
+//     const context = {
+//       log: (...m: string[]) => {
+//         logs.push(...m);
+//       }
+//     };
+//     const vm = new VM();
+//     vm.freeze(context, 'context');
+//     vm.freeze(context, 'console');
+//     await vm.run('console.log("hello", "brave new"); context.log("world")');
+//     expect(logs).toEqual(['hello', 'brave new', 'world']);
+//   });
+
+//   test('Errors thrown in VM can be caught outside the VM', async () => {
+//     const vm = new VM();
+//     expect(() => {
+//       vm.run("throw new Error('boom')");
+//     }).toThrow('boom');
+//   });
+
+//   test('Indexer.runFunctions() catches errors', async () => {
+//     const mockFetch = jest.fn(() => ({
+//       status: 200,
+//       json: async () => ({
+//         errors: null,
+//       }),
+//     }));
+//     const blockHeight = 456;
+//     const mockBlock = Block.fromStreamerMessage({
+//       block: {
+//         chunks: [0],
+//         header: {
+//           height: blockHeight
+//         }
+//       },
+//       shards: {}
+//     } as unknown as StreamerMessage) as unknown as Block;
+//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
+
+//     const functions: Record<string, any> = {};
+//     functions['buildnear.testnet/test'] = {
+//       code: `
+//             throw new Error('boom');
+//         `,
+//       schema: SIMPLE_SCHEMA
+//     };
+
+//     await expect(indexer.runFunctions(mockBlock, functions, false)).rejects.toThrow(new Error('boom'));
+//     expect(mockFetch.mock.calls).toMatchSnapshot();
+//   });
+
+//   test('Indexer.runFunctions() provisions a GraphQL endpoint with the specified schema', async () => {
+//     const blockHeight = 82699904;
+//     const mockFetch = jest.fn(() => ({
+//       status: 200,
+//       json: async () => ({
+//         errors: null,
+//       }),
+//     }));
+//     const mockBlock = Block.fromStreamerMessage({
+//       block: {
+//         chunks: [0],
+//         header: {
+//           height: blockHeight
+//         }
+//       },
+//       shards: {}
+//     } as unknown as StreamerMessage) as unknown as Block;
+//     const provisioner: any = {
+//       isUserApiProvisioned: jest.fn().mockReturnValue(false),
+//       provisionUserApi: jest.fn(),
+//     };
+//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, provisioner, DmlHandler: genericMockDmlHandler });
+
+//     const functions = {
+//       'morgs.near/test': {
+//         account_id: 'morgs.near',
+//         function_name: 'test',
+//         code: '',
+//         schema: SIMPLE_SCHEMA,
+//       }
+//     };
+//     await indexer.runFunctions(mockBlock, functions, false, { provision: true });
+
+//     expect(provisioner.isUserApiProvisioned).toHaveBeenCalledWith('morgs.near', 'test');
+//     expect(provisioner.provisionUserApi).toHaveBeenCalledTimes(1);
+//     expect(provisioner.provisionUserApi).toHaveBeenCalledWith(
+//       'morgs.near',
+//       'test',
+//       SIMPLE_SCHEMA
+//     );
+//   });
+
+//   test('Indexer.runFunctions() skips provisioning if the endpoint exists', async () => {
+//     const blockHeight = 82699904;
+//     const mockFetch = jest.fn(() => ({
+//       status: 200,
+//       json: async () => ({
+//         errors: null,
+//       }),
+//     }));
+//     const mockBlock = Block.fromStreamerMessage({
+//       block: {
+//         chunks: [0],
+//         header: {
+//           height: blockHeight
+//         }
+//       },
+//       shards: {}
+//     } as unknown as StreamerMessage) as unknown as Block;
+//     const provisioner: any = {
+//       isUserApiProvisioned: jest.fn().mockReturnValue(true),
+//       provisionUserApi: jest.fn(),
+//     };
+//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, provisioner, DmlHandler: genericMockDmlHandler });
+
+//     const functions: Record<string, any> = {
+//       'morgs.near/test': {
+//         code: '',
+//         schema: SIMPLE_SCHEMA,
+//       }
+//     };
+//     await indexer.runFunctions(mockBlock, functions, false, { provision: true });
+
+//     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
+//   });
+
+//   test('Indexer.runFunctions() supplies the required role to the GraphQL endpoint', async () => {
+//     const blockHeight = 82699904;
+//     const mockFetch = jest.fn(() => ({
+//       status: 200,
+//       json: async () => ({
+//         errors: null,
+//       }),
+//     }));
+//     const mockBlock = Block.fromStreamerMessage({
+//       block: {
+//         chunks: [0],
+//         header: {
+//           height: blockHeight
+//         }
+//       },
+//       shards: {}
+//     } as unknown as StreamerMessage) as unknown as Block;
+//     const provisioner: any = {
+//       isUserApiProvisioned: jest.fn().mockReturnValue(true),
+//       provisionUserApi: jest.fn(),
+//     };
+//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, provisioner, DmlHandler: genericMockDmlHandler });
+
+//     const functions: Record<string, any> = {
+//       'morgs.near/test': {
+//         code: `
+//                     context.graphql(\`mutation { set(functionName: "buildnear.testnet/test", key: "height", data: "\${block.blockHeight}")}\`);
+//                 `,
+//         schema: SIMPLE_SCHEMA,
+//       }
+//     };
+//     await indexer.runFunctions(mockBlock, functions, false, { provision: true });
+
+//     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
+//     expect(mockFetch.mock.calls).toMatchSnapshot();
+//   });
+
+//   test('Indexer.runFunctions() logs provisioning failures', async () => {
+//     const blockHeight = 82699904;
+//     const mockFetch = jest.fn(() => ({
+//       status: 200,
+//       json: async () => ({
+//         errors: null,
+//       }),
+//     }));
+//     const mockBlock = Block.fromStreamerMessage({
+//       block: {
+//         chunks: [0],
+//         header: {
+//           height: blockHeight
+//         }
+//       },
+//       shards: {}
+//     } as unknown as StreamerMessage) as unknown as Block;
+//     const error = new Error('something went wrong with provisioning');
+//     const provisioner: any = {
+//       isUserApiProvisioned: jest.fn().mockReturnValue(false),
+//       provisionUserApi: jest.fn().mockRejectedValue(error),
+//     };
+//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, provisioner, DmlHandler: genericMockDmlHandler });
+
+//     const functions: Record<string, any> = {
+//       'morgs.near/test': {
+//         code: `
+//                     context.graphql(\`mutation { set(functionName: "buildnear.testnet/test", key: "height", data: "\${block.blockHeight}")}\`);
+//                 `,
+//         schema: 'schema',
+//       }
+//     };
+
+//     await expect(indexer.runFunctions(mockBlock, functions, false, { provision: true })).rejects.toThrow(error);
+//     expect(mockFetch.mock.calls).toMatchSnapshot();
+//   });
+
+//   test('does not attach the hasura admin secret header when no role specified', async () => {
+//     const mockFetch = jest.fn()
+//       .mockResolvedValueOnce({
+//         status: 200,
+//         json: async () => ({
+//           data: {}
+//         })
+//       });
+//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
+//     // @ts-expect-error legacy test
+//     const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, null);
+
+//     const mutation = `
+//             mutation {
+//                 newGreeting(greeting: "howdy") {
+//                     success
+//                 }
+//             }
+//         `;
+
+//     await context.graphql(mutation);
+
+//     expect(mockFetch.mock.calls[0]).toEqual([
+//             `${HASURA_ENDPOINT}/v1/graphql`,
+//             {
+//               method: 'POST',
+//               headers: {
+//                 'Content-Type': 'application/json',
+//                 'X-Hasura-Use-Backend-Only-Permissions': 'true',
+//               },
+//               body: JSON.stringify({ query: mutation })
+//             }
+//     ]);
+//   });
+
+//   test('attaches the backend only header to requests to hasura', async () => {
+//     const mockFetch = jest.fn()
+//       .mockResolvedValueOnce({
+//         status: 200,
+//         json: async () => ({
+//           data: {}
+//         })
+//       });
+//     const role = 'morgs_near';
+//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
+//     const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, HASURA_ROLE);
+
+//     const mutation = `
+//             mutation {
+//                 newGreeting(greeting: "howdy") {
+//                     success
+//                 }
+//             }
+//         `;
+
+//     await context.graphql(mutation);
+
+//     expect(mockFetch.mock.calls[0]).toEqual([
+//             `${HASURA_ENDPOINT}/v1/graphql`,
+//             {
+//               method: 'POST',
+//               headers: {
+//                 'Content-Type': 'application/json',
+//                 'X-Hasura-Use-Backend-Only-Permissions': 'true',
+//                 'X-Hasura-Role': role,
+//                 'X-Hasura-Admin-Secret': HASURA_ADMIN_SECRET
+//               },
+//               body: JSON.stringify({ query: mutation })
+//             }
+//     ]);
+//   });
+// });

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -1,1114 +1,1086 @@
-// import { Block, type StreamerMessage } from '@near-lake/primitives';
-// import type fetch from 'node-fetch';
-
-// import Indexer from './indexer';
-// import { VM } from 'vm2';
-// import DmlHandler from '../dml-handler/dml-handler';
-// import type PgClient from '../pg-client';
-
-// describe('Indexer unit tests', () => {
-//   const oldEnv = process.env;
-
-//   const HASURA_ENDPOINT = 'mock-hasura-endpoint';
-//   const HASURA_ADMIN_SECRET = 'mock-hasura-secret';
-//   const HASURA_ROLE = 'morgs_near';
-//   const INVALID_HASURA_ROLE = 'other_near';
-
-//   const INDEXER_NAME = 'morgs.near/test_fn';
-
-//   const SIMPLE_SCHEMA = `CREATE TABLE
-//     "posts" (
-//       "id" SERIAL NOT NULL,
-//       "account_id" VARCHAR NOT NULL,
-//       "block_height" DECIMAL(58, 0) NOT NULL,
-//       "receipt_id" VARCHAR NOT NULL,
-//       "content" TEXT NOT NULL,
-//       "block_timestamp" DECIMAL(20, 0) NOT NULL,
-//       "accounts_liked" JSONB NOT NULL DEFAULT '[]',
-//       "last_comment_timestamp" DECIMAL(20, 0),
-//       CONSTRAINT "posts_pkey" PRIMARY KEY ("id")
-//     );`;
-
-//   const SOCIAL_SCHEMA = `
-//     CREATE TABLE
-//       "posts" (
-//         "id" SERIAL NOT NULL,
-//         "account_id" VARCHAR NOT NULL,
-//         "block_height" DECIMAL(58, 0) NOT NULL,
-//         "receipt_id" VARCHAR NOT NULL,
-//         "content" TEXT NOT NULL,
-//         "block_timestamp" DECIMAL(20, 0) NOT NULL,
-//         "accounts_liked" JSONB NOT NULL DEFAULT '[]',
-//         "last_comment_timestamp" DECIMAL(20, 0),
-//         CONSTRAINT "posts_pkey" PRIMARY KEY ("id")
-//       );
-
-//     CREATE TABLE
-//       "comments" (
-//         "id" SERIAL NOT NULL,
-//         "post_id" SERIAL NOT NULL,
-//         "account_id" VARCHAR NOT NULL,
-//         "block_height" DECIMAL(58, 0) NOT NULL,
-//         "content" TEXT NOT NULL,
-//         "block_timestamp" DECIMAL(20, 0) NOT NULL,
-//         "receipt_id" VARCHAR NOT NULL,
-//         CONSTRAINT "comments_pkey" PRIMARY KEY ("id")
-//       );
-
-//     CREATE TABLE
-//       "post_likes" (
-//         "post_id" SERIAL NOT NULL,
-//         "account_id" VARCHAR NOT NULL,
-//         "block_height" DECIMAL(58, 0),
-//         "block_timestamp" DECIMAL(20, 0) NOT NULL,
-//         "receipt_id" VARCHAR NOT NULL,
-//         CONSTRAINT "post_likes_pkey" PRIMARY KEY ("post_id", "account_id")
-//       );`;
-
-//   const STRESS_TEST_SCHEMA = `
-// CREATE TABLE creator_quest (
-//     account_id VARCHAR PRIMARY KEY,
-//     num_components_created INTEGER NOT NULL DEFAULT 0,
-//     completed BOOLEAN NOT NULL DEFAULT FALSE
-//   );
-
-// CREATE TABLE
-//   composer_quest (
-//     account_id VARCHAR PRIMARY KEY,
-//     num_widgets_composed INTEGER NOT NULL DEFAULT 0,
-//     completed BOOLEAN NOT NULL DEFAULT FALSE
-//   );
-
-// CREATE TABLE
-//   "contractor - quest" (
-//     account_id VARCHAR PRIMARY KEY,
-//     num_contracts_deployed INTEGER NOT NULL DEFAULT 0,
-//     completed BOOLEAN NOT NULL DEFAULT FALSE
-//   );
-
-// CREATE TABLE
-//   "posts" (
-//     "id" SERIAL NOT NULL,
-//     "account_id" VARCHAR NOT NULL,
-//     "block_height" DECIMAL(58, 0) NOT NULL,
-//     "receipt_id" VARCHAR NOT NULL,
-//     "content" TEXT NOT NULL,
-//     "block_timestamp" DECIMAL(20, 0) NOT NULL,
-//     "accounts_liked" JSONB NOT NULL DEFAULT '[]',
-//     "last_comment_timestamp" DECIMAL(20, 0),
-//     CONSTRAINT "posts_pkey" PRIMARY KEY ("id")
-//   );
-
-// CREATE TABLE
-//   "comments" (
-//     "id" SERIAL NOT NULL,
-//     "post_id" SERIAL NOT NULL,
-//     "account_id" VARCHAR NOT NULL,
-//     "block_height" DECIMAL(58, 0) NOT NULL,
-//     "content" TEXT NOT NULL,
-//     "block_timestamp" DECIMAL(20, 0) NOT NULL,
-//     "receipt_id" VARCHAR NOT NULL,
-//     CONSTRAINT "comments_pkey" PRIMARY KEY ("id")
-//   );
-
-// CREATE TABLE
-//   "post_likes" (
-//     "post_id" SERIAL NOT NULL,
-//     "account_id" VARCHAR NOT NULL,
-//     "block_height" DECIMAL(58, 0),
-//     "block_timestamp" DECIMAL(20, 0) NOT NULL,
-//     "receipt_id" VARCHAR NOT NULL,
-//     CONSTRAINT "post_likes_pkey" PRIMARY KEY ("post_id", "account_id")
-//   );
-
-// CREATE UNIQUE INDEX "posts_account_id_block_height_key" ON "posts" ("account_id" ASC, "block_height" ASC);
-
-// CREATE UNIQUE INDEX "comments_post_id_account_id_block_height_key" ON "comments" (
-//   "post_id" ASC,
-//   "account_id" ASC,
-//   "block_height" ASC
-// );
-
-// CREATE INDEX
-//   "posts_last_comment_timestamp_idx" ON "posts" ("last_comment_timestamp" DESC);
-
-// ALTER TABLE
-//   "comments"
-// ADD
-//   CONSTRAINT "comments_post_id_fkey" FOREIGN KEY ("post_id") REFERENCES "posts" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION;
-
-// ALTER TABLE
-//   "post_likes"
-// ADD
-//   CONSTRAINT "post_likes_post_id_fkey" FOREIGN KEY ("post_id") REFERENCES "posts" ("id") ON DELETE CASCADE ON UPDATE NO ACTION;
-
-// CREATE TABLE IF NOT EXISTS
-//   "My Table1" (id serial PRIMARY KEY);
-
-// CREATE TABLE
-//   "Another-Table" (id serial PRIMARY KEY);
-
-// CREATE TABLE
-// IF NOT EXISTS
-//   "Third-Table" (id serial PRIMARY KEY);
-
-// CREATE TABLE
-//   yet_another_table (id serial PRIMARY KEY);
-// `;
-//   const genericMockFetch = jest.fn()
-//     .mockResolvedValue({
-//       status: 200,
-//       json: async () => ({
-//         data: 'mock',
-//       }),
-//     });
-//   const genericMockDmlHandler: any = {
-//     createLazy: jest.fn()
-//   } as unknown as DmlHandler;
-
-//   beforeEach(() => {
-//     process.env = {
-//       ...oldEnv,
-//       HASURA_ENDPOINT,
-//       HASURA_ADMIN_SECRET
-//     };
-//   });
-
-//   afterAll(() => {
-//     process.env = oldEnv;
-//   });
-
-//   test('Indexer.runFunctions() should execute all functions against the current block', async () => {
-//     const mockFetch = jest.fn(() => ({
-//       status: 200,
-//       json: async () => ({
-//         errors: null,
-//       }),
-//     }));
-//     const blockHeight = 456;
-//     const mockBlock = Block.fromStreamerMessage({
-//       block: {
-//         chunks: [],
-//         header: {
-//           height: blockHeight
-//         }
-//       },
-//       shards: {}
-//     } as unknown as StreamerMessage) as unknown as Block;
-
-//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
-
-//     const functions: Record<string, any> = {};
-//     functions['buildnear.testnet/test'] = {
-//       code: `
-//             const foo = 3;
-//             block.result = context.graphql(\`mutation { set(functionName: "buildnear.testnet/test", key: "height", data: "\${block.blockHeight}")}\`);
-//         `,
-//       schema: SIMPLE_SCHEMA
-//     };
-//     await indexer.runFunctions(mockBlock, functions, false);
-
-//     expect(mockFetch.mock.calls).toMatchSnapshot();
-//   });
-
-//   test('Indexer.transformIndexerFunction() applies the necessary transformations', () => {
-//     const indexer = new Indexer();
-
-//     const transformedFunction = indexer.transformIndexerFunction('console.log(\'hello\')');
-
-//     expect(transformedFunction).toEqual(`
-//             async function f(){
-//                 console.log('hello')
-//             };
-//             f();
-//     `);
-//   });
-
-//   test('Indexer.buildContext() allows execution of arbitrary GraphQL operations', async () => {
-//     const mockFetch = jest.fn()
-//       .mockResolvedValueOnce({
-//         status: 200,
-//         json: async () => ({
-//           data: {
-//             greet: 'hello'
-//           }
-//         })
-//       })
-//       .mockResolvedValueOnce({
-//         status: 200,
-//         json: async () => ({
-//           data: {
-//             newGreeting: {
-//               success: true
-//             }
-//           }
-//         })
-//       });
-//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
-
-//     const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, HASURA_ROLE);
-
-//     const query = `
-//             query {
-//                 greet()
-//             }
-//         `;
-//     const { greet } = await context.graphql(query) as { greet: string };
-
-//     const mutation = `
-//             mutation {
-//                 newGreeting(greeting: "${greet} morgan") {
-//                     success
-//                 }
-//             }
-//         `;
-//     const { newGreeting: { success } } = await context.graphql(mutation);
-
-//     expect(greet).toEqual('hello');
-//     expect(success).toEqual(true);
-//     expect(mockFetch.mock.calls[0]).toEqual([
-//             `${HASURA_ENDPOINT}/v1/graphql`,
-//             {
-//               method: 'POST',
-//               headers: {
-//                 'Content-Type': 'application/json',
-//                 'X-Hasura-Use-Backend-Only-Permissions': 'true',
-//                 'X-Hasura-Role': 'morgs_near',
-//                 'X-Hasura-Admin-Secret': HASURA_ADMIN_SECRET
-//               },
-//               body: JSON.stringify({ query })
-//             }
-//     ]);
-//     expect(mockFetch.mock.calls[1]).toEqual([
-//             `${HASURA_ENDPOINT}/v1/graphql`,
-//             {
-//               method: 'POST',
-//               headers: {
-//                 'Content-Type': 'application/json',
-//                 'X-Hasura-Use-Backend-Only-Permissions': 'true',
-//                 'X-Hasura-Role': 'morgs_near',
-//                 'X-Hasura-Admin-Secret': HASURA_ADMIN_SECRET
-//               },
-//               body: JSON.stringify({ query: mutation })
-//             }
-//     ]);
-//   });
-
-//   test('Indexer.buildContext() can fetch from the near social api', async () => {
-//     const mockFetch = jest.fn();
-//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
-
-//     const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, HASURA_ROLE);
-
-//     await context.fetchFromSocialApi('/index', {
-//       method: 'POST',
-//       headers: {
-//         'Content-Type': 'application/json',
-//       },
-//       body: JSON.stringify({
-//         action: 'post',
-//         key: 'main',
-//         options: {
-//           limit: 1,
-//           order: 'desc'
-//         }
-//       })
-//     });
-
-//     expect(mockFetch.mock.calls).toMatchSnapshot();
-//   });
-
-//   test('Indexer.buildContext() throws when a GraphQL response contains errors', async () => {
-//     const mockFetch = jest.fn()
-//       .mockResolvedValue({
-//         json: async () => ({
-//           errors: ['boom']
-//         })
-//       });
-//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
-
-//     const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, INVALID_HASURA_ROLE);
-
-//     await expect(async () => await context.graphql('query { hello }')).rejects.toThrow('boom');
-//   });
-
-//   test('Indexer.buildContext() handles GraphQL variables', async () => {
-//     const mockFetch = jest.fn()
-//       .mockResolvedValue({
-//         status: 200,
-//         json: async () => ({
-//           data: 'mock',
-//         }),
-//       });
-//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
-
-//     const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, HASURA_ROLE);
-
-//     const query = 'query($name: String) { hello(name: $name) }';
-//     const variables = { name: 'morgan' };
-//     await context.graphql(query, variables);
-
-//     expect(mockFetch.mock.calls[0]).toEqual([
-//             `${HASURA_ENDPOINT}/v1/graphql`,
-//             {
-//               method: 'POST',
-//               headers: {
-//                 'Content-Type': 'application/json',
-//                 'X-Hasura-Use-Backend-Only-Permissions': 'true',
-//                 'X-Hasura-Role': 'morgs_near',
-//                 'X-Hasura-Admin-Secret': HASURA_ADMIN_SECRET
-//               },
-//               body: JSON.stringify({
-//                 query,
-//                 variables,
-//               }),
-//             },
-//     ]);
-//   });
-
-//   test('GetTables works for a variety of input schemas', async () => {
-//     const indexer = new Indexer();
-
-//     const simpleSchemaTables = indexer.getTableNames(SIMPLE_SCHEMA);
-//     expect(simpleSchemaTables).toStrictEqual(['posts']);
-
-//     const socialSchemaTables = indexer.getTableNames(SOCIAL_SCHEMA);
-//     expect(socialSchemaTables).toStrictEqual(['posts', 'comments', 'post_likes']);
-
-//     const stressTestSchemaTables = indexer.getTableNames(STRESS_TEST_SCHEMA);
-//     expect(stressTestSchemaTables).toStrictEqual([
-//       'creator_quest',
-//       'composer_quest',
-//       'contractor - quest',
-//       'posts',
-//       'comments',
-//       'post_likes',
-//       'My Table1',
-//       'Another-Table',
-//       'Third-Table',
-//       'yet_another_table']);
-
-//     // Test that duplicate table names throw an error
-//     const duplicateTableSchema = `CREATE TABLE
-//     "posts" (
-//       "id" SERIAL NOT NULL
-//     );
-//     CREATE TABLE posts (
-//       "id" SERIAL NOT NULL
-//     );`;
-//     expect(() => {
-//       indexer.getTableNames(duplicateTableSchema);
-//     }).toThrow('Table posts already exists in schema. Table names must be unique. Quotes are not allowed as a differentiator between table names.');
-
-//     // Test that schema with no tables throws an error
-//     expect(() => {
-//       indexer.getTableNames('');
-//     }).toThrow('Schema does not have any tables. There should be at least one table.');
-//   });
-
-//   test('SanitizeTableName works properly on many test cases', async () => {
-//     const indexer = new Indexer();
-
-//     expect(indexer.sanitizeTableName('table_name')).toStrictEqual('TableName');
-//     expect(indexer.sanitizeTableName('tablename')).toStrictEqual('Tablename'); // name is not capitalized
-//     expect(indexer.sanitizeTableName('table name')).toStrictEqual('TableName');
-//     expect(indexer.sanitizeTableName('table!name!')).toStrictEqual('TableName');
-//     expect(indexer.sanitizeTableName('123TABle')).toStrictEqual('_123TABle'); // underscore at beginning
-//     expect(indexer.sanitizeTableName('123_tABLE')).toStrictEqual('_123TABLE'); // underscore at beginning, capitalization
-//     expect(indexer.sanitizeTableName('some-table_name')).toStrictEqual('SomeTableName');
-//     expect(indexer.sanitizeTableName('!@#$%^&*()table@)*&(%#')).toStrictEqual('Table'); // All special characters removed
-//     expect(indexer.sanitizeTableName('T_name')).toStrictEqual('TName');
-//     expect(indexer.sanitizeTableName('_table')).toStrictEqual('Table'); // Starting underscore was removed
-//   });
-
-//   test('indexer fails to build context.db due to collision on sanitized table names', async () => {
-//     const indexer = new Indexer({ DmlHandler: genericMockDmlHandler });
-
-//     const schemaWithDuplicateSanitizedTableNames = `CREATE TABLE
-//     "test table" (
-//       "id" SERIAL NOT NULL
-//     );
-//     CREATE TABLE "test!table" (
-//       "id" SERIAL NOT NULL
-//     );`;
-
-//     // Does not outright throw an error but instead returns an empty object
-//     expect(indexer.buildDatabaseContext('test_account', 'test_schema_name', schemaWithDuplicateSanitizedTableNames, 1))
-//       .toStrictEqual({});
-//   });
-
-//   test('indexer builds context and inserts an objects into existing table', async () => {
-//     const mockDmlHandler: any = {
-//       createLazy: jest.fn().mockImplementation(() => {
-//         return { insert: jest.fn().mockReturnValue([{ colA: 'valA' }, { colA: 'valA' }]) };
-//       })
-//     };
-
-//     const indexer = new Indexer({
-//       fetch: genericMockFetch as unknown as typeof fetch,
-//       DmlHandler: mockDmlHandler
-//     });
-//     const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
-
-//     const objToInsert = [{
-//       account_id: 'morgs_near',
-//       block_height: 1,
-//       receipt_id: 'abc',
-//       content: 'test',
-//       block_timestamp: 800,
-//       accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
-//     },
-//     {
-//       account_id: 'morgs_near',
-//       block_height: 2,
-//       receipt_id: 'abc',
-//       content: 'test',
-//       block_timestamp: 801,
-//       accounts_liked: JSON.stringify(['cwpuzzles.near'])
-//     }];
-
-//     const result = await context.db.Posts.insert(objToInsert);
-//     expect(result.length).toEqual(2);
-//   });
-
-//   test('indexer builds context and does simultaneous upserts', async () => {
-//     const dmlHandlerInstance = DmlHandler.createLazy('test_account');
-//     const mockGetPgClient = jest.spyOn(dmlHandlerInstance, 'getPgClient').mockImplementation(async () => {
-//       return {
-//         query: jest.fn().mockReturnValue({ rows: [] }),
-//         format: jest.fn().mockReturnValue('mock')
-//       } as unknown as PgClient;
-//     });
-//     const initializeSpy = jest.spyOn(dmlHandlerInstance, 'initialize');
-//     const upsertSpy = jest.spyOn(dmlHandlerInstance, 'upsert');
-//     const mockDmlHandler: any = {
-//       createLazy: jest.fn().mockReturnValue(dmlHandlerInstance)
-//     };
-//     const indexer = new Indexer({
-//       fetch: genericMockFetch as unknown as typeof fetch,
-//       DmlHandler: mockDmlHandler
-//     });
-//     const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
-//     const promises = [];
-
-//     for (let i = 1; i <= 100; i++) {
-//       const promise = context.db.Posts.upsert(
-//         {
-//           account_id: 'morgs_near',
-//           block_height: i,
-//           receipt_id: 'abc',
-//           content: 'test_content',
-//           block_timestamp: 800,
-//           accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
-//         },
-//         ['account_id', 'block_height'],
-//         ['content', 'block_timestamp']
-//       );
-//       promises.push(promise);
-//     }
-//     await Promise.all(promises);
-
-//     expect(initializeSpy).toHaveBeenCalledTimes(100);
-//     expect(upsertSpy).toHaveBeenCalledTimes(100);
-//     expect(mockGetPgClient).toHaveBeenCalledTimes(1);
-//   });
-
-//   test('indexer builds context handles simultaneous initialize errors', async () => {
-//     const dmlHandlerInstance = DmlHandler.createLazy('test_account');
-//     const mockGetPgClient = jest.spyOn(dmlHandlerInstance, 'getPgClient').mockImplementation(async () => {
-//       throw new Error('upstream timeout');
-//     });
-//     const initializeSpy = jest.spyOn(dmlHandlerInstance, 'initialize');
-//     const upsertSpy = jest.spyOn(dmlHandlerInstance, 'upsert');
-//     const mockDmlHandler: any = {
-//       createLazy: jest.fn().mockReturnValue(dmlHandlerInstance)
-//     };
-//     const indexer = new Indexer({
-//       fetch: genericMockFetch as unknown as typeof fetch,
-//       DmlHandler: mockDmlHandler
-//     });
-//     const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
-//     const promises = [];
-
-//     for (let i = 1; i <= 100; i++) {
-//       const promise = context.db.Posts.upsert(
-//         {
-//           account_id: 'morgs_near',
-//           block_height: i,
-//           receipt_id: 'abc',
-//           content: 'test_content',
-//           block_timestamp: 800,
-//           accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
-//         },
-//         ['account_id', 'block_height'],
-//         ['content', 'block_timestamp']
-//       );
-//       promises.push(promise);
-//     }
-//     await expect(Promise.all(promises)).rejects.toThrow('upstream timeout');
-
-//     expect(initializeSpy).toHaveBeenCalled();
-//     expect(upsertSpy).toHaveBeenCalled();
-//     expect(mockGetPgClient).toHaveBeenCalledTimes(1);
-//   });
-
-//   test('indexer builds context and selects objects from existing table', async () => {
-//     const selectFn = jest.fn();
-//     selectFn.mockImplementation((...args) => {
-//       // Expects limit to be last parameter
-//       return args[args.length - 1] === null ? [{ colA: 'valA' }, { colA: 'valA' }] : [{ colA: 'valA' }];
-//     });
-//     const mockDmlHandler: any = {
-//       createLazy: jest.fn().mockImplementation(() => {
-//         return { select: selectFn };
-//       })
-//     };
-
-//     const indexer = new Indexer({
-//       fetch: genericMockFetch as unknown as typeof fetch,
-//       DmlHandler: mockDmlHandler
-//     });
-//     const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
-
-//     const objToSelect = {
-//       account_id: 'morgs_near',
-//       receipt_id: 'abc',
-//     };
-//     const result = await context.db.Posts.select(objToSelect);
-//     expect(result.length).toEqual(2);
-//     const resultLimit = await context.db.Posts.select(objToSelect, 1);
-//     expect(resultLimit.length).toEqual(1);
-//   });
-
-//   test('indexer builds context and updates multiple objects from existing table', async () => {
-//     const mockDmlHandler: any = {
-//       createLazy: jest.fn().mockImplementation(() => {
-//         return {
-//           update: jest.fn().mockImplementation((_, __, whereObj, updateObj) => {
-//             if (whereObj.account_id === 'morgs_near' && updateObj.content === 'test_content') {
-//               return [{ colA: 'valA' }, { colA: 'valA' }];
-//             }
-//             return [{}];
-//           })
-//         };
-//       })
-//     };
-
-//     const indexer = new Indexer({
-//       fetch: genericMockFetch as unknown as typeof fetch,
-//       DmlHandler: mockDmlHandler
-//     });
-//     const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
-
-//     const whereObj = {
-//       account_id: 'morgs_near',
-//       receipt_id: 'abc',
-//     };
-//     const updateObj = {
-//       content: 'test_content',
-//       block_timestamp: 805,
-//     };
-//     const result = await context.db.Posts.update(whereObj, updateObj);
-//     expect(result.length).toEqual(2);
-//   });
-
-//   test('indexer builds context and upserts on existing table', async () => {
-//     const mockDmlHandler: any = {
-//       createLazy: jest.fn().mockImplementation(() => {
-//         return {
-//           upsert: jest.fn().mockImplementation((_, __, objects, conflict, update) => {
-//             if (objects.length === 2 && conflict.includes('account_id') && update.includes('content')) {
-//               return [{ colA: 'valA' }, { colA: 'valA' }];
-//             } else if (objects.length === 1 && conflict.includes('account_id') && update.includes('content')) {
-//               return [{ colA: 'valA' }];
-//             }
-//             return [{}];
-//           })
-//         };
-//       })
-//     };
-
-//     const indexer = new Indexer({
-//       fetch: genericMockFetch as unknown as typeof fetch,
-//       DmlHandler: mockDmlHandler
-//     });
-//     const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
-
-//     const objToInsert = [{
-//       account_id: 'morgs_near',
-//       block_height: 1,
-//       receipt_id: 'abc',
-//       content: 'test',
-//       block_timestamp: 800,
-//       accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
-//     },
-//     {
-//       account_id: 'morgs_near',
-//       block_height: 2,
-//       receipt_id: 'abc',
-//       content: 'test',
-//       block_timestamp: 801,
-//       accounts_liked: JSON.stringify(['cwpuzzles.near'])
-//     }];
-
-//     let result = await context.db.Posts.upsert(objToInsert, ['account_id', 'block_height'], ['content', 'block_timestamp']);
-//     expect(result.length).toEqual(2);
-//     result = await context.db.Posts.upsert(objToInsert[0], ['account_id', 'block_height'], ['content', 'block_timestamp']);
-//     expect(result.length).toEqual(1);
-//   });
-
-//   test('indexer builds context and deletes objects from existing table', async () => {
-//     const mockDmlHandler: any = {
-//       createLazy: jest.fn().mockImplementation(() => {
-//         return { delete: jest.fn().mockReturnValue([{ colA: 'valA' }, { colA: 'valA' }]) };
-//       })
-//     };
-
-//     const indexer = new Indexer({
-//       fetch: genericMockFetch as unknown as typeof fetch,
-//       DmlHandler: mockDmlHandler
-//     });
-//     const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
-
-//     const deleteFilter = {
-//       account_id: 'morgs_near',
-//       receipt_id: 'abc',
-//     };
-//     const result = await context.db.Posts.delete(deleteFilter);
-//     expect(result.length).toEqual(2);
-//   });
-
-//   test('indexer builds context and verifies all methods generated', async () => {
-//     const mockDmlHandler: any = {
-//       createLazy: jest.fn()
-//     };
-
-//     const indexer = new Indexer({
-//       fetch: genericMockFetch as unknown as typeof fetch,
-//       DmlHandler: mockDmlHandler
-//     });
-//     const context = indexer.buildContext(STRESS_TEST_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
-
-//     expect(Object.keys(context.db)).toStrictEqual([
-//       'CreatorQuest',
-//       'ComposerQuest',
-//       'ContractorQuest',
-//       'Posts',
-//       'Comments',
-//       'PostLikes',
-//       'MyTable1',
-//       'AnotherTable',
-//       'ThirdTable',
-//       'YetAnotherTable']);
-//     expect(Object.keys(context.db.CreatorQuest)).toStrictEqual([
-//       'insert',
-//       'select',
-//       'update',
-//       'upsert',
-//       'delete']);
-//     expect(Object.keys(context.db.PostLikes)).toStrictEqual([
-//       'insert',
-//       'select',
-//       'update',
-//       'upsert',
-//       'delete']);
-//     expect(Object.keys(context.db.MyTable1)).toStrictEqual([
-//       'insert',
-//       'select',
-//       'update',
-//       'upsert',
-//       'delete']);
-//   });
-
-//   test('indexer builds context and returns empty array if failed to generate db methods', async () => {
-//     const mockDmlHandler: any = {
-//       createLazy: jest.fn()
-//     };
-
-//     const indexer = new Indexer({
-//       fetch: genericMockFetch as unknown as typeof fetch,
-//       DmlHandler: mockDmlHandler
-//     });
-//     const context = indexer.buildContext('', 'morgs.near/social_feed1', 1, 'postgres');
-
-//     expect(Object.keys(context.db)).toStrictEqual([]);
-//   });
-
-//   test('Indexer.runFunctions() allows imperative execution of GraphQL operations', async () => {
-//     const postId = 1;
-//     const commentId = 2;
-//     const blockHeight = 82699904;
-//     const mockFetch = jest.fn()
-//       .mockReturnValueOnce({ // starting log
-//         status: 200,
-//         json: async () => ({
-//           data: {
-//             indexer_log_store: [
-//               {
-//                 id: '12345',
-//               },
-//             ],
-//           },
-//         }),
-//       })
-//       .mockReturnValueOnce({
-//         status: 200,
-//         json: async () => ({
-//           errors: null,
-//         }),
-//       })
-//       .mockReturnValueOnce({ // query
-//         status: 200,
-//         json: async () => ({
-//           data: {
-//             posts: [
-//               {
-//                 id: postId,
-//               },
-//             ],
-//           },
-//         }),
-//       })
-//       .mockReturnValueOnce({ // mutation
-//         status: 200,
-//         json: async () => ({
-//           data: {
-//             insert_comments: {
-//               returning: {
-//                 id: commentId,
-//               },
-//             },
-//           },
-//         }),
-//       })
-//       .mockReturnValueOnce({
-//         status: 200,
-//         json: async () => ({
-//           errors: null,
-//         }),
-//       });
-
-//     const mockBlock = Block.fromStreamerMessage({
-//       block: {
-//         chunks: [0],
-//         header: {
-//           height: blockHeight
-//         }
-//       },
-//       shards: {}
-//     } as unknown as StreamerMessage) as unknown as Block;
-//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
-
-//     const functions: Record<string, any> = {};
-//     functions['buildnear.testnet/test'] = {
-//       code: `
-//             const { posts } = await context.graphql(\`
-//                 query {
-//                     posts(where: { id: { _eq: 1 } }) {
-//                         id
-//                     }
-//                 }
-//             \`);
-
-//             if (!posts || posts.length === 0) {
-//                 return;
-//             }
-
-//             const [post] = posts;
-
-//             const { insert_comments: { returning: { id } } } = await context.graphql(\`
-//                 mutation {
-//                     insert_comments(
-//                         objects: {account_id: "morgs.near", block_height: \${block.blockHeight}, content: "cool post", post_id: \${post.id}}
-//                     ) {
-//                         returning {
-//                             id
-//                         }
-//                     }
-//                 }
-//             \`);
-
-//             return (\`Created comment \${id} on post \${post.id}\`)
-//         `,
-//       schema: SIMPLE_SCHEMA
-//     };
-
-//     await indexer.runFunctions(mockBlock, functions, false);
-
-//     expect(mockFetch.mock.calls).toMatchSnapshot();
-//   });
-
-//   test('Indexer.runFunctions() console.logs', async () => {
-//     const logs: string[] = [];
-//     const context = {
-//       log: (...m: string[]) => {
-//         logs.push(...m);
-//       }
-//     };
-//     const vm = new VM();
-//     vm.freeze(context, 'context');
-//     vm.freeze(context, 'console');
-//     await vm.run('console.log("hello", "brave new"); context.log("world")');
-//     expect(logs).toEqual(['hello', 'brave new', 'world']);
-//   });
-
-//   test('Errors thrown in VM can be caught outside the VM', async () => {
-//     const vm = new VM();
-//     expect(() => {
-//       vm.run("throw new Error('boom')");
-//     }).toThrow('boom');
-//   });
-
-//   test('Indexer.runFunctions() catches errors', async () => {
-//     const mockFetch = jest.fn(() => ({
-//       status: 200,
-//       json: async () => ({
-//         errors: null,
-//       }),
-//     }));
-//     const blockHeight = 456;
-//     const mockBlock = Block.fromStreamerMessage({
-//       block: {
-//         chunks: [0],
-//         header: {
-//           height: blockHeight
-//         }
-//       },
-//       shards: {}
-//     } as unknown as StreamerMessage) as unknown as Block;
-//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
-
-//     const functions: Record<string, any> = {};
-//     functions['buildnear.testnet/test'] = {
-//       code: `
-//             throw new Error('boom');
-//         `,
-//       schema: SIMPLE_SCHEMA
-//     };
-
-//     await expect(indexer.runFunctions(mockBlock, functions, false)).rejects.toThrow(new Error('boom'));
-//     expect(mockFetch.mock.calls).toMatchSnapshot();
-//   });
-
-//   test('Indexer.runFunctions() provisions a GraphQL endpoint with the specified schema', async () => {
-//     const blockHeight = 82699904;
-//     const mockFetch = jest.fn(() => ({
-//       status: 200,
-//       json: async () => ({
-//         errors: null,
-//       }),
-//     }));
-//     const mockBlock = Block.fromStreamerMessage({
-//       block: {
-//         chunks: [0],
-//         header: {
-//           height: blockHeight
-//         }
-//       },
-//       shards: {}
-//     } as unknown as StreamerMessage) as unknown as Block;
-//     const provisioner: any = {
-//       isUserApiProvisioned: jest.fn().mockReturnValue(false),
-//       provisionUserApi: jest.fn(),
-//     };
-//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, provisioner, DmlHandler: genericMockDmlHandler });
-
-//     const functions = {
-//       'morgs.near/test': {
-//         account_id: 'morgs.near',
-//         function_name: 'test',
-//         code: '',
-//         schema: SIMPLE_SCHEMA,
-//       }
-//     };
-//     await indexer.runFunctions(mockBlock, functions, false, { provision: true });
-
-//     expect(provisioner.isUserApiProvisioned).toHaveBeenCalledWith('morgs.near', 'test');
-//     expect(provisioner.provisionUserApi).toHaveBeenCalledTimes(1);
-//     expect(provisioner.provisionUserApi).toHaveBeenCalledWith(
-//       'morgs.near',
-//       'test',
-//       SIMPLE_SCHEMA
-//     );
-//   });
-
-//   test('Indexer.runFunctions() skips provisioning if the endpoint exists', async () => {
-//     const blockHeight = 82699904;
-//     const mockFetch = jest.fn(() => ({
-//       status: 200,
-//       json: async () => ({
-//         errors: null,
-//       }),
-//     }));
-//     const mockBlock = Block.fromStreamerMessage({
-//       block: {
-//         chunks: [0],
-//         header: {
-//           height: blockHeight
-//         }
-//       },
-//       shards: {}
-//     } as unknown as StreamerMessage) as unknown as Block;
-//     const provisioner: any = {
-//       isUserApiProvisioned: jest.fn().mockReturnValue(true),
-//       provisionUserApi: jest.fn(),
-//     };
-//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, provisioner, DmlHandler: genericMockDmlHandler });
-
-//     const functions: Record<string, any> = {
-//       'morgs.near/test': {
-//         code: '',
-//         schema: SIMPLE_SCHEMA,
-//       }
-//     };
-//     await indexer.runFunctions(mockBlock, functions, false, { provision: true });
-
-//     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
-//   });
-
-//   test('Indexer.runFunctions() supplies the required role to the GraphQL endpoint', async () => {
-//     const blockHeight = 82699904;
-//     const mockFetch = jest.fn(() => ({
-//       status: 200,
-//       json: async () => ({
-//         errors: null,
-//       }),
-//     }));
-//     const mockBlock = Block.fromStreamerMessage({
-//       block: {
-//         chunks: [0],
-//         header: {
-//           height: blockHeight
-//         }
-//       },
-//       shards: {}
-//     } as unknown as StreamerMessage) as unknown as Block;
-//     const provisioner: any = {
-//       isUserApiProvisioned: jest.fn().mockReturnValue(true),
-//       provisionUserApi: jest.fn(),
-//     };
-//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, provisioner, DmlHandler: genericMockDmlHandler });
-
-//     const functions: Record<string, any> = {
-//       'morgs.near/test': {
-//         code: `
-//                     context.graphql(\`mutation { set(functionName: "buildnear.testnet/test", key: "height", data: "\${block.blockHeight}")}\`);
-//                 `,
-//         schema: SIMPLE_SCHEMA,
-//       }
-//     };
-//     await indexer.runFunctions(mockBlock, functions, false, { provision: true });
-
-//     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
-//     expect(mockFetch.mock.calls).toMatchSnapshot();
-//   });
-
-//   test('Indexer.runFunctions() logs provisioning failures', async () => {
-//     const blockHeight = 82699904;
-//     const mockFetch = jest.fn(() => ({
-//       status: 200,
-//       json: async () => ({
-//         errors: null,
-//       }),
-//     }));
-//     const mockBlock = Block.fromStreamerMessage({
-//       block: {
-//         chunks: [0],
-//         header: {
-//           height: blockHeight
-//         }
-//       },
-//       shards: {}
-//     } as unknown as StreamerMessage) as unknown as Block;
-//     const error = new Error('something went wrong with provisioning');
-//     const provisioner: any = {
-//       isUserApiProvisioned: jest.fn().mockReturnValue(false),
-//       provisionUserApi: jest.fn().mockRejectedValue(error),
-//     };
-//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, provisioner, DmlHandler: genericMockDmlHandler });
-
-//     const functions: Record<string, any> = {
-//       'morgs.near/test': {
-//         code: `
-//                     context.graphql(\`mutation { set(functionName: "buildnear.testnet/test", key: "height", data: "\${block.blockHeight}")}\`);
-//                 `,
-//         schema: 'schema',
-//       }
-//     };
-
-//     await expect(indexer.runFunctions(mockBlock, functions, false, { provision: true })).rejects.toThrow(error);
-//     expect(mockFetch.mock.calls).toMatchSnapshot();
-//   });
-
-//   test('does not attach the hasura admin secret header when no role specified', async () => {
-//     const mockFetch = jest.fn()
-//       .mockResolvedValueOnce({
-//         status: 200,
-//         json: async () => ({
-//           data: {}
-//         })
-//       });
-//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
-//     // @ts-expect-error legacy test
-//     const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, null);
-
-//     const mutation = `
-//             mutation {
-//                 newGreeting(greeting: "howdy") {
-//                     success
-//                 }
-//             }
-//         `;
-
-//     await context.graphql(mutation);
-
-//     expect(mockFetch.mock.calls[0]).toEqual([
-//             `${HASURA_ENDPOINT}/v1/graphql`,
-//             {
-//               method: 'POST',
-//               headers: {
-//                 'Content-Type': 'application/json',
-//                 'X-Hasura-Use-Backend-Only-Permissions': 'true',
-//               },
-//               body: JSON.stringify({ query: mutation })
-//             }
-//     ]);
-//   });
-
-//   test('attaches the backend only header to requests to hasura', async () => {
-//     const mockFetch = jest.fn()
-//       .mockResolvedValueOnce({
-//         status: 200,
-//         json: async () => ({
-//           data: {}
-//         })
-//       });
-//     const role = 'morgs_near';
-//     const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
-//     const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, HASURA_ROLE);
-
-//     const mutation = `
-//             mutation {
-//                 newGreeting(greeting: "howdy") {
-//                     success
-//                 }
-//             }
-//         `;
-
-//     await context.graphql(mutation);
-
-//     expect(mockFetch.mock.calls[0]).toEqual([
-//             `${HASURA_ENDPOINT}/v1/graphql`,
-//             {
-//               method: 'POST',
-//               headers: {
-//                 'Content-Type': 'application/json',
-//                 'X-Hasura-Use-Backend-Only-Permissions': 'true',
-//                 'X-Hasura-Role': role,
-//                 'X-Hasura-Admin-Secret': HASURA_ADMIN_SECRET
-//               },
-//               body: JSON.stringify({ query: mutation })
-//             }
-//     ]);
-//   });
-// });
+import { Block, type StreamerMessage } from '@near-lake/primitives';
+import type fetch from 'node-fetch';
+
+import Indexer from './indexer';
+import { VM } from 'vm2';
+import DmlHandler from '../dml-handler/dml-handler';
+import type PgClient from '../pg-client';
+
+describe('Indexer unit tests', () => {
+  const oldEnv = process.env;
+
+  const HASURA_ENDPOINT = 'mock-hasura-endpoint';
+  const HASURA_ADMIN_SECRET = 'mock-hasura-secret';
+  const HASURA_ROLE = 'morgs_near';
+  const INVALID_HASURA_ROLE = 'other_near';
+
+  const INDEXER_NAME = 'morgs.near/test_fn';
+
+  const SIMPLE_SCHEMA = `CREATE TABLE
+    "posts" (
+      "id" SERIAL NOT NULL,
+      "account_id" VARCHAR NOT NULL,
+      "block_height" DECIMAL(58, 0) NOT NULL,
+      "receipt_id" VARCHAR NOT NULL,
+      "content" TEXT NOT NULL,
+      "block_timestamp" DECIMAL(20, 0) NOT NULL,
+      "accounts_liked" JSONB NOT NULL DEFAULT '[]',
+      "last_comment_timestamp" DECIMAL(20, 0),
+      CONSTRAINT "posts_pkey" PRIMARY KEY ("id")
+    );`;
+
+  const SOCIAL_SCHEMA = `
+    CREATE TABLE
+      "posts" (
+        "id" SERIAL NOT NULL,
+        "account_id" VARCHAR NOT NULL,
+        "block_height" DECIMAL(58, 0) NOT NULL,
+        "receipt_id" VARCHAR NOT NULL,
+        "content" TEXT NOT NULL,
+        "block_timestamp" DECIMAL(20, 0) NOT NULL,
+        "accounts_liked" JSONB NOT NULL DEFAULT '[]',
+        "last_comment_timestamp" DECIMAL(20, 0),
+        CONSTRAINT "posts_pkey" PRIMARY KEY ("id")
+      );
+
+    CREATE TABLE
+      "comments" (
+        "id" SERIAL NOT NULL,
+        "post_id" SERIAL NOT NULL,
+        "account_id" VARCHAR NOT NULL,
+        "block_height" DECIMAL(58, 0) NOT NULL,
+        "content" TEXT NOT NULL,
+        "block_timestamp" DECIMAL(20, 0) NOT NULL,
+        "receipt_id" VARCHAR NOT NULL,
+        CONSTRAINT "comments_pkey" PRIMARY KEY ("id")
+      );
+
+    CREATE TABLE
+      "post_likes" (
+        "post_id" SERIAL NOT NULL,
+        "account_id" VARCHAR NOT NULL,
+        "block_height" DECIMAL(58, 0),
+        "block_timestamp" DECIMAL(20, 0) NOT NULL,
+        "receipt_id" VARCHAR NOT NULL,
+        CONSTRAINT "post_likes_pkey" PRIMARY KEY ("post_id", "account_id")
+      );`;
+
+  const STRESS_TEST_SCHEMA = `
+CREATE TABLE creator_quest (
+    account_id VARCHAR PRIMARY KEY,
+    num_components_created INTEGER NOT NULL DEFAULT 0,
+    completed BOOLEAN NOT NULL DEFAULT FALSE
+  );
+
+CREATE TABLE
+  composer_quest (
+    account_id VARCHAR PRIMARY KEY,
+    num_widgets_composed INTEGER NOT NULL DEFAULT 0,
+    completed BOOLEAN NOT NULL DEFAULT FALSE
+  );
+
+CREATE TABLE
+  "contractor - quest" (
+    account_id VARCHAR PRIMARY KEY,
+    num_contracts_deployed INTEGER NOT NULL DEFAULT 0,
+    completed BOOLEAN NOT NULL DEFAULT FALSE
+  );
+
+CREATE TABLE
+  "posts" (
+    "id" SERIAL NOT NULL,
+    "account_id" VARCHAR NOT NULL,
+    "block_height" DECIMAL(58, 0) NOT NULL,
+    "receipt_id" VARCHAR NOT NULL,
+    "content" TEXT NOT NULL,
+    "block_timestamp" DECIMAL(20, 0) NOT NULL,
+    "accounts_liked" JSONB NOT NULL DEFAULT '[]',
+    "last_comment_timestamp" DECIMAL(20, 0),
+    CONSTRAINT "posts_pkey" PRIMARY KEY ("id")
+  );
+
+CREATE TABLE
+  "comments" (
+    "id" SERIAL NOT NULL,
+    "post_id" SERIAL NOT NULL,
+    "account_id" VARCHAR NOT NULL,
+    "block_height" DECIMAL(58, 0) NOT NULL,
+    "content" TEXT NOT NULL,
+    "block_timestamp" DECIMAL(20, 0) NOT NULL,
+    "receipt_id" VARCHAR NOT NULL,
+    CONSTRAINT "comments_pkey" PRIMARY KEY ("id")
+  );
+
+CREATE TABLE
+  "post_likes" (
+    "post_id" SERIAL NOT NULL,
+    "account_id" VARCHAR NOT NULL,
+    "block_height" DECIMAL(58, 0),
+    "block_timestamp" DECIMAL(20, 0) NOT NULL,
+    "receipt_id" VARCHAR NOT NULL,
+    CONSTRAINT "post_likes_pkey" PRIMARY KEY ("post_id", "account_id")
+  );
+
+CREATE UNIQUE INDEX "posts_account_id_block_height_key" ON "posts" ("account_id" ASC, "block_height" ASC);
+
+CREATE UNIQUE INDEX "comments_post_id_account_id_block_height_key" ON "comments" (
+  "post_id" ASC,
+  "account_id" ASC,
+  "block_height" ASC
+);
+
+CREATE INDEX
+  "posts_last_comment_timestamp_idx" ON "posts" ("last_comment_timestamp" DESC);
+
+ALTER TABLE
+  "comments"
+ADD
+  CONSTRAINT "comments_post_id_fkey" FOREIGN KEY ("post_id") REFERENCES "posts" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+ALTER TABLE
+  "post_likes"
+ADD
+  CONSTRAINT "post_likes_post_id_fkey" FOREIGN KEY ("post_id") REFERENCES "posts" ("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+CREATE TABLE IF NOT EXISTS
+  "My Table1" (id serial PRIMARY KEY);
+
+CREATE TABLE
+  "Another-Table" (id serial PRIMARY KEY);
+
+CREATE TABLE
+IF NOT EXISTS
+  "Third-Table" (id serial PRIMARY KEY);
+
+CREATE TABLE
+  yet_another_table (id serial PRIMARY KEY);
+`;
+  const genericMockFetch = jest.fn()
+    .mockResolvedValue({
+      status: 200,
+      json: async () => ({
+        data: 'mock',
+      }),
+    });
+  const genericMockDmlHandler: any = {
+    create: jest.fn()
+  } as unknown as DmlHandler;
+
+  const genericDbCredentials: any = {
+    database: 'test_near',
+    host: 'postgres',
+    password: 'test_pass',
+    port: 5432,
+    username: 'test_near'
+  };
+
+  const genericProvisioner: any = {
+    getDatabaseConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials)
+  }
+
+  beforeEach(() => {
+    process.env = {
+      ...oldEnv,
+      HASURA_ENDPOINT,
+      HASURA_ADMIN_SECRET
+    };
+  });
+
+  afterAll(() => {
+    process.env = oldEnv;
+  });
+
+  test('Indexer.runFunctions() should execute all functions against the current block', async () => {
+    const mockFetch = jest.fn(() => ({
+      status: 200,
+      json: async () => ({
+        errors: null,
+      }),
+    }));
+    const blockHeight = 456;
+    const mockBlock = Block.fromStreamerMessage({
+      block: {
+        chunks: [],
+        header: {
+          height: blockHeight
+        }
+      },
+      shards: {}
+    } as unknown as StreamerMessage) as unknown as Block;
+
+    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, provisioner: genericProvisioner, DmlHandler: genericMockDmlHandler });
+
+    const functions: Record<string, any> = {};
+    functions['buildnear.testnet/test'] = {
+      code: `
+            const foo = 3;
+            block.result = context.graphql(\`mutation { set(functionName: "buildnear.testnet/test", key: "height", data: "\${block.blockHeight}")}\`);
+        `,
+      schema: SIMPLE_SCHEMA
+    };
+    await indexer.runFunctions(mockBlock, functions, false);
+
+    expect(mockFetch.mock.calls).toMatchSnapshot();
+  });
+
+  test('Indexer.transformIndexerFunction() applies the necessary transformations', () => {
+    const indexer = new Indexer();
+
+    const transformedFunction = indexer.transformIndexerFunction('console.log(\'hello\')');
+
+    expect(transformedFunction).toEqual(`
+            async function f(){
+                console.log('hello')
+            };
+            f();
+    `);
+  });
+
+  test('Indexer.buildContext() allows execution of arbitrary GraphQL operations', async () => {
+    const mockFetch = jest.fn()
+      .mockResolvedValueOnce({
+        status: 200,
+        json: async () => ({
+          data: {
+            greet: 'hello'
+          }
+        })
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        json: async () => ({
+          data: {
+            newGreeting: {
+              success: true
+            }
+          }
+        })
+      });
+    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
+
+    const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, HASURA_ROLE);
+
+    const query = `
+            query {
+                greet()
+            }
+        `;
+    const { greet } = await context.graphql(query) as { greet: string };
+
+    const mutation = `
+            mutation {
+                newGreeting(greeting: "${greet} morgan") {
+                    success
+                }
+            }
+        `;
+    const { newGreeting: { success } } = await context.graphql(mutation);
+
+    expect(greet).toEqual('hello');
+    expect(success).toEqual(true);
+    expect(mockFetch.mock.calls[0]).toEqual([
+            `${HASURA_ENDPOINT}/v1/graphql`,
+            {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'X-Hasura-Use-Backend-Only-Permissions': 'true',
+                'X-Hasura-Role': 'morgs_near',
+                'X-Hasura-Admin-Secret': HASURA_ADMIN_SECRET
+              },
+              body: JSON.stringify({ query })
+            }
+    ]);
+    expect(mockFetch.mock.calls[1]).toEqual([
+            `${HASURA_ENDPOINT}/v1/graphql`,
+            {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'X-Hasura-Use-Backend-Only-Permissions': 'true',
+                'X-Hasura-Role': 'morgs_near',
+                'X-Hasura-Admin-Secret': HASURA_ADMIN_SECRET
+              },
+              body: JSON.stringify({ query: mutation })
+            }
+    ]);
+  });
+
+  test('Indexer.buildContext() can fetch from the near social api', async () => {
+    const mockFetch = jest.fn();
+    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
+
+    const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, HASURA_ROLE);
+
+    await context.fetchFromSocialApi('/index', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        action: 'post',
+        key: 'main',
+        options: {
+          limit: 1,
+          order: 'desc'
+        }
+      })
+    });
+
+    expect(mockFetch.mock.calls).toMatchSnapshot();
+  });
+
+  test('Indexer.buildContext() throws when a GraphQL response contains errors', async () => {
+    const mockFetch = jest.fn()
+      .mockResolvedValue({
+        json: async () => ({
+          errors: ['boom']
+        })
+      });
+    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
+
+    const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, INVALID_HASURA_ROLE);
+
+    await expect(async () => await context.graphql('query { hello }')).rejects.toThrow('boom');
+  });
+
+  test('Indexer.buildContext() handles GraphQL variables', async () => {
+    const mockFetch = jest.fn()
+      .mockResolvedValue({
+        status: 200,
+        json: async () => ({
+          data: 'mock',
+        }),
+      });
+    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
+
+    const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, HASURA_ROLE);
+
+    const query = 'query($name: String) { hello(name: $name) }';
+    const variables = { name: 'morgan' };
+    await context.graphql(query, variables);
+
+    expect(mockFetch.mock.calls[0]).toEqual([
+            `${HASURA_ENDPOINT}/v1/graphql`,
+            {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'X-Hasura-Use-Backend-Only-Permissions': 'true',
+                'X-Hasura-Role': 'morgs_near',
+                'X-Hasura-Admin-Secret': HASURA_ADMIN_SECRET
+              },
+              body: JSON.stringify({
+                query,
+                variables,
+              }),
+            },
+    ]);
+  });
+
+  test('GetTables works for a variety of input schemas', async () => {
+    const indexer = new Indexer();
+
+    const simpleSchemaTables = indexer.getTableNames(SIMPLE_SCHEMA);
+    expect(simpleSchemaTables).toStrictEqual(['posts']);
+
+    const socialSchemaTables = indexer.getTableNames(SOCIAL_SCHEMA);
+    expect(socialSchemaTables).toStrictEqual(['posts', 'comments', 'post_likes']);
+
+    const stressTestSchemaTables = indexer.getTableNames(STRESS_TEST_SCHEMA);
+    expect(stressTestSchemaTables).toStrictEqual([
+      'creator_quest',
+      'composer_quest',
+      'contractor - quest',
+      'posts',
+      'comments',
+      'post_likes',
+      'My Table1',
+      'Another-Table',
+      'Third-Table',
+      'yet_another_table']);
+
+    // Test that duplicate table names throw an error
+    const duplicateTableSchema = `CREATE TABLE
+    "posts" (
+      "id" SERIAL NOT NULL
+    );
+    CREATE TABLE posts (
+      "id" SERIAL NOT NULL
+    );`;
+    expect(() => {
+      indexer.getTableNames(duplicateTableSchema);
+    }).toThrow('Table posts already exists in schema. Table names must be unique. Quotes are not allowed as a differentiator between table names.');
+
+    // Test that schema with no tables throws an error
+    expect(() => {
+      indexer.getTableNames('');
+    }).toThrow('Schema does not have any tables. There should be at least one table.');
+  });
+
+  test('SanitizeTableName works properly on many test cases', async () => {
+    const indexer = new Indexer();
+
+    expect(indexer.sanitizeTableName('table_name')).toStrictEqual('TableName');
+    expect(indexer.sanitizeTableName('tablename')).toStrictEqual('Tablename'); // name is not capitalized
+    expect(indexer.sanitizeTableName('table name')).toStrictEqual('TableName');
+    expect(indexer.sanitizeTableName('table!name!')).toStrictEqual('TableName');
+    expect(indexer.sanitizeTableName('123TABle')).toStrictEqual('_123TABle'); // underscore at beginning
+    expect(indexer.sanitizeTableName('123_tABLE')).toStrictEqual('_123TABLE'); // underscore at beginning, capitalization
+    expect(indexer.sanitizeTableName('some-table_name')).toStrictEqual('SomeTableName');
+    expect(indexer.sanitizeTableName('!@#$%^&*()table@)*&(%#')).toStrictEqual('Table'); // All special characters removed
+    expect(indexer.sanitizeTableName('T_name')).toStrictEqual('TName');
+    expect(indexer.sanitizeTableName('_table')).toStrictEqual('Table'); // Starting underscore was removed
+  });
+
+  test('indexer fails to build context.db due to collision on sanitized table names', async () => {
+    const indexer = new Indexer({ DmlHandler: genericMockDmlHandler });
+
+    const schemaWithDuplicateSanitizedTableNames = `CREATE TABLE
+    "test table" (
+      "id" SERIAL NOT NULL
+    );
+    CREATE TABLE "test!table" (
+      "id" SERIAL NOT NULL
+    );`;
+
+    // Does not outright throw an error but instead returns an empty object
+    expect(indexer.buildDatabaseContext('test_account', 'test_schema_name', schemaWithDuplicateSanitizedTableNames, 1))
+      .toStrictEqual({});
+  });
+
+  test('indexer builds context and inserts an objects into existing table', async () => {
+    const mockDmlHandler: any = {
+      create: jest.fn().mockImplementation(() => {
+        return { insert: jest.fn().mockReturnValue([{ colA: 'valA' }, { colA: 'valA' }]) };
+      })
+    };
+
+    const indexer = new Indexer({
+      fetch: genericMockFetch as unknown as typeof fetch,
+      DmlHandler: mockDmlHandler
+    });
+    const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
+
+    const objToInsert = [{
+      account_id: 'morgs_near',
+      block_height: 1,
+      receipt_id: 'abc',
+      content: 'test',
+      block_timestamp: 800,
+      accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
+    },
+    {
+      account_id: 'morgs_near',
+      block_height: 2,
+      receipt_id: 'abc',
+      content: 'test',
+      block_timestamp: 801,
+      accounts_liked: JSON.stringify(['cwpuzzles.near'])
+    }];
+
+    const result = await context.db.Posts.insert(objToInsert);
+    expect(result.length).toEqual(2);
+  });
+
+  test('indexer builds context and does simultaneous upserts', async () => {
+    const mockPgClient = {
+      query: jest.fn().mockReturnValue({ rows: [] }),
+      format: jest.fn().mockReturnValue('mock')
+    } as unknown as PgClient;
+    const dmlHandlerInstance = DmlHandler.create(genericDbCredentials, mockPgClient);
+    const upsertSpy = jest.spyOn(dmlHandlerInstance, 'upsert');
+    const mockDmlHandler: any = {
+      create: jest.fn().mockReturnValue(dmlHandlerInstance)
+    };
+    const indexer = new Indexer({
+      fetch: genericMockFetch as unknown as typeof fetch,
+      DmlHandler: mockDmlHandler
+    });
+    const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
+    const promises = [];
+
+    for (let i = 1; i <= 100; i++) {
+      const promise = context.db.Posts.upsert(
+        {
+          account_id: 'morgs_near',
+          block_height: i,
+          receipt_id: 'abc',
+          content: 'test_content',
+          block_timestamp: 800,
+          accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
+        },
+        ['account_id', 'block_height'],
+        ['content', 'block_timestamp']
+      );
+      promises.push(promise);
+    }
+    await Promise.all(promises);
+
+    expect(upsertSpy).toHaveBeenCalledTimes(100);
+  });
+
+  test('indexer builds context and selects objects from existing table', async () => {
+    const selectFn = jest.fn();
+    selectFn.mockImplementation((...args) => {
+      // Expects limit to be last parameter
+      return args[args.length - 1] === null ? [{ colA: 'valA' }, { colA: 'valA' }] : [{ colA: 'valA' }];
+    });
+    const mockDmlHandler: any = {
+      create: jest.fn().mockImplementation(() => {
+        return { select: selectFn };
+      })
+    };
+
+    const indexer = new Indexer({
+      fetch: genericMockFetch as unknown as typeof fetch,
+      DmlHandler: mockDmlHandler
+    });
+    const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
+
+    const objToSelect = {
+      account_id: 'morgs_near',
+      receipt_id: 'abc',
+    };
+    const result = await context.db.Posts.select(objToSelect);
+    expect(result.length).toEqual(2);
+    const resultLimit = await context.db.Posts.select(objToSelect, 1);
+    expect(resultLimit.length).toEqual(1);
+  });
+
+  test('indexer builds context and updates multiple objects from existing table', async () => {
+    const mockDmlHandler: any = {
+      create: jest.fn().mockImplementation(() => {
+        return {
+          update: jest.fn().mockImplementation((_, __, whereObj, updateObj) => {
+            if (whereObj.account_id === 'morgs_near' && updateObj.content === 'test_content') {
+              return [{ colA: 'valA' }, { colA: 'valA' }];
+            }
+            return [{}];
+          })
+        };
+      })
+    };
+
+    const indexer = new Indexer({
+      fetch: genericMockFetch as unknown as typeof fetch,
+      DmlHandler: mockDmlHandler
+    });
+    const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
+
+    const whereObj = {
+      account_id: 'morgs_near',
+      receipt_id: 'abc',
+    };
+    const updateObj = {
+      content: 'test_content',
+      block_timestamp: 805,
+    };
+    const result = await context.db.Posts.update(whereObj, updateObj);
+    expect(result.length).toEqual(2);
+  });
+
+  test('indexer builds context and upserts on existing table', async () => {
+    const mockDmlHandler: any = {
+      create: jest.fn().mockImplementation(() => {
+        return {
+          upsert: jest.fn().mockImplementation((_, __, objects, conflict, update) => {
+            if (objects.length === 2 && conflict.includes('account_id') && update.includes('content')) {
+              return [{ colA: 'valA' }, { colA: 'valA' }];
+            } else if (objects.length === 1 && conflict.includes('account_id') && update.includes('content')) {
+              return [{ colA: 'valA' }];
+            }
+            return [{}];
+          })
+        };
+      })
+    };
+
+    const indexer = new Indexer({
+      fetch: genericMockFetch as unknown as typeof fetch,
+      DmlHandler: mockDmlHandler
+    });
+    const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
+
+    const objToInsert = [{
+      account_id: 'morgs_near',
+      block_height: 1,
+      receipt_id: 'abc',
+      content: 'test',
+      block_timestamp: 800,
+      accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
+    },
+    {
+      account_id: 'morgs_near',
+      block_height: 2,
+      receipt_id: 'abc',
+      content: 'test',
+      block_timestamp: 801,
+      accounts_liked: JSON.stringify(['cwpuzzles.near'])
+    }];
+
+    let result = await context.db.Posts.upsert(objToInsert, ['account_id', 'block_height'], ['content', 'block_timestamp']);
+    expect(result.length).toEqual(2);
+    result = await context.db.Posts.upsert(objToInsert[0], ['account_id', 'block_height'], ['content', 'block_timestamp']);
+    expect(result.length).toEqual(1);
+  });
+
+  test('indexer builds context and deletes objects from existing table', async () => {
+    const mockDmlHandler: any = {
+      create: jest.fn().mockImplementation(() => {
+        return { delete: jest.fn().mockReturnValue([{ colA: 'valA' }, { colA: 'valA' }]) };
+      })
+    };
+
+    const indexer = new Indexer({
+      fetch: genericMockFetch as unknown as typeof fetch,
+      DmlHandler: mockDmlHandler
+    });
+    const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
+
+    const deleteFilter = {
+      account_id: 'morgs_near',
+      receipt_id: 'abc',
+    };
+    const result = await context.db.Posts.delete(deleteFilter);
+    expect(result.length).toEqual(2);
+  });
+
+  test('indexer builds context and verifies all methods generated', async () => {
+    const mockDmlHandler: any = {
+      create: jest.fn()
+    };
+
+    const indexer = new Indexer({
+      fetch: genericMockFetch as unknown as typeof fetch,
+      DmlHandler: mockDmlHandler
+    });
+    const context = indexer.buildContext(STRESS_TEST_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres');
+
+    expect(Object.keys(context.db)).toStrictEqual([
+      'CreatorQuest',
+      'ComposerQuest',
+      'ContractorQuest',
+      'Posts',
+      'Comments',
+      'PostLikes',
+      'MyTable1',
+      'AnotherTable',
+      'ThirdTable',
+      'YetAnotherTable']);
+    expect(Object.keys(context.db.CreatorQuest)).toStrictEqual([
+      'insert',
+      'select',
+      'update',
+      'upsert',
+      'delete']);
+    expect(Object.keys(context.db.PostLikes)).toStrictEqual([
+      'insert',
+      'select',
+      'update',
+      'upsert',
+      'delete']);
+    expect(Object.keys(context.db.MyTable1)).toStrictEqual([
+      'insert',
+      'select',
+      'update',
+      'upsert',
+      'delete']);
+  });
+
+  test('indexer builds context and returns empty array if failed to generate db methods', async () => {
+    const mockDmlHandler: any = {
+      create: jest.fn()
+    };
+
+    const indexer = new Indexer({
+      fetch: genericMockFetch as unknown as typeof fetch,
+      DmlHandler: mockDmlHandler
+    });
+    const context = indexer.buildContext('', 'morgs.near/social_feed1', 1, 'postgres');
+
+    expect(Object.keys(context.db)).toStrictEqual([]);
+  });
+
+  test('Indexer.runFunctions() allows imperative execution of GraphQL operations', async () => {
+    const postId = 1;
+    const commentId = 2;
+    const blockHeight = 82699904;
+    const mockFetch = jest.fn()
+      .mockReturnValueOnce({ // starting log
+        status: 200,
+        json: async () => ({
+          data: {
+            indexer_log_store: [
+              {
+                id: '12345',
+              },
+            ],
+          },
+        }),
+      })
+      .mockReturnValueOnce({
+        status: 200,
+        json: async () => ({
+          errors: null,
+        }),
+      })
+      .mockReturnValueOnce({ // query
+        status: 200,
+        json: async () => ({
+          data: {
+            posts: [
+              {
+                id: postId,
+              },
+            ],
+          },
+        }),
+      })
+      .mockReturnValueOnce({ // mutation
+        status: 200,
+        json: async () => ({
+          data: {
+            insert_comments: {
+              returning: {
+                id: commentId,
+              },
+            },
+          },
+        }),
+      })
+      .mockReturnValueOnce({
+        status: 200,
+        json: async () => ({
+          errors: null,
+        }),
+      });
+
+    const mockBlock = Block.fromStreamerMessage({
+      block: {
+        chunks: [0],
+        header: {
+          height: blockHeight
+        }
+      },
+      shards: {}
+    } as unknown as StreamerMessage) as unknown as Block;
+    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, provisioner: genericProvisioner, DmlHandler: genericMockDmlHandler });
+
+    const functions: Record<string, any> = {};
+    functions['buildnear.testnet/test'] = {
+      code: `
+            const { posts } = await context.graphql(\`
+                query {
+                    posts(where: { id: { _eq: 1 } }) {
+                        id
+                    }
+                }
+            \`);
+
+            if (!posts || posts.length === 0) {
+                return;
+            }
+
+            const [post] = posts;
+
+            const { insert_comments: { returning: { id } } } = await context.graphql(\`
+                mutation {
+                    insert_comments(
+                        objects: {account_id: "morgs.near", block_height: \${block.blockHeight}, content: "cool post", post_id: \${post.id}}
+                    ) {
+                        returning {
+                            id
+                        }
+                    }
+                }
+            \`);
+
+            return (\`Created comment \${id} on post \${post.id}\`)
+        `,
+      schema: SIMPLE_SCHEMA
+    };
+
+    await indexer.runFunctions(mockBlock, functions, false);
+
+    expect(mockFetch.mock.calls).toMatchSnapshot();
+  });
+
+  test('Indexer.runFunctions() console.logs', async () => {
+    const logs: string[] = [];
+    const context = {
+      log: (...m: string[]) => {
+        logs.push(...m);
+      }
+    };
+    const vm = new VM();
+    vm.freeze(context, 'context');
+    vm.freeze(context, 'console');
+    await vm.run('console.log("hello", "brave new"); context.log("world")');
+    expect(logs).toEqual(['hello', 'brave new', 'world']);
+  });
+
+  test('Errors thrown in VM can be caught outside the VM', async () => {
+    const vm = new VM();
+    expect(() => {
+      vm.run("throw new Error('boom')");
+    }).toThrow('boom');
+  });
+
+  test('Indexer.runFunctions() catches errors', async () => {
+    const mockFetch = jest.fn(() => ({
+      status: 200,
+      json: async () => ({
+        errors: null,
+      }),
+    }));
+    const blockHeight = 456;
+    const mockBlock = Block.fromStreamerMessage({
+      block: {
+        chunks: [0],
+        header: {
+          height: blockHeight
+        }
+      },
+      shards: {}
+    } as unknown as StreamerMessage) as unknown as Block;
+    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, provisioner: genericProvisioner, DmlHandler: genericMockDmlHandler });
+
+    const functions: Record<string, any> = {};
+    functions['buildnear.testnet/test'] = {
+      code: `
+            throw new Error('boom');
+        `,
+      schema: SIMPLE_SCHEMA
+    };
+
+    await expect(indexer.runFunctions(mockBlock, functions, false)).rejects.toThrow(new Error('boom'));
+    expect(mockFetch.mock.calls).toMatchSnapshot();
+  });
+
+  test('Indexer.runFunctions() provisions a GraphQL endpoint with the specified schema', async () => {
+    const blockHeight = 82699904;
+    const mockFetch = jest.fn(() => ({
+      status: 200,
+      json: async () => ({
+        errors: null,
+      }),
+    }));
+    const mockBlock = Block.fromStreamerMessage({
+      block: {
+        chunks: [0],
+        header: {
+          height: blockHeight
+        }
+      },
+      shards: {}
+    } as unknown as StreamerMessage) as unknown as Block;
+    const provisioner: any = {
+      getDatabaseConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
+      isUserApiProvisioned: jest.fn().mockReturnValue(false),
+      provisionUserApi: jest.fn(),
+    };
+    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, provisioner, DmlHandler: genericMockDmlHandler });
+
+    const functions = {
+      'morgs.near/test': {
+        account_id: 'morgs.near',
+        function_name: 'test',
+        code: '',
+        schema: SIMPLE_SCHEMA,
+      }
+    };
+    await indexer.runFunctions(mockBlock, functions, false, { provision: true });
+
+    expect(provisioner.isUserApiProvisioned).toHaveBeenCalledWith('morgs.near', 'test');
+    expect(provisioner.provisionUserApi).toHaveBeenCalledTimes(1);
+    expect(provisioner.provisionUserApi).toHaveBeenCalledWith(
+      'morgs.near',
+      'test',
+      SIMPLE_SCHEMA
+    );
+  });
+
+  test('Indexer.runFunctions() skips provisioning if the endpoint exists', async () => {
+    const blockHeight = 82699904;
+    const mockFetch = jest.fn(() => ({
+      status: 200,
+      json: async () => ({
+        errors: null,
+      }),
+    }));
+    const mockBlock = Block.fromStreamerMessage({
+      block: {
+        chunks: [0],
+        header: {
+          height: blockHeight
+        }
+      },
+      shards: {}
+    } as unknown as StreamerMessage) as unknown as Block;
+    const provisioner: any = {
+      getDatabaseConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
+      isUserApiProvisioned: jest.fn().mockReturnValue(true),
+      provisionUserApi: jest.fn(),
+    };
+    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, provisioner, DmlHandler: genericMockDmlHandler });
+
+    const functions: Record<string, any> = {
+      'morgs.near/test': {
+        code: '',
+        schema: SIMPLE_SCHEMA,
+      }
+    };
+    await indexer.runFunctions(mockBlock, functions, false, { provision: true });
+
+    expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
+  });
+
+  test('Indexer.runFunctions() supplies the required role to the GraphQL endpoint', async () => {
+    const blockHeight = 82699904;
+    const mockFetch = jest.fn(() => ({
+      status: 200,
+      json: async () => ({
+        errors: null,
+      }),
+    }));
+    const mockBlock = Block.fromStreamerMessage({
+      block: {
+        chunks: [0],
+        header: {
+          height: blockHeight
+        }
+      },
+      shards: {}
+    } as unknown as StreamerMessage) as unknown as Block;
+    const provisioner: any = {
+      getDatabaseConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
+      isUserApiProvisioned: jest.fn().mockReturnValue(true),
+      provisionUserApi: jest.fn(),
+    };
+    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, provisioner, DmlHandler: genericMockDmlHandler });
+
+    const functions: Record<string, any> = {
+      'morgs.near/test': {
+        code: `
+                    context.graphql(\`mutation { set(functionName: "buildnear.testnet/test", key: "height", data: "\${block.blockHeight}")}\`);
+                `,
+        schema: SIMPLE_SCHEMA,
+      }
+    };
+    await indexer.runFunctions(mockBlock, functions, false, { provision: true });
+
+    expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
+    expect(mockFetch.mock.calls).toMatchSnapshot();
+  });
+
+  test('Indexer.runFunctions() logs provisioning failures', async () => {
+    const blockHeight = 82699904;
+    const mockFetch = jest.fn(() => ({
+      status: 200,
+      json: async () => ({
+        errors: null,
+      }),
+    }));
+    const mockBlock = Block.fromStreamerMessage({
+      block: {
+        chunks: [0],
+        header: {
+          height: blockHeight
+        }
+      },
+      shards: {}
+    } as unknown as StreamerMessage) as unknown as Block;
+    const error = new Error('something went wrong with provisioning');
+    const provisioner: any = {
+      getDatabaseConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
+      isUserApiProvisioned: jest.fn().mockReturnValue(false),
+      provisionUserApi: jest.fn().mockRejectedValue(error),
+    };
+    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, provisioner, DmlHandler: genericMockDmlHandler });
+
+    const functions: Record<string, any> = {
+      'morgs.near/test': {
+        code: `
+                    context.graphql(\`mutation { set(functionName: "buildnear.testnet/test", key: "height", data: "\${block.blockHeight}")}\`);
+                `,
+        schema: 'schema',
+      }
+    };
+
+    await expect(indexer.runFunctions(mockBlock, functions, false, { provision: true })).rejects.toThrow(error);
+    expect(mockFetch.mock.calls).toMatchSnapshot();
+  });
+
+  test('does not attach the hasura admin secret header when no role specified', async () => {
+    const mockFetch = jest.fn()
+      .mockResolvedValueOnce({
+        status: 200,
+        json: async () => ({
+          data: {}
+        })
+      });
+    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
+    // @ts-expect-error legacy test
+    const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, null);
+
+    const mutation = `
+            mutation {
+                newGreeting(greeting: "howdy") {
+                    success
+                }
+            }
+        `;
+
+    await context.graphql(mutation);
+
+    expect(mockFetch.mock.calls[0]).toEqual([
+            `${HASURA_ENDPOINT}/v1/graphql`,
+            {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'X-Hasura-Use-Backend-Only-Permissions': 'true',
+              },
+              body: JSON.stringify({ query: mutation })
+            }
+    ]);
+  });
+
+  test('attaches the backend only header to requests to hasura', async () => {
+    const mockFetch = jest.fn()
+      .mockResolvedValueOnce({
+        status: 200,
+        json: async () => ({
+          data: {}
+        })
+      });
+    const role = 'morgs_near';
+    const indexer = new Indexer({ fetch: mockFetch as unknown as typeof fetch, DmlHandler: genericMockDmlHandler });
+    const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, HASURA_ROLE);
+
+    const mutation = `
+            mutation {
+                newGreeting(greeting: "howdy") {
+                    success
+                }
+            }
+        `;
+
+    await context.graphql(mutation);
+
+    expect(mockFetch.mock.calls[0]).toEqual([
+            `${HASURA_ENDPOINT}/v1/graphql`,
+            {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'X-Hasura-Use-Backend-Only-Permissions': 'true',
+                'X-Hasura-Role': role,
+                'X-Hasura-Admin-Secret': HASURA_ADMIN_SECRET
+              },
+              body: JSON.stringify({ query: mutation })
+            }
+    ]);
+  });
+});

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -30,10 +30,18 @@ interface IndexerFunction {
   code: string
 }
 
+interface DatabaseConnectionParameters {
+  host: string
+  port: number
+  database: string
+  user: string
+  password: string
+}
+
 
 export default class Indexer {
   DEFAULT_HASURA_ROLE;
-  database_connection_parameters: any | undefined = undefined;
+  database_connection_parameters: DatabaseConnectionParameters | undefined = undefined;
 
   private readonly deps: Dependencies;
 
@@ -94,7 +102,7 @@ export default class Indexer {
         // Cache database credentials after provisioning
         try {
           this.database_connection_parameters = this.database_connection_parameters ?? 
-            await this.deps.provisioner.getDatabaseConnectionParameters(functionName.split('/')[0].replace(/[.-]/g, '_'));
+            await this.deps.provisioner.getDatabaseConnectionParameters(hasuraRoleName);
         } catch (e) {
           const error = e as Error;
           simultaneousPromises.push(this.writeLog(functionName, blockHeight, 'Failed to get database connection parameters', error.message));

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -94,7 +94,7 @@ export default class Indexer {
         // Cache database credentials after provisioning
         try {
           this.database_connection_parameters = this.database_connection_parameters ?? 
-            await this.deps.provisioner.getDatabaseConnectionParameters(indexerFunction.account_id.replace(/[^a-zA-Z0-9]/g, '_'));
+            await this.deps.provisioner.getDatabaseConnectionParameters(functionName.split('/')[0].replace(/[.-]/g, '_'));
         } catch (e) {
           const error = e as Error;
           simultaneousPromises.push(this.writeLog(functionName, blockHeight, 'Failed to get database connection parameters', error.message));

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -30,8 +30,10 @@ interface IndexerFunction {
   code: string
 }
 
+
 export default class Indexer {
   DEFAULT_HASURA_ROLE;
+  database_connection_parameters: any | undefined = undefined;
 
   private readonly deps: Dependencies;
 
@@ -87,6 +89,16 @@ export default class Indexer {
             simultaneousPromises.push(this.writeLog(functionName, blockHeight, 'Provisioning endpoint: failure', error.message));
             throw error;
           }
+        }
+
+        // Cache database credentials after provisioning
+        try {
+          this.database_connection_parameters = this.database_connection_parameters ?? 
+            await this.deps.provisioner.getDatabaseConnectionParameters(indexerFunction.account_id.replace(/[^a-zA-Z0-9]/g, '_'));
+        } catch (e) {
+          const error = e as Error;
+          simultaneousPromises.push(this.writeLog(functionName, blockHeight, 'Failed to get database connection parameters', error.message));
+          throw error;
         }
 
         await this.setStatus(functionName, blockHeight, 'RUNNING');
@@ -219,11 +231,10 @@ export default class Indexer {
     schema: string,
     blockHeight: number,
   ): Record<string, Record<string, (...args: any[]) => any>> {
-    const account = functionName.split('/')[0].replace(/[.-]/g, '_');
     try {
       const tables = this.getTableNames(schema);
       const sanitizedTableNames = new Set<string>();
-      const dmlHandler: DmlHandler = this.deps.DmlHandler.createLazy(account);
+      const dmlHandler: DmlHandler = this.deps.DmlHandler.create(this.database_connection_parameters);
 
       // Generate and collect methods for each table name
       const result = tables.reduce((prev, tableName) => {

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -147,4 +147,8 @@ export default class Provisioner {
       'Failed to provision endpoint'
     );
   }
+
+  async getDatabaseConnectionParameters (accountId: string): Promise<any> {
+    return await this.hasuraClient.getDbConnectionParameters(accountId);
+  }
 }

--- a/runner/src/redis-client/redis-client.test.ts
+++ b/runner/src/redis-client/redis-client.test.ts
@@ -66,21 +66,6 @@ describe('RedisClient', () => {
     expect(unprocessedMessageCount).toEqual(2);
   });
 
-  it('returns stream storage data', async () => {
-    const mockClient = {
-      on: jest.fn(),
-      connect: jest.fn().mockResolvedValue(null),
-      get: jest.fn().mockResolvedValue(JSON.stringify({ account_id: '123', function_name: 'testFunc' })),
-    } as any;
-
-    const client = new RedisClient(mockClient);
-
-    const storageData = await client.getStreamStorage('streamKey');
-
-    expect(mockClient.get).toHaveBeenCalledWith('streamKey:storage');
-    expect(storageData).toEqual({ account_id: '123', function_name: 'testFunc' });
-  });
-
   it('returns the list of streams', async () => {
     const mockClient = {
       on: jest.fn(),

--- a/runner/src/redis-client/redis-client.ts
+++ b/runner/src/redis-client/redis-client.ts
@@ -73,6 +73,7 @@ export default class RedisClient {
   };
 
   async getStreamStorage (streamKey: string): Promise<StreamStorage> {
+    console.log('Should never run 2');
     const storageKey = this.generateStorageKey(streamKey);
     const results = await this.client.get(storageKey);
 

--- a/runner/src/redis-client/redis-client.ts
+++ b/runner/src/redis-client/redis-client.ts
@@ -7,13 +7,6 @@ interface StreamMessage {
   }
 }
 
-interface StreamStorage {
-  account_id: string
-  function_name: string
-  code: string
-  schema: string
-}
-
 export type StreamType = 'historical' | 'real-time';
 
 export default class RedisClient {
@@ -28,10 +21,6 @@ export default class RedisClient {
     client.on('error', (err) => { console.log('Redis Client Error', err); });
     client.connect().catch(console.error);
   }
-
-  private generateStorageKey (streamkey: string): string {
-    return `${streamkey}:storage`;
-  };
 
   getStreamType (streamKey: string): StreamType {
     if (streamKey.endsWith(':historical:stream')) {
@@ -70,18 +59,6 @@ export default class RedisClient {
     const results = await this.client.xLen(streamKey);
 
     return results;
-  };
-
-  async getStreamStorage (streamKey: string): Promise<StreamStorage> {
-    console.log('Should never run 2');
-    const storageKey = this.generateStorageKey(streamKey);
-    const results = await this.client.get(storageKey);
-
-    if (results === null) {
-      throw new Error(`${storageKey} does not have any data`);
-    }
-
-    return JSON.parse(results);
   };
 
   async getStreams (): Promise<string[]> {


### PR DESCRIPTION
Currently, Runner fetches DB credentials every invocation of runFunction because provisioning of the user's DB occurs in Runner. As such, we couldn't be sure if we could fetch credentials for the user's DB from Hasura or not. The fetch is slow and increases the latency of any indexers which leverage context.db.

I updated the code to cache the credentials locally after the first successful fetch. This allows all future requests to succeed as these credentials will never change after they are set. The changes were aimed to be minimal as we intend to migrate provisioning out of Runner. In fact, the changes aid in the effort as the credentials fetch is done through the Provisioner class rather than separately in DmlHandler. 