### PR TITLE
fix: Configure cron db from environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,10 +79,10 @@ services:
       - "6379:6379"
 
   postgres:
-    image: postgres:14
+    build:
+      context: ./postgres
     restart: always
     volumes:
-    - ./init-scripts/postgres:/docker-entrypoint-initdb.d
     - postgres:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: postgrespassword

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       PGUSER: postgres
       PGPASSWORD: postgrespassword
       PGDATABASE: postgres
+      CRON_DATABASE: postgres
       PORT: 9180
       AWS_REGION: eu-central-1
       AWS_ACCESS_KEY_ID:

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y postgresql-14-cron
 
 RUN echo "shared_preload_libraries = 'pg_cron'" >> /usr/share/postgresql/postgresql.conf.sample
 
-RUN echo "CREATE EXTENSION pg_cron;" > /docker-entrypoint-initdb.d/init-pg-cron.sql
+COPY ./init.sql /docker-entrypoint-initdb.d/
 
 EXPOSE 5432
 

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -1,3 +1,4 @@
+-- pgbouncer
 CREATE ROLE pgbouncer LOGIN;
 ALTER ROLE pgbouncer WITH PASSWORD 'pgbouncer';
 CREATE OR REPLACE FUNCTION public.user_lookup(in i_username text, out uname text, out phash text)
@@ -10,3 +11,6 @@ END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 REVOKE ALL ON FUNCTION public.user_lookup(text) FROM public;
 GRANT EXECUTE ON FUNCTION public.user_lookup(text) TO pgbouncer;
+
+-- pg_cron
+CREATE EXTENSION pg_cron;

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -34,13 +34,15 @@ export interface DatabaseConnectionParameters {
 
 interface Config {
   cronDatabase: string
-  // Allow overriding the default values for testing
-  postgresHost?: string
-  postgresPort?: number
+  // Override the host/port values returned by Hasura during testing/local development
+  hasuraHostOverride?: string
+  hasuraPortOverride?: number
 }
 
 const defaultConfig: Config = {
   cronDatabase: process.env.CRON_DATABASE,
+  hasuraHostOverride: process.env.HASURA_HOST_OVERRIDE,
+  hasuraPortOverride: process.env.HASURA_PORT_OVERRIDE ? Number(process.env.HASURA_PORT_OVERRIDE) : undefined
 };
 
 export default class Provisioner {
@@ -108,8 +110,8 @@ export default class Provisioner {
           user: userDbConnectionParameters.username,
           password: userDbConnectionParameters.password,
           database: this.config.cronDatabase,
-          host: this.config.postgresHost ?? userDbConnectionParameters.host,
-          port: this.config.postgresPort ?? userDbConnectionParameters.port,
+          host: this.config.hasuraHostOverride ?? userDbConnectionParameters.host,
+          port: this.config.hasuraPortOverride ?? userDbConnectionParameters.port,
         });
 
         await userCronPgClient.query(

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -7,7 +7,6 @@ import HasuraClient from '../hasura-client';
 import PgClientClass from '../pg-client';
 
 const DEFAULT_PASSWORD_LENGTH = 16;
-const CRON_DATABASE = 'cron';
 
 const adminDefaultPgClientGlobal = new PgClientClass({
   user: process.env.PGUSER,
@@ -20,7 +19,7 @@ const adminDefaultPgClientGlobal = new PgClientClass({
 const adminCronPgClientGlobal = new PgClientClass({
   user: process.env.PGUSER,
   password: process.env.PGPASSWORD,
-  database: CRON_DATABASE,
+  database: process.env.CRON_DATABASE,
   host: process.env.PGHOST,
   port: Number(process.env.PGPORT),
 });

--- a/runner/tests/integration.test.ts
+++ b/runner/tests/integration.test.ts
@@ -60,8 +60,8 @@ describe('Indexer integration', () => {
       pgClient,
       {
         cronDatabase: postgresContainer.getDatabase(),
-        postgresHost: postgresContainer.getIpAddress(),
-        postgresPort: Number(postgresContainer.getPort()),
+        hasuraHostOverride: postgresContainer.getIpAddress(),
+        hasuraPortOverride: Number(postgresContainer.getPort()),
       }
     );
 

--- a/runner/tests/testcontainers/postgres.ts
+++ b/runner/tests/testcontainers/postgres.ts
@@ -17,7 +17,7 @@ export class PostgreSqlContainer {
   }
 
   public static async build (): Promise<PostgreSqlContainer> {
-    const container = await GenericContainer.fromDockerfile('../', 'postgres.Dockerfile').build();
+    const container = await GenericContainer.fromDockerfile('../postgres').build();
 
     return new PostgreSqlContainer(container);
   }


### PR DESCRIPTION
The admin/cron connection is currently hard-coded to the `cron` database, but this needs to be configurable so that we can use the default DB (`postgres`) locally.

Additionally, this PR combines the `pgbouncer` / `pg_cron` init scripts and uses the combined output in both docker compose and integration tests.