### PR TITLE
Cache provisioning status

### DIFF
--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -882,7 +882,7 @@ CREATE TABLE
     } as unknown as StreamerMessage) as unknown as Block;
     const provisioner: any = {
       getDatabaseConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
-      isUserApiProvisioned: jest.fn().mockReturnValue(false),
+      fetchUserApiProvisioningStatus: jest.fn().mockReturnValue(false),
       provisionUserApi: jest.fn(),
     };
     const indexer = new Indexer(defaultIndexerBehavior, { fetch: mockFetch as unknown as typeof fetch, provisioner, DmlHandler: genericMockDmlHandler });
@@ -897,7 +897,7 @@ CREATE TABLE
     };
     await indexer.runFunctions(mockBlock, functions, false, { provision: true });
 
-    expect(provisioner.isUserApiProvisioned).toHaveBeenCalledWith('morgs.near', 'test');
+    expect(provisioner.fetchUserApiProvisioningStatus).toHaveBeenCalledWith('morgs.near', 'test');
     expect(provisioner.provisionUserApi).toHaveBeenCalledTimes(1);
     expect(provisioner.provisionUserApi).toHaveBeenCalledWith(
       'morgs.near',
@@ -926,7 +926,7 @@ CREATE TABLE
     } as unknown as StreamerMessage) as unknown as Block;
     const provisioner: any = {
       getDatabaseConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
-      isUserApiProvisioned: jest.fn().mockReturnValue(true),
+      fetchUserApiProvisioningStatus: jest.fn().mockReturnValue(true),
       provisionUserApi: jest.fn(),
     };
     const indexer = new Indexer(defaultIndexerBehavior, { fetch: mockFetch as unknown as typeof fetch, provisioner, DmlHandler: genericMockDmlHandler });
@@ -962,7 +962,7 @@ CREATE TABLE
     } as unknown as StreamerMessage) as unknown as Block;
     const provisioner: any = {
       getDatabaseConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
-      isUserApiProvisioned: jest.fn().mockReturnValue(true),
+      fetchUserApiProvisioningStatus: jest.fn().mockReturnValue(true),
       provisionUserApi: jest.fn(),
     };
     const indexer = new Indexer(defaultIndexerBehavior, { fetch: mockFetch as unknown as typeof fetch, provisioner, DmlHandler: genericMockDmlHandler });
@@ -1000,7 +1000,7 @@ CREATE TABLE
     } as unknown as StreamerMessage) as unknown as Block;
     const provisioner: any = {
       getDatabaseConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
-      isUserApiProvisioned: jest.fn().mockReturnValue(true),
+      fetchUserApiProvisioningStatus: jest.fn().mockReturnValue(true),
       provisionUserApi: jest.fn(),
     };
     const indexer = new Indexer(defaultIndexerBehavior, { fetch: mockFetch as unknown as typeof fetch, provisioner, DmlHandler: genericMockDmlHandler });
