### PR TITLE
feat: Reduce Runner Logs and DB Writes

### DIFF
--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -1,5 +1,6 @@
 import { wrapError } from '../utility';
 import PgClient from '../pg-client';
+import { type DatabaseConnectionParameters } from '../provisioner/provisioner';
 
 export default class DmlHandler {
   validTableNameRegex = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
@@ -9,15 +10,15 @@ export default class DmlHandler {
   ) {}
 
   static create (
-    database_connection_parameters: any,
+    databaseConnectionParameters: DatabaseConnectionParameters,
     pgClientInstance: PgClient | undefined = undefined
   ): DmlHandler {
     const pgClient = pgClientInstance ?? new PgClient({
-      user: database_connection_parameters.username,
-      password: database_connection_parameters.password,
+      user: databaseConnectionParameters.username,
+      password: databaseConnectionParameters.password,
       host: process.env.PGHOST,
-      port: Number(database_connection_parameters.port),
-      database: database_connection_parameters.database,
+      port: Number(databaseConnectionParameters.port),
+      database: databaseConnectionParameters.database,
     });
     return new DmlHandler(pgClient);
   }

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -1,6 +1,6 @@
 import { startServer as startMetricsServer } from './metrics';
 import startRunnerServer from './server/runner-server';
-import StreamHandler from './stream-handler';
+import type StreamHandler from './stream-handler';
 
 const executors = new Map<string, StreamHandler>();
 startRunnerServer(executors);

--- a/runner/src/indexer/__snapshots__/indexer.test.ts.snap
+++ b/runner/src/indexer/__snapshots__/indexer.test.ts.snap
@@ -1,5 +1,215 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Indexer unit tests Indexer log level respected by writeLog 1`] = `
+[
+  [
+    "mock-hasura-endpoint/v1/graphql",
+    {
+      "body": "{"query":"mutation writeLog($function_name: String!, $block_height: numeric!, $message: String!){\\n                insert_indexer_log_entries_one(object: {function_name: $function_name, block_height: $block_height, message: $message}) {id}\\n             }","variables":{"function_name":"buildnear.testnet/test","block_height":456,"message":"Running function buildnear.testnet/test on block 456, lag is: NaNms from block timestamp"}}",
+      "headers": {
+        "Content-Type": "application/json",
+        "X-Hasura-Admin-Secret": "mock-hasura-secret",
+        "X-Hasura-Role": "append",
+        "X-Hasura-Use-Backend-Only-Permissions": "true",
+      },
+      "method": "POST",
+    },
+  ],
+  [
+    "mock-hasura-endpoint/v1/graphql",
+    {
+      "body": "{"query":"\\n                mutation SetStatus($function_name: String, $status: String) {\\n                  insert_indexer_state_one(object: {function_name: $function_name, status: $status, current_block_height: 0 }, on_conflict: { constraint: indexer_state_pkey, update_columns: status }) {\\n                    function_name\\n                    status\\n                  }\\n                }\\n            ","variables":{"function_name":"buildnear.testnet/test","status":"RUNNING"}}",
+      "headers": {
+        "Content-Type": "application/json",
+        "X-Hasura-Admin-Secret": "mock-hasura-secret",
+        "X-Hasura-Role": "append",
+        "X-Hasura-Use-Backend-Only-Permissions": "true",
+      },
+      "method": "POST",
+    },
+  ],
+  [
+    "mock-hasura-endpoint/v1/graphql",
+    {
+      "body": "{"query":"mutation writeLog($function_name: String!, $block_height: numeric!, $message: String!){\\n                insert_indexer_log_entries_one(object: {function_name: $function_name, block_height: $block_height, message: $message}) {id}\\n             }","variables":{"function_name":"buildnear.testnet/test","block_height":456,"message":"debug log"}}",
+      "headers": {
+        "Content-Type": "application/json",
+        "X-Hasura-Admin-Secret": "mock-hasura-secret",
+        "X-Hasura-Role": "append",
+        "X-Hasura-Use-Backend-Only-Permissions": "true",
+      },
+      "method": "POST",
+    },
+  ],
+  [
+    "mock-hasura-endpoint/v1/graphql",
+    {
+      "body": "{"query":"mutation writeLog($function_name: String!, $block_height: numeric!, $message: String!){\\n                insert_indexer_log_entries_one(object: {function_name: $function_name, block_height: $block_height, message: $message}) {id}\\n             }","variables":{"function_name":"buildnear.testnet/test","block_height":456,"message":"info log"}}",
+      "headers": {
+        "Content-Type": "application/json",
+        "X-Hasura-Admin-Secret": "mock-hasura-secret",
+        "X-Hasura-Role": "append",
+        "X-Hasura-Use-Backend-Only-Permissions": "true",
+      },
+      "method": "POST",
+    },
+  ],
+  [
+    "mock-hasura-endpoint/v1/graphql",
+    {
+      "body": "{"query":"mutation writeLog($function_name: String!, $block_height: numeric!, $message: String!){\\n                insert_indexer_log_entries_one(object: {function_name: $function_name, block_height: $block_height, message: $message}) {id}\\n             }","variables":{"function_name":"buildnear.testnet/test","block_height":456,"message":"error log"}}",
+      "headers": {
+        "Content-Type": "application/json",
+        "X-Hasura-Admin-Secret": "mock-hasura-secret",
+        "X-Hasura-Role": "append",
+        "X-Hasura-Use-Backend-Only-Permissions": "true",
+      },
+      "method": "POST",
+    },
+  ],
+  [
+    "mock-hasura-endpoint/v1/graphql",
+    {
+      "body": "{"query":"mutation writeLog($function_name: String!, $block_height: numeric!, $message: String!){\\n                insert_indexer_log_entries_one(object: {function_name: $function_name, block_height: $block_height, message: $message}) {id}\\n             }","variables":{"function_name":"buildnear.testnet/test","block_height":456,"message":"Selecting objects in table posts with values {\\"account_id\\":\\"morgs_near\\",\\"receipt_id\\":\\"abc\\"} with no limit"}}",
+      "headers": {
+        "Content-Type": "application/json",
+        "X-Hasura-Admin-Secret": "mock-hasura-secret",
+        "X-Hasura-Role": "append",
+        "X-Hasura-Use-Backend-Only-Permissions": "true",
+      },
+      "method": "POST",
+    },
+  ],
+  [
+    "mock-hasura-endpoint/v1/graphql",
+    {
+      "body": "{"query":"mutation WriteBlock($function_name: String!, $block_height: numeric!) {\\n                  insert_indexer_state(\\n                    objects: {current_block_height: $block_height, function_name: $function_name}\\n                    on_conflict: {constraint: indexer_state_pkey, update_columns: current_block_height}\\n                  ) {\\n                    returning {\\n                      current_block_height\\n                      function_name\\n                    }\\n                  }\\n                }","variables":{"function_name":"buildnear.testnet/test","block_height":456}}",
+      "headers": {
+        "Content-Type": "application/json",
+        "X-Hasura-Admin-Secret": "mock-hasura-secret",
+        "X-Hasura-Role": "append",
+        "X-Hasura-Use-Backend-Only-Permissions": "true",
+      },
+      "method": "POST",
+    },
+  ],
+]
+`;
+
+exports[`Indexer unit tests Indexer log level respected by writeLog 2`] = `
+[
+  [
+    "mock-hasura-endpoint/v1/graphql",
+    {
+      "body": "{"query":"mutation writeLog($function_name: String!, $block_height: numeric!, $message: String!){\\n                insert_indexer_log_entries_one(object: {function_name: $function_name, block_height: $block_height, message: $message}) {id}\\n             }","variables":{"function_name":"buildnear.testnet/test","block_height":456,"message":"Running function buildnear.testnet/test on block 456, lag is: NaNms from block timestamp"}}",
+      "headers": {
+        "Content-Type": "application/json",
+        "X-Hasura-Admin-Secret": "mock-hasura-secret",
+        "X-Hasura-Role": "append",
+        "X-Hasura-Use-Backend-Only-Permissions": "true",
+      },
+      "method": "POST",
+    },
+  ],
+  [
+    "mock-hasura-endpoint/v1/graphql",
+    {
+      "body": "{"query":"\\n                mutation SetStatus($function_name: String, $status: String) {\\n                  insert_indexer_state_one(object: {function_name: $function_name, status: $status, current_block_height: 0 }, on_conflict: { constraint: indexer_state_pkey, update_columns: status }) {\\n                    function_name\\n                    status\\n                  }\\n                }\\n            ","variables":{"function_name":"buildnear.testnet/test","status":"RUNNING"}}",
+      "headers": {
+        "Content-Type": "application/json",
+        "X-Hasura-Admin-Secret": "mock-hasura-secret",
+        "X-Hasura-Role": "append",
+        "X-Hasura-Use-Backend-Only-Permissions": "true",
+      },
+      "method": "POST",
+    },
+  ],
+  [
+    "mock-hasura-endpoint/v1/graphql",
+    {
+      "body": "{"query":"mutation writeLog($function_name: String!, $block_height: numeric!, $message: String!){\\n                insert_indexer_log_entries_one(object: {function_name: $function_name, block_height: $block_height, message: $message}) {id}\\n             }","variables":{"function_name":"buildnear.testnet/test","block_height":456,"message":"info log"}}",
+      "headers": {
+        "Content-Type": "application/json",
+        "X-Hasura-Admin-Secret": "mock-hasura-secret",
+        "X-Hasura-Role": "append",
+        "X-Hasura-Use-Backend-Only-Permissions": "true",
+      },
+      "method": "POST",
+    },
+  ],
+  [
+    "mock-hasura-endpoint/v1/graphql",
+    {
+      "body": "{"query":"mutation writeLog($function_name: String!, $block_height: numeric!, $message: String!){\\n                insert_indexer_log_entries_one(object: {function_name: $function_name, block_height: $block_height, message: $message}) {id}\\n             }","variables":{"function_name":"buildnear.testnet/test","block_height":456,"message":"error log"}}",
+      "headers": {
+        "Content-Type": "application/json",
+        "X-Hasura-Admin-Secret": "mock-hasura-secret",
+        "X-Hasura-Role": "append",
+        "X-Hasura-Use-Backend-Only-Permissions": "true",
+      },
+      "method": "POST",
+    },
+  ],
+  [
+    "mock-hasura-endpoint/v1/graphql",
+    {
+      "body": "{"query":"mutation WriteBlock($function_name: String!, $block_height: numeric!) {\\n                  insert_indexer_state(\\n                    objects: {current_block_height: $block_height, function_name: $function_name}\\n                    on_conflict: {constraint: indexer_state_pkey, update_columns: current_block_height}\\n                  ) {\\n                    returning {\\n                      current_block_height\\n                      function_name\\n                    }\\n                  }\\n                }","variables":{"function_name":"buildnear.testnet/test","block_height":456}}",
+      "headers": {
+        "Content-Type": "application/json",
+        "X-Hasura-Admin-Secret": "mock-hasura-secret",
+        "X-Hasura-Role": "append",
+        "X-Hasura-Use-Backend-Only-Permissions": "true",
+      },
+      "method": "POST",
+    },
+  ],
+]
+`;
+
+exports[`Indexer unit tests Indexer log level respected by writeLog 3`] = `
+[
+  [
+    "mock-hasura-endpoint/v1/graphql",
+    {
+      "body": "{"query":"\\n                mutation SetStatus($function_name: String, $status: String) {\\n                  insert_indexer_state_one(object: {function_name: $function_name, status: $status, current_block_height: 0 }, on_conflict: { constraint: indexer_state_pkey, update_columns: status }) {\\n                    function_name\\n                    status\\n                  }\\n                }\\n            ","variables":{"function_name":"buildnear.testnet/test","status":"RUNNING"}}",
+      "headers": {
+        "Content-Type": "application/json",
+        "X-Hasura-Admin-Secret": "mock-hasura-secret",
+        "X-Hasura-Role": "append",
+        "X-Hasura-Use-Backend-Only-Permissions": "true",
+      },
+      "method": "POST",
+    },
+  ],
+  [
+    "mock-hasura-endpoint/v1/graphql",
+    {
+      "body": "{"query":"mutation writeLog($function_name: String!, $block_height: numeric!, $message: String!){\\n                insert_indexer_log_entries_one(object: {function_name: $function_name, block_height: $block_height, message: $message}) {id}\\n             }","variables":{"function_name":"buildnear.testnet/test","block_height":456,"message":"error log"}}",
+      "headers": {
+        "Content-Type": "application/json",
+        "X-Hasura-Admin-Secret": "mock-hasura-secret",
+        "X-Hasura-Role": "append",
+        "X-Hasura-Use-Backend-Only-Permissions": "true",
+      },
+      "method": "POST",
+    },
+  ],
+  [
+    "mock-hasura-endpoint/v1/graphql",
+    {
+      "body": "{"query":"mutation WriteBlock($function_name: String!, $block_height: numeric!) {\\n                  insert_indexer_state(\\n                    objects: {current_block_height: $block_height, function_name: $function_name}\\n                    on_conflict: {constraint: indexer_state_pkey, update_columns: current_block_height}\\n                  ) {\\n                    returning {\\n                      current_block_height\\n                      function_name\\n                    }\\n                  }\\n                }","variables":{"function_name":"buildnear.testnet/test","block_height":456}}",
+      "headers": {
+        "Content-Type": "application/json",
+        "X-Hasura-Admin-Secret": "mock-hasura-secret",
+        "X-Hasura-Role": "append",
+        "X-Hasura-Use-Backend-Only-Permissions": "true",
+      },
+      "method": "POST",
+    },
+  ],
+]
+`;
+
 exports[`Indexer unit tests Indexer.buildContext() can fetch from the near social api 1`] = `
 [
   [

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -36,14 +36,16 @@ interface IndexerFunction {
 
 export default class Indexer {
   DEFAULT_HASURA_ROLE;
-  database_connection_parameters: DatabaseConnectionParameters | undefined = undefined;
 
   private readonly indexer_behavior: IndexerBehavior;
   private readonly deps: Dependencies;
+  // TODO: After provisioning migrated out of Runner, fetch credentials before Indexer initialization
+  private database_connection_parameters: DatabaseConnectionParameters | undefined;
 
   constructor (
     indexerBehavior: IndexerBehavior,
-    deps?: Partial<Dependencies>
+    deps?: Partial<Dependencies>,
+    databaseConnectionParameters = undefined,
   ) {
     this.DEFAULT_HASURA_ROLE = 'append';
     this.indexer_behavior = indexerBehavior;
@@ -54,6 +56,7 @@ export default class Indexer {
       parser: new Parser(),
       ...deps,
     };
+    this.database_connection_parameters = databaseConnectionParameters;
   }
 
   async runFunctions (

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -6,6 +6,8 @@ import { Parser } from 'node-sql-parser';
 import Provisioner from '../provisioner';
 import DmlHandler from '../dml-handler/dml-handler';
 import { type IndexerBehavior, LogLevel, Status } from '../stream-handler/stream-handler';
+import { type DatabaseConnectionParameters } from '../provisioner/provisioner';
+import assert from 'assert';
 
 interface Dependencies {
   fetch: typeof fetch
@@ -30,14 +32,6 @@ interface IndexerFunction {
   provisioned?: boolean
   schema: string
   code: string
-}
-
-interface DatabaseConnectionParameters {
-  host: string
-  port: number
-  database: string
-  user: string
-  password: string
 }
 
 export default class Indexer {
@@ -249,6 +243,7 @@ export default class Indexer {
     try {
       const tables = this.getTableNames(schema);
       const sanitizedTableNames = new Set<string>();
+      assert(this.database_connection_parameters !== undefined, 'Database connection parameters are not set');
       const dmlHandler: DmlHandler = this.deps.DmlHandler.create(this.database_connection_parameters);
 
       // Generate and collect methods for each table name

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -75,6 +75,7 @@ export default class Indexer {
 
         const runningMessage = `Running function ${functionName} on block ${blockHeight}, lag is: ${lag?.toString()}ms from block timestamp`;
 
+        // TODO: Migrate Set Status to Stream Handler
         simultaneousPromises.push(this.writeLog(LogLevel.INFO, functionName, blockHeight, runningMessage));
 
         const hasuraRoleName = functionName.split('/')[0].replace(/[.-]/g, '_');
@@ -119,16 +120,12 @@ export default class Indexer {
           await vm.run(modifiedFunction);
         } catch (e) {
           const error = e as Error;
-          // NOTE: logging the exception would likely leak some information about the index runner.
-          // For now, we just log the message. In the future we could sanitize the stack trace
-          // and give the correct line number offsets within the indexer function
-          console.error(`${functionName}: Error running IndexerFunction on block ${blockHeight}: ${error.message}`);
           await this.writeLog(LogLevel.ERROR, functionName, blockHeight, 'Error running IndexerFunction', error.message);
           throw e;
         }
         simultaneousPromises.push(this.writeFunctionState(functionName, blockHeight, isHistorical));
       } catch (e) {
-        console.error(`${functionName}: Failed to run function`, e);
+        // TODO: Migrate Set Status to Stream Handler
         await this.setStatus(functionName, blockHeight, Status.FAILING);
         throw e;
       } finally {

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -5,7 +5,7 @@ import { Parser } from 'node-sql-parser';
 
 import Provisioner from '../provisioner';
 import DmlHandler from '../dml-handler/dml-handler';
-import { Status } from '../stream-handler/stream-handler';
+import { LogLevel, Status } from '../stream-handler/stream-handler';
 
 interface Dependencies {
   fetch: typeof fetch
@@ -62,7 +62,7 @@ export default class Indexer {
     block: Block,
     functions: Record<string, IndexerFunction>,
     isHistorical: boolean,
-    options: { provision?: boolean } = { provision: false }
+    options: { provision?: boolean, log_level: LogLevel } = { provision: false, log_level: LogLevel.INFO }
   ): Promise<string[]> {
     const blockHeight = block.blockHeight;
 
@@ -76,7 +76,6 @@ export default class Indexer {
         const indexerFunction = functions[functionName];
 
         const runningMessage = `Running function ${functionName} on block ${blockHeight}` + (isHistorical ? ' historical backfill' : `, lag is: ${lag?.toString()}ms from block timestamp`);
-        console.log(runningMessage); // Print the running message to the console
 
         simultaneousPromises.push(this.writeLog(functionName, blockHeight, runningMessage));
 

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -109,7 +109,7 @@ export default class Indexer {
           throw error;
         }
 
-        // TODO: Migrate Set Status to Stream Handler
+        // TODO: Prevent unnecesary reruns of set status
         simultaneousPromises.push(this.setStatus(functionName, blockHeight, 'RUNNING'));
         const vm = new VM({ timeout: 20000, allowAsync: true });
         const context = this.buildContext(indexerFunction.schema, functionName, blockHeight, hasuraRoleName);
@@ -128,7 +128,7 @@ export default class Indexer {
         }
         simultaneousPromises.push(this.writeFunctionState(functionName, blockHeight, isHistorical));
       } catch (e) {
-        // TODO: Migrate Set Status to Stream Handler
+        // TODO: Prevent unnecesary reruns of set status
         await this.setStatus(functionName, blockHeight, Status.FAILING);
         throw e;
       } finally {

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -78,7 +78,6 @@ export default class Indexer {
 
         const runningMessage = `Running function ${functionName} on block ${blockHeight}, lag is: ${lag?.toString()}ms from block timestamp`;
 
-        // TODO: Migrate Set Status to Stream Handler
         simultaneousPromises.push(this.writeLog(LogLevel.INFO, functionName, blockHeight, runningMessage));
 
         const hasuraRoleName = functionName.split('/')[0].replace(/[.-]/g, '_');
@@ -110,6 +109,7 @@ export default class Indexer {
           throw error;
         }
 
+        // TODO: Migrate Set Status to Stream Handler
         simultaneousPromises.push(this.setStatus(functionName, blockHeight, 'RUNNING'));
         const vm = new VM({ timeout: 20000, allowAsync: true });
         const context = this.buildContext(indexerFunction.schema, functionName, blockHeight, hasuraRoleName);

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -337,7 +337,6 @@ export default class Indexer {
   }
 
   async writeLog (logLevel: LogLevel, functionName: string, blockHeight: number, ...message: any[]): Promise<any> {
-    // If log level is lower than configured log level, do not write log to database
     if (logLevel < this.indexer_behavior.log_level) {
       return;
     }

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -13,6 +13,14 @@ const sharedPgClient = new PgClient({
   port: Number(process.env.PGPORT),
 });
 
+export interface DatabaseConnectionParameters {
+  host: string
+  port: number
+  database: string
+  username: string
+  password: string
+}
+
 export default class Provisioner {
   constructor (
     private readonly hasuraClient: HasuraClient = new HasuraClient(),

--- a/runner/src/server/runner-service.test.ts
+++ b/runner/src/server/runner-service.test.ts
@@ -1,5 +1,5 @@
 import type StreamHandler from '../stream-handler/stream-handler';
-import { Status } from '../stream-handler/stream-handler';
+import { LogLevel, Status } from '../stream-handler/stream-handler';
 import getRunnerService from './runner-service';
 import * as grpc from '@grpc/grpc-js';
 
@@ -24,6 +24,11 @@ const BASIC_EXECUTOR_CONTEXT = {
 
 describe('Runner gRPC Service', () => {
   let genericStreamHandlerType: typeof StreamHandler;
+
+  const genericIndexerBehavior = {
+    log_level: LogLevel.INFO
+  };
+
   beforeEach(() => {
     genericStreamHandlerType = jest.fn().mockImplementation((...args) => {
       return {
@@ -40,7 +45,7 @@ describe('Runner gRPC Service', () => {
 
     service.StartExecutor(request, mockCallback);
 
-    expect(genericStreamHandlerType).toHaveBeenCalledWith(BASIC_REDIS_STREAM, BASIC_INDEXER_CONFIG);
+    expect(genericStreamHandlerType).toHaveBeenCalledWith(BASIC_REDIS_STREAM, BASIC_INDEXER_CONFIG, genericIndexerBehavior);
     expect(mockCallback).toHaveBeenCalledWith(null, { executorId: BASIC_EXECUTOR_ID });
   });
 
@@ -103,7 +108,7 @@ describe('Runner gRPC Service', () => {
     service.StartExecutor(startRequest, mockCallback);
 
     expect(genericStreamHandlerType).toHaveBeenCalledTimes(1);
-    expect(genericStreamHandlerType).toHaveBeenCalledWith(BASIC_REDIS_STREAM, BASIC_INDEXER_CONFIG);
+    expect(genericStreamHandlerType).toHaveBeenCalledWith(BASIC_REDIS_STREAM, BASIC_INDEXER_CONFIG, genericIndexerBehavior);
     expect(mockCallback.mock.calls).toEqual([
       [null, { executorId: BASIC_EXECUTOR_ID }],
       [{

--- a/runner/src/server/runner-service.ts
+++ b/runner/src/server/runner-service.ts
@@ -1,6 +1,6 @@
 import { type ServerUnaryCall, type sendUnaryData } from '@grpc/grpc-js';
 import * as grpc from '@grpc/grpc-js';
-import { Status } from '../stream-handler/stream-handler';
+import { LogLevel, Status } from '../stream-handler/stream-handler';
 import crypto from 'crypto';
 
 import { type RunnerHandlers } from '../generated/runner/Runner';
@@ -52,6 +52,7 @@ function getRunnerService (executors: Map<string, StreamHandler>, StreamHandlerT
           version: Number(version),
           code,
           schema,
+          log_level: LogLevel.INFO, // TODO: Pass this in from Coordinator
         });
         executors.set(executorId, streamHandler);
         callback(null, { executorId });

--- a/runner/src/server/runner-service.ts
+++ b/runner/src/server/runner-service.ts
@@ -52,6 +52,8 @@ function getRunnerService (executors: Map<string, StreamHandler>, StreamHandlerT
           version: Number(version),
           code,
           schema,
+        },
+        {
           log_level: LogLevel.INFO, // TODO: Pass this in from Coordinator
         });
         executors.set(executorId, streamHandler);

--- a/runner/src/stream-handler/stream-handler.ts
+++ b/runner/src/stream-handler/stream-handler.ts
@@ -30,6 +30,7 @@ export interface IndexerBehavior {
 export enum WorkerMessageType {
   METRICS = 'METRICS',
   BLOCK_HEIGHT = 'BLOCK_HEIGHT',
+  STATUS = 'STATUS',
 }
 
 export interface WorkerMessage {
@@ -98,6 +99,9 @@ export default class StreamHandler {
 
   private handleMessage (message: WorkerMessage): void {
     switch (message.type) {
+      case WorkerMessageType.STATUS:
+        this.executorContext.status = message.data;
+        break;
       case WorkerMessageType.BLOCK_HEIGHT:
         this.executorContext.block_height = message.data;
         break;

--- a/runner/src/stream-handler/stream-handler.ts
+++ b/runner/src/stream-handler/stream-handler.ts
@@ -9,12 +9,19 @@ export enum Status {
   FAILING = 'FAILING',
   STOPPED = 'STOPPED',
 }
+
+export enum LogLevel {
+  DEBUG = 'DEBUG',
+  INFO = 'INFO',
+  ERROR = 'ERROR',
+}
 export interface IndexerConfig {
   account_id: string
   function_name: string
   code: string
   schema: string
   version: number
+  log_level: LogLevel
 }
 
 export enum WorkerMessageType {

--- a/runner/src/stream-handler/worker.ts
+++ b/runner/src/stream-handler/worker.ts
@@ -43,7 +43,7 @@ void (async function main () {
     indexerBehavior,
   };
 
-  console.log('Started processing stream: ', indexerConfig, indexerBehavior);
+  console.log('Started processing stream: ', streamKey, indexerConfig.account_id, indexerConfig.function_name, indexerConfig.version, indexerBehavior);
 
   await handleStream(workerContext, streamKey);
 })();

--- a/runner/src/stream-handler/worker.ts
+++ b/runner/src/stream-handler/worker.ts
@@ -119,15 +119,13 @@ async function blockQueueConsumer (workerContext: WorkerContext, streamKey: stri
         continue;
       }
       METRICS.BLOCK_WAIT_DURATION.labels({ indexer: indexerName, type: workerContext.streamType }).observe(performance.now() - blockStartTime);
-      await indexer.runFunctions(block, functions, isHistorical, { provision: true });
+      await indexer.runFunctions(block, functions, isHistorical, { provision: true, log_level: workerContext.indexerConfig.log_level });
       await workerContext.redisClient.deleteStreamMessage(streamKey, streamMessageId);
       await workerContext.queue.shift();
 
       METRICS.EXECUTION_DURATION.labels({ indexer: indexerName, type: workerContext.streamType }).observe(performance.now() - startTime);
 
       METRICS.LAST_PROCESSED_BLOCK_HEIGHT.labels({ indexer: indexerName, type: workerContext.streamType }).set(currBlockHeight);
-
-      console.log(`Success: ${indexerName} ${workerContext.streamType} on block ${currBlockHeight}}`);
     } catch (err) {
       await sleep(10000);
       console.log(`Failed: ${indexerName} ${workerContext.streamType} on block ${currBlockHeight}`, err);


### PR DESCRIPTION
Runner logs excessively, both to the machine, and to postgres. Most of these logs are not necessary or contain too much information.

The plan is to reduce logs the following ways.

1. Only output failure log for first failure (Instead of every 10 seconds)
2. Stop outputting "Running function on X block" logs to GCP
3. Stop outputting "Success: Ran function on X block" logs to GCP
4. Remove DB logs for hasura calls
5. Remove context.db logging

To support 1, Runner needs a way to know when a failure was the first. So, it needs to remember the state of the Runner locally. This is a good opportunity to introduce a refactor to stop setting of Runner status every loop. We can instead only write when the status changes.

In addition, there is some overlap with this epic. So, to orient these changes towards our intentions there, I will also introduce a rudimentary log level into Runner. This value will be INFO by default, and the extra logs will be at the DEBUG level. This ensures these logs are automatically skipped while also adding some backbone for expected future implementation.