### PR TITLE
feat: Schedule log partition jobs during provisioning

### DIFF
--- a/runner/src/hasura-client/hasura-client.ts
+++ b/runner/src/hasura-client/hasura-client.ts
@@ -10,6 +10,14 @@ interface SqlOptions {
   source?: string
 }
 
+interface DatabaseConnectionParameters {
+  password: string
+  database: string
+  username: string
+  host: string
+  port: number
+}
+
 type MetadataRequestArgs = Record<string, any>;
 
 type MetadataRequests = Record<string, any>;
@@ -99,7 +107,7 @@ export default class HasuraClient {
     return metadata;
   }
 
-  async getDbConnectionParameters (account: string): Promise<any> {
+  async getDbConnectionParameters (account: string): Promise<DatabaseConnectionParameters> {
     const metadata = await this.exportMetadata();
     const source = metadata.sources.find((source: { name: any, configuration: any }) => source.name === account);
     if (source === undefined) {

--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -104,8 +104,8 @@ describe('Provisioner', () => {
         ['GRANT EXECUTE ON FUNCTION cron.schedule_in_database TO morgs_near;'],
       ]);
       expect(userPgClientQuery.mock.calls).toEqual([
-        ["SELECT cron.schedule_in_database('morgs_near_test_function_logs_create_partition', '0 1 * * *', $$SELECT fn_create_partition('morgs_near_test_function.__logs', CURRENT_DATE, '1 day', '2 day')$$, morgs_near);"],
-        ["SELECT cron.schedule_in_database('morgs_near_test_function_logs_delete_partition', '0 2 * * *', $$SELECT fn_delete_partition('morgs_near_test_function.__logs', CURRENT_DATE, '-15 day', '-14 day')$$, morgs_near);"]
+        ["SELECT cron.schedule_in_database('morgs_near_test_function_logs_create_partition', '0 1 * * *', $$SELECT fn_create_partition('morgs_near_test_function.__logs', CURRENT_DATE, '1 day', '2 day')$$, 'morgs_near');"],
+        ["SELECT cron.schedule_in_database('morgs_near_test_function_logs_delete_partition', '0 2 * * *', $$SELECT fn_delete_partition('morgs_near_test_function.__logs', CURRENT_DATE, '-15 day', '-14 day')$$, 'morgs_near');"]
       ]);
       expect(hasuraClient.addDatasource).toBeCalledWith(sanitizedAccountId, password, sanitizedAccountId);
       expect(hasuraClient.createSchema).toBeCalledWith(sanitizedAccountId, schemaName);

--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -204,13 +204,13 @@ describe('Provisioner', () => {
     it('throws when grant cron access fails', async () => {
       cronPgClient.query = jest.fn().mockRejectedValue(error);
 
-      await expect(provisioner.provisionUserApi(accountId, functionName, databaseSchema)).rejects.toThrow('Failed to provision endpoint: Failed to grant cron access: some error');
+      await expect(provisioner.provisionUserApi(accountId, functionName, databaseSchema)).rejects.toThrow('Failed to provision endpoint: Failed to setup partitioned logs table: Failed to grant cron access: some error');
     });
 
     it('throws when scheduling cron jobs fails', async () => {
-      cronPgClient.query = jest.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(null).mockRejectedValueOnce(error);
+      userPgClientQuery = jest.fn().mockRejectedValueOnce(error);
 
-      await expect(provisioner.provisionUserApi(accountId, functionName, databaseSchema)).rejects.toThrow('Failed to provision endpoint: Failed to schedule log partition jobs: some error');
+      await expect(provisioner.provisionUserApi(accountId, functionName, databaseSchema)).rejects.toThrow('Failed to provision endpoint: Failed to setup partitioned logs table: Failed to schedule log partition jobs: some error');
     });
   });
 });

--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -1,5 +1,3 @@
-import pgFormat from 'pg-format';
-
 import Provisioner from './provisioner';
 
 describe('Provisioner', () => {
@@ -46,12 +44,10 @@ describe('Provisioner', () => {
 
     adminPgClient = {
       query: jest.fn().mockReturnValue(null),
-      format: pgFormat,
     };
 
     cronPgClient = {
       query: jest.fn().mockReturnValue(null),
-      format: pgFormat,
     };
 
     provisioner = new Provisioner(hasuraClient, adminPgClient, cronPgClient, crypto);

--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -13,7 +13,6 @@ describe('Provisioner', () => {
   const sanitizedFunctionName = 'test_function';
   const databaseSchema = 'CREATE TABLE blocks (height numeric)';
   const error = new Error('some error');
-  const defaultDatabase = 'default';
   const schemaName = `${sanitizedAccountId}_${sanitizedFunctionName}`;
 
   const password = 'password';
@@ -108,17 +107,6 @@ describe('Provisioner', () => {
         ]
       );
       expect(provisioner.isUserApiProvisioned(accountId, functionName)).toBe(true);
-    });
-
-    it('untracks tables from the previous schema if they exists', async () => {
-      hasuraClient.doesSchemaExist = jest.fn().mockReturnValueOnce(true);
-
-      const provisioner = new Provisioner(hasuraClient, pgClient, crypto);
-
-      await provisioner.provisionUserApi(accountId, functionName, databaseSchema);
-
-      expect(hasuraClient.getTableNames).toBeCalledWith(schemaName, defaultDatabase);
-      expect(hasuraClient.untrackTables).toBeCalledWith(defaultDatabase, schemaName, tableNames);
     });
 
     it('skips provisioning the datasource if it already exists', async () => {

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -161,12 +161,6 @@ export default class Provisioner {
             await this.addDatasource(userName, password, databaseName);
           }
 
-          // Untrack tables from old schema to prevent conflicts with new DB
-          if (await this.hasuraClient.doesSchemaExist(HasuraClient.DEFAULT_DATABASE, schemaName)) {
-            const tableNames = await this.getTableNames(schemaName, HasuraClient.DEFAULT_DATABASE);
-            await this.hasuraClient.untrackTables(HasuraClient.DEFAULT_DATABASE, schemaName, tableNames);
-          }
-
           await this.createSchema(databaseName, schemaName);
           await this.runMigrations(databaseName, schemaName, databaseSchema);
 

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -103,14 +103,14 @@ export default class Provisioner {
 
         await userCronPgClient.query(
           this.pgFormat(
-            "SELECT cron.schedule_in_database('%1$I_logs_create_partition', '0 1 * * *', $$SELECT fn_create_partition('%1$I.__logs', CURRENT_DATE, '1 day', '2 day')$$, %2$I);",
+            "SELECT cron.schedule_in_database('%1$I_logs_create_partition', '0 1 * * *', $$SELECT fn_create_partition('%1$I.__logs', CURRENT_DATE, '1 day', '2 day')$$, %2$L);",
             schemaName,
             databaseName
           )
         );
         await userCronPgClient.query(
           this.pgFormat(
-            "SELECT cron.schedule_in_database('%1$I_logs_delete_partition', '0 2 * * *', $$SELECT fn_delete_partition('%1$I.__logs', CURRENT_DATE, '-15 day', '-14 day')$$, %2$I);",
+            "SELECT cron.schedule_in_database('%1$I_logs_delete_partition', '0 2 * * *', $$SELECT fn_delete_partition('%1$I.__logs', CURRENT_DATE, '-15 day', '-14 day')$$, %2$L);",
             schemaName,
             databaseName
           )

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -120,6 +120,17 @@ export default class Provisioner {
     );
   }
 
+  async setupPartitionedLogsTable (userName: string, databaseName: string, schemaName: string): Promise<void> {
+    await wrapError(
+      async () => {
+        // TODO: Create logs table
+        await this.grantCronAccess(userName);
+        await this.scheduleLogPartitionJobs(userName, databaseName, schemaName);
+      },
+      'Failed to setup partitioned logs table'
+    );
+  }
+
   async createUserDb (userName: string, password: string, databaseName: string): Promise<void> {
     await wrapError(
       async () => {
@@ -215,8 +226,7 @@ export default class Provisioner {
           await this.createSchema(databaseName, schemaName);
           await this.runMigrations(databaseName, schemaName, databaseSchema);
 
-          await this.grantCronAccess(userName);
-          await this.scheduleLogPartitionJobs(userName, databaseName, schemaName);
+          await this.setupPartitionedLogsTable(userName, databaseName, schemaName);
 
           const tableNames = await this.getTableNames(schemaName, databaseName);
           await this.trackTables(schemaName, tableNames, databaseName);


### PR DESCRIPTION
This PR expands provisioning to also schedule the cron jobs for adding/deleting log partitions. It assumes:
1. The `cron` database exists and has `pg_cron` enabled (https://github.com/near/near-ops/pull/1665)
2. The `__logs` table exists and has the partition functions defined (https://github.com/near/queryapi/pull/608)

In relation to this flow, the high-level steps are:
1. Use an admin connection to the `cron` database to grant the required access to the user
2. Use a user connection to the `cron` database to schedule the jobs

The cron job is executed under the user which schedules the job, therefore the user _must_ schedule the job as they are the only ones who have access to their schemas. If the admin were to schedule the job the job itself would fail as it doesn't have the required access.

Merging this before 2. is fine, the jobs will just fail, but should start to succeed after it has been implemented.