@@ -1040,7 +1040,7 @@ CREATE TABLE
     const error = new Error('something went wrong with provisioning');
     const provisioner: any = {
       getDatabaseConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
-      isUserApiProvisioned: jest.fn().mockReturnValue(false),
+      fetchUserApiProvisioningStatus: jest.fn().mockReturnValue(false),
       provisionUserApi: jest.fn().mockRejectedValue(error),
     };
     const indexer = new Indexer(defaultIndexerBehavior, { fetch: mockFetch as unknown as typeof fetch, provisioner, DmlHandler: genericMockDmlHandler });

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -86,7 +86,7 @@ export default class Indexer {
 
         if (options.provision && !indexerFunction.provisioned) {
           try {
-            if (!await this.deps.provisioner.isUserApiProvisioned(indexerFunction.account_id, indexerFunction.function_name)) {
+            if (!this.deps.provisioner.isUserApiProvisioned(indexerFunction.account_id, indexerFunction.function_name)) {
               await this.setStatus(functionName, blockHeight, 'PROVISIONING');
               simultaneousPromises.push(this.writeLog(LogLevel.INFO, functionName, blockHeight, 'Provisioning endpoint: starting'));
 

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -86,7 +86,7 @@ export default class Indexer {
 
         if (options.provision && !indexerFunction.provisioned) {
           try {
-            if (!this.deps.provisioner.isUserApiProvisioned(indexerFunction.account_id, indexerFunction.function_name)) {
+            if (!await this.deps.provisioner.fetchUserApiProvisioningStatus(indexerFunction.account_id, indexerFunction.function_name)) {
               await this.setStatus(functionName, blockHeight, 'PROVISIONING');
               simultaneousPromises.push(this.writeLog(LogLevel.INFO, functionName, blockHeight, 'Provisioning endpoint: starting'));
 

--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -53,7 +53,8 @@ describe('Provisioner', () => {
 
       const provisioner = new Provisioner(hasuraClient, pgClient, crypto);
 
-      await expect(provisioner.isUserApiProvisioned(accountId, functionName)).resolves.toBe(false);
+      await expect(provisioner.fetchUserApiProvisioningStatus(accountId, functionName)).resolves.toBe(false);
+      await expect(provisioner.isUserApiProvisioned(accountId, functionName)).toBe(false);
     });
 
     it('returns false if datasource and schema dont exists', async () => {
@@ -62,7 +63,8 @@ describe('Provisioner', () => {
 
       const provisioner = new Provisioner(hasuraClient, pgClient, crypto);
 
-      await expect(provisioner.isUserApiProvisioned(accountId, functionName)).resolves.toBe(false);
+      await expect(provisioner.fetchUserApiProvisioningStatus(accountId, functionName)).resolves.toBe(false);
+      await expect(provisioner.isUserApiProvisioned(accountId, functionName)).toBe(false);
     });
 
     it('returns true if datasource and schema exists', async () => {
@@ -71,7 +73,8 @@ describe('Provisioner', () => {
 
       const provisioner = new Provisioner(hasuraClient, pgClient, crypto);
 
-      await expect(provisioner.isUserApiProvisioned(accountId, functionName)).resolves.toBe(true);
+      await expect(provisioner.fetchUserApiProvisioningStatus(accountId, functionName)).resolves.toBe(true);
+      await expect(provisioner.isUserApiProvisioned(accountId, functionName)).toBe(true);
     });
   });
 
@@ -104,6 +107,7 @@ describe('Provisioner', () => {
           'delete'
         ]
       );
+      await expect(provisioner.isUserApiProvisioned(accountId, functionName)).toBe(true);
     });
 
     it('untracks tables from the previous schema if they exists', async () => {

--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -54,7 +54,7 @@ describe('Provisioner', () => {
       const provisioner = new Provisioner(hasuraClient, pgClient, crypto);
 
       await expect(provisioner.fetchUserApiProvisioningStatus(accountId, functionName)).resolves.toBe(false);
-      await expect(provisioner.isUserApiProvisioned(accountId, functionName)).toBe(false);
+      expect(provisioner.isUserApiProvisioned(accountId, functionName)).toBe(false);
     });
 
     it('returns false if datasource and schema dont exists', async () => {
@@ -64,7 +64,7 @@ describe('Provisioner', () => {
       const provisioner = new Provisioner(hasuraClient, pgClient, crypto);
 
       await expect(provisioner.fetchUserApiProvisioningStatus(accountId, functionName)).resolves.toBe(false);
-      await expect(provisioner.isUserApiProvisioned(accountId, functionName)).toBe(false);
+      expect(provisioner.isUserApiProvisioned(accountId, functionName)).toBe(false);
     });
 
     it('returns true if datasource and schema exists', async () => {
@@ -74,7 +74,7 @@ describe('Provisioner', () => {
       const provisioner = new Provisioner(hasuraClient, pgClient, crypto);
 
       await expect(provisioner.fetchUserApiProvisioningStatus(accountId, functionName)).resolves.toBe(true);
-      await expect(provisioner.isUserApiProvisioned(accountId, functionName)).toBe(true);
+      expect(provisioner.isUserApiProvisioned(accountId, functionName)).toBe(true);
     });
   });
 
@@ -107,7 +107,7 @@ describe('Provisioner', () => {
           'delete'
         ]
       );
-      await expect(provisioner.isUserApiProvisioned(accountId, functionName)).toBe(true);
+      expect(provisioner.isUserApiProvisioned(accountId, functionName)).toBe(true);
     });
 
     it('untracks tables from the previous schema if they exists', async () => {

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -52,14 +52,8 @@ export default class Provisioner {
   }
 
   private setProvisioned (accountId: string, functionName: string): void {
-    const accountIndexers = this.#hasBeenProvisioned[accountId] ?? {};
-    this.#hasBeenProvisioned = {
-      ...this.#hasBeenProvisioned,
-      [accountId]: {
-        ...accountIndexers,
-        [functionName]: true
-      }
-    };
+    this.#hasBeenProvisioned[accountId] ??= {};
+    this.#hasBeenProvisioned[accountId][functionName] = true;
   }
 
   async createDatabase (name: string): Promise<void> {

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -45,13 +45,13 @@ export default class Provisioner {
       .replace(/\//g, '0');
   }
 
-  isUserApiProvisioned(accountId: string, functionName: string): boolean {
+  isUserApiProvisioned (accountId: string, functionName: string): boolean {
     const accountIndexers = this.#hasBeenProvisioned[accountId];
     if (!accountIndexers) { return false; }
     return accountIndexers[functionName];
   }
 
-  private setProvisioned(accountId: string, functionName: string) {
+  private setProvisioned (accountId: string, functionName: string): void {
     const accountIndexers = this.#hasBeenProvisioned[accountId] ?? {};
     this.#hasBeenProvisioned = {
       ...this.#hasBeenProvisioned,
@@ -59,7 +59,7 @@ export default class Provisioner {
         ...accountIndexers,
         [functionName]: true
       }
-    }
+    };
   }
 
   async createDatabase (name: string): Promise<void> {


### PR DESCRIPTION
Checking provisioning status through Hasura takes 70-100ms on Dev. This PR caches the provisioning status inside of `Provisioner` and does make extra requests to Hasura on every run.