### PR TITLE
fix: DmlHandler using wrong port

### DIFF
--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -21,7 +21,7 @@ export default class DmlHandler {
       user: databaseConnectionParameters.username,
       password: databaseConnectionParameters.password,
       host: process.env.PGHOST,
-      port: Number(databaseConnectionParameters.port),
+      port: Number(process.env.PGPORT ?? databaseConnectionParameters.port),
       database: databaseConnectionParameters.database,
     });
     return new DmlHandler(pgClient);


### PR DESCRIPTION
DmlHandler was using port number handed to it by Hasura, which is 5432. We want it to use 6432 which is the port specified by the env variable. 6432 points to pgBouncer. 