### PR TITLE
Support WHERE col IN (...) in context.db.table.select and delete

### DIFF
--- a/frontend/src/utils/pgSchemaTypeGen.js
+++ b/frontend/src/utils/pgSchemaTypeGen.js
@@ -171,10 +171,10 @@ export class PgSchemaTypeGen {
 			itemDefinition += `declare interface ${sanitizedTableName}Item {\n`;
       filterDefinition += `declare interface ${sanitizedTableName}Filter {\n`;
 			for (const [colName, col] of Object.entries(columns)) {
-        partialDefinition += `  ${colName}?: ${col.type};\n`;
         const tsType = col.nullable ? `${col.type} | null` : `${col.type}`
+        partialDefinition += `  ${colName}?: ${tsType};\n`;
         const optional = col.required ? "" : "?";
-        itemDefinition += `  ${colName}${optional}: ${col.nullable ? `${col.type} | null` : col.type};\n`;
+        itemDefinition += `  ${colName}${optional}: ${tsType};\n`;
         const conditionType = `${tsType} | ${col.type}[]`;
         filterDefinition += `  ${colName}?: ${conditionType};\n`;
 			}

--- a/frontend/src/utils/pgSchemaTypeGen.js
+++ b/frontend/src/utils/pgSchemaTypeGen.js
@@ -200,7 +200,6 @@ export class PgSchemaTypeGen {
 
 		contextObject += '\n  }\n};'
 		this.tableList = tableList;
-    console.log(tsDefinitions);
 
 		return tsDefinitions + contextObject;
 	}

--- a/runner/src/dml-handler/dml-handler.test.ts
+++ b/runner/src/dml-handler/dml-handler.test.ts
@@ -1,6 +1,6 @@
 import pgFormat from 'pg-format';
 import DmlHandler from './dml-handler';
-import PgClient from '../pg-client';
+import type PgClient from '../pg-client';
 
 describe('DML Handler tests', () => {
   const getDbConnectionParameters = {
@@ -19,7 +19,7 @@ describe('DML Handler tests', () => {
   beforeEach(() => {
     query = jest.fn().mockReturnValue({ rows: [] });
     pgClient = {
-      query: query, 
+      query,
       format: pgFormat
     } as unknown as PgClient;
   });
@@ -73,6 +73,34 @@ describe('DML Handler tests', () => {
     await dmlHandler.select(SCHEMA, TABLE_NAME, inputObj);
     expect(query.mock.calls).toEqual([
       ['SELECT * FROM test_schema."test_table" WHERE account_id=$1 AND block_height=$2', Object.values(inputObj)]
+    ]);
+  });
+
+  test('Test valid select with a single column condition and multiple column conditions', async () => {
+    const inputObj = {
+      account_id: ['test_acc_near1', 'test_acc_near2'],
+      block_height: 999,
+    };
+
+    const dmlHandler = DmlHandler.create(getDbConnectionParameters, pgClient);
+
+    await dmlHandler.select(SCHEMA, TABLE_NAME, inputObj);
+    expect(query.mock.calls).toEqual([
+      ['SELECT * FROM test_schema."test_table" WHERE account_id IN ($1,$2) AND block_height=$3', [...inputObj.account_id, inputObj.block_height]]
+    ]);
+  });
+
+  test('Test valid select with two multiple column conditions', async () => {
+    const inputObj = {
+      account_id: ['test_acc_near1', 'test_acc_near2'],
+      block_height: [998, 999],
+    };
+
+    const dmlHandler = DmlHandler.create(getDbConnectionParameters, pgClient);
+
+    await dmlHandler.select(SCHEMA, TABLE_NAME, inputObj);
+    expect(query.mock.calls).toEqual([
+      ['SELECT * FROM test_schema."test_table" WHERE account_id IN ($1,$2) AND block_height IN ($3,$4)', [...inputObj.account_id, ...inputObj.block_height]]
     ]);
   });
 

--- a/runner/src/dml-handler/dml-handler.test.ts
+++ b/runner/src/dml-handler/dml-handler.test.ts
@@ -160,17 +160,17 @@ describe('DML Handler tests', () => {
     ]);
   });
 
-  test('Test valid delete on two fields', async () => {
+  test('Test valid delete with a single column condition and multiple column conditions', async () => {
     const inputObj = {
       account_id: 'test_acc_near',
-      block_height: 999,
+      block_height: [998, 999],
     };
 
     const dmlHandler = DmlHandler.create(getDbConnectionParameters, pgClient);
 
     await dmlHandler.delete(SCHEMA, TABLE_NAME, inputObj);
     expect(query.mock.calls).toEqual([
-      ['DELETE FROM test_schema."test_table" WHERE account_id=$1 AND block_height=$2 RETURNING *', Object.values(inputObj)]
+      ['DELETE FROM test_schema."test_table" WHERE account_id=$1 AND block_height IN ($2,$3) RETURNING *', [inputObj.account_id, ...inputObj.block_height]]
     ]);
   });
 });

--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -40,16 +40,16 @@ export default class DmlHandler {
   async select (schemaName: string, tableName: string, object: any, limit: number | null = null): Promise<any[]> {
     const columns = Object.keys(object);
     const queryVars: Array<string | number> = [];
-    const whereClause = Array.from({ length: columns.length }, (_, colIdx) => {
-      const colCondition = Object.values(object)[colIdx];
+    const whereClause = columns.map((colName) => {
+      const colCondition = object[colName];
       if (colCondition instanceof Array) {
         const inVals: Array<string | number> = colCondition as Array<string | number>;
         const inStr = Array.from({ length: inVals.length }, (_, idx) => `$${queryVars.length + idx + 1}`).join(',');
         queryVars.push(...inVals);
-        return `${columns[colIdx]} IN (${inStr})`;
+        return `${colName} IN (${inStr})`;
       } else {
         queryVars.push(colCondition as (string | number));
-        return `${columns[colIdx]}=$${queryVars.length}`;
+        return `${colName}=$${queryVars.length}`;
       }
     }).join(' AND ');
     let query = `SELECT * FROM ${schemaName}."${tableName}" WHERE ${whereClause}`;

--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -2,6 +2,9 @@ import { wrapError } from '../utility';
 import PgClient from '../pg-client';
 import { type DatabaseConnectionParameters } from '../provisioner/provisioner';
 
+type WhereClauseMulti = Record<string, (string | number | Array<string | number>)>;
+type WhereClauseSingle = Record<string, (string | number)>;
+
 export default class DmlHandler {
   validTableNameRegex = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
@@ -23,6 +26,24 @@ export default class DmlHandler {
     return new DmlHandler(pgClient);
   }
 
+  private getWhereClause(whereObject: WhereClauseMulti) {
+    const columns = Object.keys(whereObject);
+    const queryVars: Array<string | number> = [];
+    const whereClause = columns.map((colName) => {
+      const colCondition = whereObject[colName];
+      if (colCondition instanceof Array) {
+        const inVals: Array<string | number> = colCondition;
+        const inStr = Array.from({length: inVals.length}, (_, idx) => `$${queryVars.length + idx + 1}`).join(',');
+        queryVars.push(...inVals);
+        return `${colName} IN (${inStr})`;
+      } else {
+        queryVars.push(colCondition);
+        return `${colName}=$${queryVars.length}`;
+      }
+    }).join(' AND ');
+    return {queryVars, whereClause};
+  }
+
   async insert (schemaName: string, tableName: string, objects: any[]): Promise<any[]> {
     if (!objects?.length) {
       return [];
@@ -37,21 +58,8 @@ export default class DmlHandler {
     return result.rows;
   }
 
-  async select (schemaName: string, tableName: string, whereObject: Record<string, (string | number | Array<string | number>)>, limit: number | null = null): Promise<any[]> {
-    const columns = Object.keys(whereObject);
-    const queryVars: Array<string | number> = [];
-    const whereClause = columns.map((colName) => {
-      const colCondition = whereObject[colName];
-      if (colCondition instanceof Array) {
-        const inVals: Array<string | number> = colCondition;
-        const inStr = Array.from({ length: inVals.length }, (_, idx) => `$${queryVars.length + idx + 1}`).join(',');
-        queryVars.push(...inVals);
-        return `${colName} IN (${inStr})`;
-      } else {
-        queryVars.push(colCondition);
-        return `${colName}=$${queryVars.length}`;
-      }
-    }).join(' AND ');
+  async select (schemaName: string, tableName: string, whereObject: WhereClauseMulti, limit: number | null = null): Promise<any[]> {
+    const {queryVars, whereClause} = this.getWhereClause(whereObject);
     let query = `SELECT * FROM ${schemaName}."${tableName}" WHERE ${whereClause}`;
     if (limit !== null) {
       query = query.concat(' LIMIT ', Math.round(limit).toString());
@@ -61,7 +69,7 @@ export default class DmlHandler {
     return result.rows;
   }
 
-  async update (schemaName: string, tableName: string, whereObject: any, updateObject: any): Promise<any[]> {
+  async update (schemaName: string, tableName: string, whereObject: WhereClauseSingle, updateObject: any): Promise<any[]> {
     const updateKeys = Object.keys(updateObject);
     const updateParam = Array.from({ length: updateKeys.length }, (_, index) => `${updateKeys[index]}=$${index + 1}`).join(', ');
     const whereKeys = Object.keys(whereObject);
@@ -89,13 +97,11 @@ export default class DmlHandler {
     return result.rows;
   }
 
-  async delete (schemaName: string, tableName: string, object: any): Promise<any[]> {
-    const keys = Object.keys(object);
-    const values = Object.values(object);
-    const param = Array.from({ length: keys.length }, (_, index) => `${keys[index]}=$${index + 1}`).join(' AND ');
-    const query = `DELETE FROM ${schemaName}."${tableName}" WHERE ${param} RETURNING *`;
+  async delete (schemaName: string, tableName: string, whereObject: WhereClauseMulti): Promise<any[]> {
+    const {queryVars, whereClause} = this.getWhereClause(whereObject);
+    const query = `DELETE FROM ${schemaName}."${tableName}" WHERE ${whereClause} RETURNING *`;
 
-    const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query), values), `Failed to execute '${query}' on ${schemaName}."${tableName}".`);
+    const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query), queryVars), `Failed to execute '${query}' on ${schemaName}."${tableName}".`);
     return result.rows;
   }
 }

--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -37,18 +37,18 @@ export default class DmlHandler {
     return result.rows;
   }
 
-  async select (schemaName: string, tableName: string, object: any, limit: number | null = null): Promise<any[]> {
-    const columns = Object.keys(object);
+  async select (schemaName: string, tableName: string, whereObject: Record<string, (string | number | Array<string | number>)>, limit: number | null = null): Promise<any[]> {
+    const columns = Object.keys(whereObject);
     const queryVars: Array<string | number> = [];
     const whereClause = columns.map((colName) => {
-      const colCondition = object[colName];
+      const colCondition = whereObject[colName];
       if (colCondition instanceof Array) {
-        const inVals: Array<string | number> = colCondition as Array<string | number>;
+        const inVals: Array<string | number> = colCondition;
         const inStr = Array.from({ length: inVals.length }, (_, idx) => `$${queryVars.length + idx + 1}`).join(',');
         queryVars.push(...inVals);
         return `${colName} IN (${inStr})`;
       } else {
-        queryVars.push(colCondition as (string | number));
+        queryVars.push(colCondition);
         return `${colName}=$${queryVars.length}`;
       }
     }).join(' AND ');


### PR DESCRIPTION
With this PR, we can use `context.db.Table.select({column_name: ['a.near', 'b.near']})`. I think it is best to keep it within the same select method instead of introducing a new one like `selectMany`. The same support is added for `delete`.

Frontend support is added. I also improved parameter naming to reflect SQL statements like `where`, `values` and `set`. Here is the sample output:
```TS
declare interface ActionsIndexItem {
  block_date: Date;
  receiver_id: string;
  first_block_height: number;
  bitmap: string;
}

declare interface ActionsIndexPartial {
  block_date?: Date;
  receiver_id?: string;
  first_block_height?: number;
  bitmap?: string;
}

declare interface ActionsIndexFilter {
  block_date?: Date | Date[];
  receiver_id?: string | string[];
  first_block_height?: number | number[];
  bitmap?: string | string[];
}

type ActionsIndexColumns = "block_date" | "receiver_id" | "first_block_height" | "bitmap";

declare const context: {
	graphql: (operation, variables) => Promise<any>,
	set: (key, value) => Promise<any>,
	log: (...log) => Promise<any>,
	fetchFromSocialApi: (path, options) => Promise<Response>,
	db: {
		ActionsIndex: {
			insert: (values: ActionsIndexItem | ActionsIndexItem[]) => Promise<ActionsIndexItem[]>;
			select: (where: ActionsIndexFilter, limit = null) => Promise<ActionsIndexItem[]>;
			update: (where: ActionsIndexPartial, set: ActionsIndexPartial) => Promise<ActionsIndexItem[]>;
			upsert: (values: ActionsIndexItem | ActionsIndexItem[], conflictColumns: ActionsIndexColumns[], updateColumns: ActionsIndexColumns[]) => Promise<ActionsIndexItem[]>;
			delete: (where: ActionsIndexFilter) => Promise<ActionsIndexItem[]>;
		},
  }
};
```