### PR TITLE
feat: Support Adding of Owners through add_user

### DIFF
--- a/registry/contract/deploy-dev.sh
+++ b/registry/contract/deploy-dev.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-near deploy --wasmFile ./target/wasm32-unknown-unknown/release/registry.wasm --accountId dev-queryapi.dataplatform.near
+near contract deploy dev-queryapi.dataplatform.near use-file ./target/wasm32-unknown-unknown/release/registry.wasm without-init-call network-config mainnet sign-with-keychain send

--- a/registry/contract/deploy-prod.sh
+++ b/registry/contract/deploy-prod.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-near deploy --wasmFile ./target/wasm32-unknown-unknown/release/registry.wasm --accountId queryapi.dataplatform.near
+near contract deploy queryapi.dataplatform.near use-file ./target/wasm32-unknown-unknown/release/registry.wasm without-init-call network-config mainnet sign-with-keychain send

--- a/registry/contract/src/lib.rs
+++ b/registry/contract/src/lib.rs
@@ -235,7 +235,7 @@ impl Contract {
         }
     }
 
-    pub fn add_user(&mut self, account_id: String, role: ) {
+    pub fn add_user(&mut self, account_id: String, role: String) {
         self.assert_roles(vec![Role::Owner]);
 
         let account_id = account_id.parse::<AccountId>().unwrap_or_else(|_| {
@@ -249,6 +249,12 @@ impl Contract {
         {
             env::panic_str(&format!("Account {} already exists", account_id));
         }
+
+        let role_to_set: Role = match role.as_str() {
+            "Owner" => Role::Owner,
+            "User" => Role::User,
+            _ => Role::User,
+        };
 
         self.account_roles.push(AccountRole {
             account_id,

--- a/registry/contract/src/lib.rs
+++ b/registry/contract/src/lib.rs
@@ -95,6 +95,10 @@ impl Default for Contract {
                     role: Role::Owner,
                 },
                 AccountRole {
+                    account_id: "eduohe.near".parse().unwrap(),
+                    role: Role::Owner,
+                },
+                AccountRole {
                     account_id: env::current_account_id(),
                     role: Role::Owner,
                 },

--- a/registry/contract/src/lib.rs
+++ b/registry/contract/src/lib.rs
@@ -235,7 +235,7 @@ impl Contract {
         }
     }
 
-    pub fn add_user(&mut self, account_id: String) {
+    pub fn add_user(&mut self, account_id: String, role: ) {
         self.assert_roles(vec![Role::Owner]);
 
         let account_id = account_id.parse::<AccountId>().unwrap_or_else(|_| {
@@ -252,7 +252,7 @@ impl Contract {
 
         self.account_roles.push(AccountRole {
             account_id,
-            role: Role::User,
+            role: role_to_set,
         })
     }
 
@@ -647,7 +647,7 @@ mod tests {
                 role: Role::User,
             }],
         };
-        contract.add_user("alice.near".to_string());
+        contract.add_user("alice.near".to_string(), "".to_string());
     }
 
     #[test]
@@ -661,11 +661,11 @@ mod tests {
             }],
         };
 
-        contract.add_user("bob.near".to_string());
+        contract.add_user("bob.near".to_string(), "".to_string());
     }
 
     #[test]
-    fn add_user() {
+    fn add_user_with_no_role_parameter() {
         let mut contract = Contract {
             registry: IndexersByAccount::new(StorageKeys::Registry),
             account_roles: vec![AccountRole {
@@ -674,7 +674,7 @@ mod tests {
             }],
         };
 
-        contract.add_user("alice.near".to_string());
+        contract.add_user("alice.near".to_string(), "".to_string());
 
         assert!(contract
             .account_roles
@@ -693,7 +693,25 @@ mod tests {
             }],
         };
 
-        contract.add_user("0".to_string());
+        contract.add_user("0".to_string(), "".to_string());
+    }
+
+    #[test]
+    fn owner_can_add_user_with_owner_role() {
+        let mut contract = Contract {
+            registry: IndexersByAccount::new(StorageKeys::Registry),
+            account_roles: vec![AccountRole {
+                account_id: "bob.near".parse().unwrap(),
+                role: Role::Owner,
+            }],
+        };
+
+        contract.add_user("alice.near".to_string(), "Owner".to_string());
+
+        assert!(contract
+            .account_roles
+            .iter()
+            .any(|account| account.account_id == "alice.near"))
     }
 
     #[test]

--- a/registry/contract/src/lib.rs
+++ b/registry/contract/src/lib.rs
@@ -235,7 +235,7 @@ impl Contract {
         }
     }
 
-    pub fn add_user(&mut self, account_id: String, role: String) {
+    pub fn add_user(&mut self, account_id: String, role: Option<Role>) {
         self.assert_roles(vec![Role::Owner]);
 
         let account_id = account_id.parse::<AccountId>().unwrap_or_else(|_| {
@@ -250,15 +250,9 @@ impl Contract {
             env::panic_str(&format!("Account {} already exists", account_id));
         }
 
-        let role_to_set: Role = match role.as_str() {
-            "Owner" => Role::Owner,
-            "User" => Role::User,
-            _ => Role::User,
-        };
-
         self.account_roles.push(AccountRole {
             account_id,
-            role: role_to_set,
+            role: role.unwrap_or(Role::User),
         })
     }
 
@@ -653,7 +647,7 @@ mod tests {
                 role: Role::User,
             }],
         };
-        contract.add_user("alice.near".to_string(), "".to_string());
+        contract.add_user("alice.near".to_string(), None);
     }
 
     #[test]
@@ -667,7 +661,7 @@ mod tests {
             }],
         };
 
-        contract.add_user("bob.near".to_string(), "".to_string());
+        contract.add_user("bob.near".to_string(), None);
     }
 
     #[test]
@@ -680,7 +674,7 @@ mod tests {
             }],
         };
 
-        contract.add_user("alice.near".to_string(), "".to_string());
+        contract.add_user("alice.near".to_string(), None);
 
         assert!(contract
             .account_roles
@@ -699,7 +693,7 @@ mod tests {
             }],
         };
 
-        contract.add_user("0".to_string(), "".to_string());
+        contract.add_user("0".to_string(), None);
     }
 
     #[test]
@@ -712,7 +706,7 @@ mod tests {
             }],
         };
 
-        contract.add_user("alice.near".to_string(), "Owner".to_string());
+        contract.add_user("alice.near".to_string(), Some(Role::Owner));
 
         assert!(contract
             .account_roles


### PR DESCRIPTION
There is no way to add someone as Owner without a migration. 

I've updated the add_user function to accept a role as a parameter, allowing addition of Owners without migration. 