### PR TITLE
feat: Include indexer name in context db build failure warning

### DIFF
--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -362,7 +362,7 @@ export default class Indexer {
       return result;
     } catch (error) {
       const errorContent = error as Error;
-      console.debug('Caught error when generating context.db methods. Building no functions. You can still use other context object methods.', errorContent.message);
+      console.warn(`${functionName}: Caught error when generating context.db methods. Building no functions. You can still use other context object methods.`, errorContent.message);
     }
 
     return {}; // Default to empty object if error


### PR DESCRIPTION
context.db build failures are just logged instead of blocking to allow complex schemas but with only graphql calls available. However, these logs are repeatedly output and not tagged with an indexer name. This adds an indexer name to the log to aid debugging. 