### PR TITLE
feat: Avoid unnecessary status updates

### DIFF
--- a/runner/package-lock.json
+++ b/runner/package-lock.json
@@ -51,6 +51,7 @@
         "eslint-plugin-n": "^16.0.1",
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-promise": "^6.1.1",
+        "graphql-request": "^6.1.0",
         "jest": "^29.6.2",
         "prettier": "^3.0.0",
         "testcontainers": "^10.7.2",
@@ -1772,6 +1773,15 @@
       "peerDependencies": {
         "@opentelemetry/resources": "^1.0.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "dev": true,
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -5509,6 +5519,15 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -7119,6 +7138,29 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
+    },
+    "node_modules/graphql": {
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-6.1.0.tgz",
+      "integrity": "sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0",
+        "cross-fetch": "^3.1.5"
+      },
+      "peerDependencies": {
+        "graphql": "14 - 16"
+      }
     },
     "node_modules/gtoken": {
       "version": "5.3.2",

--- a/runner/package.json
+++ b/runner/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-n": "^16.0.1",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-promise": "^6.1.1",
+    "graphql-request": "^6.1.0",
     "jest": "^29.6.2",
     "prettier": "^3.0.0",
     "testcontainers": "^10.7.2",

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -59,6 +59,8 @@ export default class Indexer {
   private database_connection_parameters: DatabaseConnectionParameters | undefined;
   private dml_handler: DmlHandler | undefined;
 
+  private currentStatus?: string;
+
   constructor (
     indexerBehavior: IndexerBehavior,
     deps?: Partial<Dependencies>,
@@ -416,6 +418,12 @@ export default class Indexer {
   }
 
   async setStatus (functionName: string, blockHeight: number, status: string): Promise<any> {
+    if (this.currentStatus === status) {
+      return;
+    }
+
+    this.currentStatus = status;
+
     const setStatusMutation = `
       mutation SetStatus($function_name: String, $status: String) {
         insert_indexer_state_one(object: {function_name: $function_name, status: $status, current_block_height: 0 }, on_conflict: { constraint: indexer_state_pkey, update_columns: status }) {

--- a/runner/tests/integration.test.ts
+++ b/runner/tests/integration.test.ts
@@ -1,6 +1,6 @@
 import { Block, type StreamerMessage } from '@near-lake/primitives';
 import { Network, type StartedNetwork } from 'testcontainers';
-import fetch from 'node-fetch';
+import { gql, GraphQLClient } from 'graphql-request';
 
 import Indexer from '../src/indexer';
 import HasuraClient from '../src/hasura-client';
@@ -18,6 +18,7 @@ describe('Indexer integration', () => {
   let network: StartedNetwork;
   let postgresContainer: StartedPostgreSqlContainer;
   let hasuraContainer: StartedHasuraGraphQLContainer;
+  let graphqlClient: GraphQLClient;
 
   beforeAll(async () => {
     network = await new Network().start();
@@ -28,6 +29,11 @@ describe('Indexer integration', () => {
       .withNetwork(network)
       .withDatabaseUrl(postgresContainer.getConnectionUri(network.getName()))
       .start();
+    graphqlClient = new GraphQLClient(`${hasuraContainer.getEndpoint()}/v1/graphql`, {
+      headers: {
+        'X-Hasura-Admin-Secret': hasuraContainer.getAdminSecret(),
+      }
+    });
   });
 
   afterAll(async () => {
@@ -110,27 +116,36 @@ describe('Indexer integration', () => {
       }
     );
 
-    const e = hasuraContainer.getEndpoint();
-    const resp = await fetch(`${e}/v1/graphql`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Hasura-Role': 'morgs_near',
-        'X-Hasura-Admin-Secret': hasuraContainer.getAdminSecret() // required as there is no configured auth hook
-      },
-      body: JSON.stringify({
-        query: `
-          query {
-            morgs_near_test_blocks {
-              height
-            }
-          }
-        `
-      })
-    });
+    const { morgs_near_test_blocks: blocks }: any = await graphqlClient.request(gql`
+      query {
+        morgs_near_test_blocks {
+          height
+        }
+      }
+    `);
 
-    const { data } = await resp.json();
+    expect(blocks[0].height).toEqual(115185108);
 
-    expect(data.morgs_near_test_blocks[0].height).toEqual(115185108);
+    const { indexer_state: [state] }: any = await graphqlClient.request(gql`
+      query {
+        indexer_state(where: { function_name: { _eq: "morgs.near/test" } }) {
+          current_block_height
+          status
+        }
+      }
+    `);
+
+    expect(state.current_block_height).toEqual(115185108);
+    expect(state.status).toEqual('RUNNING');
+
+    const { indexer_log_entries: logs }: any = await graphqlClient.request(gql`
+      query {
+        indexer_log_entries(where: { function_name: { _eq:"morgs.near/test" } }) {
+          message
+        }
+      }
+    `);
+
+    expect(logs.length).toEqual(3);
   });
 });


### PR DESCRIPTION
Quick & dirty PR which short-circuits updating the status via GraphQL when it is unchanged. We don't need to check whether block height has changed, as that is updated in a separate call later on. I've also updated the integration tests to assert the output of status/logs.