### PR TITLE
refactor: Convert IndexerConfig to Class

### DIFF
--- a/coordinator/Cargo.lock
+++ b/coordinator/Cargo.lock
@@ -3,6 +3,16 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "actix"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +931,7 @@ dependencies = [
  "tonic 0.10.2",
  "tonic-build 0.10.2",
  "tracing",
+ "tracing-stackdriver",
  "tracing-subscriber",
  "wildmatch",
 ]
@@ -4359,6 +4370,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-stackdriver"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80048836e000e1f058562f01d69cc46f476955bf389c0dc2d2d7edb98ca63ac1"
+dependencies = [
+ "Inflector",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4368,12 +4404,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log 0.2.0",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/coordinator/Cargo.lock
+++ b/coordinator/Cargo.lock
@@ -3,16 +3,6 @@
 version = 3
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "actix"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,7 +921,6 @@ dependencies = [
  "tonic 0.10.2",
  "tonic-build 0.10.2",
  "tracing",
- "tracing-stackdriver",
  "tracing-subscriber",
  "wildmatch",
 ]
@@ -4370,31 +4359,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-stackdriver"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80048836e000e1f058562f01d69cc46f476955bf389c0dc2d2d7edb98ca63ac1"
-dependencies = [
- "Inflector",
- "serde",
- "serde_json",
- "thiserror",
- "time",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4404,15 +4368,12 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log 0.2.0",
- "tracing-serde",
 ]
 
 [[package]]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,9 +46,12 @@ services:
       HASURA_ENDPOINT: http://hasura-graphql:8080
       HASURA_ADMIN_SECRET: myadminsecretkey
       REDIS_CONNECTION_STRING: redis://redis
-      PGHOST: pgbouncer
-      PGHOST_HASURA: pgbouncer
-      PGPORT: 6432
+      PGHOST: postgres
+      PGPORT: 5432
+      PGHOST_HASURA: postgres
+      PGPORT_HASURA: 5432
+      PGHOST_PGBOUNCER: pgbouncer
+      PGPORT_PGBOUNCER: 6432
       PGUSER: postgres
       PGPASSWORD: postgrespassword
       PGDATABASE: postgres

--- a/runner/src/dml-handler/dml-handler.test.ts
+++ b/runner/src/dml-handler/dml-handler.test.ts
@@ -2,14 +2,15 @@ import pgFormat from 'pg-format';
 import DmlHandler from './dml-handler';
 import type PgClient from '../pg-client';
 import { type TableDefinitionNames } from '../indexer';
+import { type PostgresConnectionParams } from '../pg-client';
 
 describe('DML Handler tests', () => {
-  const getDbConnectionParameters = {
+  const getDbConnectionParameters: PostgresConnectionParams = {
     database: 'test_near',
     host: 'postgres',
     password: 'test_pass',
     port: 5432,
-    username: 'test_near'
+    user: 'test_near'
   };
   let pgClient: PgClient;
   let query: any;

--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -14,11 +14,19 @@ export default class DmlHandler {
     databaseConnectionParameters: DatabaseConnectionParameters,
     pgClientInstance: PgClient | undefined = undefined,
   ) {
+    // console.log('ENV', process.env.PGHOST, process.env.PGPORT);
+    console.log('DBCONN', {
+      user: databaseConnectionParameters.username,
+      password: databaseConnectionParameters.password,
+      host: databaseConnectionParameters.host,
+      port: databaseConnectionParameters.port,
+      database: databaseConnectionParameters.database,
+    });
     this.pgClient = pgClientInstance ?? new PgClient({
       user: databaseConnectionParameters.username,
       password: databaseConnectionParameters.password,
-      host: process.env.PGHOST,
-      port: Number(process.env.PGPORT ?? databaseConnectionParameters.port),
+      host: databaseConnectionParameters.host,
+      port: databaseConnectionParameters.port,
       database: databaseConnectionParameters.database,
     });
   }

--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -1,6 +1,5 @@
 import { wrapError } from '../utility';
-import PgClient from '../pg-client';
-import { type DatabaseConnectionParameters } from '../provisioner/provisioner';
+import PgClient, { type PostgresConnectionParams } from '../pg-client';
 import { type TableDefinitionNames } from '../indexer';
 
 type WhereClauseMulti = Record<string, (string | number | Array<string | number>)>;
@@ -11,24 +10,10 @@ export default class DmlHandler {
   pgClient: PgClient;
 
   constructor (
-    databaseConnectionParameters: DatabaseConnectionParameters,
+    databaseConnectionParameters: PostgresConnectionParams,
     pgClientInstance: PgClient | undefined = undefined,
   ) {
-    // console.log('ENV', process.env.PGHOST, process.env.PGPORT);
-    console.log('DBCONN', {
-      user: databaseConnectionParameters.username,
-      password: databaseConnectionParameters.password,
-      host: databaseConnectionParameters.host,
-      port: databaseConnectionParameters.port,
-      database: databaseConnectionParameters.database,
-    });
-    this.pgClient = pgClientInstance ?? new PgClient({
-      user: databaseConnectionParameters.username,
-      password: databaseConnectionParameters.password,
-      host: databaseConnectionParameters.host,
-      port: databaseConnectionParameters.port,
-      database: databaseConnectionParameters.database,
-    });
+    this.pgClient = pgClientInstance ?? new PgClient(databaseConnectionParameters);
   }
 
   private getWhereClause (whereObject: WhereClauseMulti, columnLookup: Map<string, string>): { queryVars: Array<string | number>, whereClause: string } {

--- a/runner/src/hasura-client/hasura-client.ts
+++ b/runner/src/hasura-client/hasura-client.ts
@@ -10,7 +10,7 @@ interface SqlOptions {
   source?: string
 }
 
-export interface DatabaseConnectionParameters {
+export interface HasuraDatabaseConnectionParameters {
   password: string
   database: string
   username: string
@@ -125,7 +125,7 @@ export default class HasuraClient {
     return metadata;
   }
 
-  async getDbConnectionParameters (account: string): Promise<DatabaseConnectionParameters> {
+  async getDbConnectionParameters (account: string): Promise<HasuraDatabaseConnectionParameters> {
     const metadata = await this.exportMetadata();
     const source = metadata.sources.find((source: { name: any, configuration: any }) => source.name === account);
     if (source === undefined) {

--- a/runner/src/hasura-client/hasura-client.ts
+++ b/runner/src/hasura-client/hasura-client.ts
@@ -10,7 +10,7 @@ interface SqlOptions {
   source?: string
 }
 
-interface DatabaseConnectionParameters {
+export interface DatabaseConnectionParameters {
   password: string
   database: string
   username: string

--- a/runner/src/hasura-client/index.ts
+++ b/runner/src/hasura-client/index.ts
@@ -1,2 +1,2 @@
 export { default } from './hasura-client';
-export type { DatabaseConnectionParameters } from './hasura-client';
+export type { HasuraDatabaseConnectionParameters } from './hasura-client';

--- a/runner/src/hasura-client/index.ts
+++ b/runner/src/hasura-client/index.ts
@@ -1,1 +1,2 @@
 export { default } from './hasura-client';
+export type { DatabaseConnectionParameters } from './hasura-client';

--- a/runner/src/indexer-config/index.ts
+++ b/runner/src/indexer-config/index.ts
@@ -1,0 +1,1 @@
+export { default } from './indexer-config';

--- a/runner/src/indexer-config/indexer-config.test.ts
+++ b/runner/src/indexer-config/indexer-config.test.ts
@@ -3,10 +3,36 @@ import IndexerConfig from './indexer-config';
 
 describe('IndexerConfig unit tests', () => {
   const REDIS_STREAM = 'test:stream';
-  const ACCOUNT_ID = 'morgs.near';
-  const FUNCTION_NAME = 'test_indexer';
-  // const CODE = '';
+  const ACCOUNT_ID = 'test-account.near';
+  const FUNCTION_NAME = 'test-indexer';
   const SCHEMA = '';
+
+  test('constructor sets executorId correctly', () => {
+    const indexerConfig = new IndexerConfig(REDIS_STREAM, ACCOUNT_ID, FUNCTION_NAME, 0, '', SCHEMA, LogLevel.INFO);
+
+    expect(indexerConfig.executorId).toEqual('d43da7e3e466961f28ddaa99c8f7c2b44f25ef8d44931c677e48a6fd051bb966');
+  });
+
+  test('exposes full indexer name correctly', () => {
+    const indexerConfig = new IndexerConfig(REDIS_STREAM, ACCOUNT_ID, FUNCTION_NAME, 0, '', SCHEMA, LogLevel.INFO);
+
+    expect(indexerConfig.fullName()).toEqual('test-account.near/test-indexer');
+  });
+
+  test('returns correct hasura values', () => {
+    const indexerConfig = new IndexerConfig(REDIS_STREAM, ACCOUNT_ID, FUNCTION_NAME, 0, '', SCHEMA, LogLevel.INFO);
+
+    expect(indexerConfig.hasuraRoleName()).toEqual('test_account_near');
+    expect(indexerConfig.hasuraFunctionName()).toEqual('test_indexer');
+  });
+
+  test('returns correct postgres values', () => {
+    const indexerConfig = new IndexerConfig(REDIS_STREAM, ACCOUNT_ID, FUNCTION_NAME, 0, '', SCHEMA, LogLevel.INFO);
+
+    expect(indexerConfig.userName()).toEqual('test_account_near');
+    expect(indexerConfig.databaseName()).toEqual('test_account_near');
+    expect(indexerConfig.schemaName()).toEqual('test_account_near_test_indexer');
+  });
 
   test('transformedCode applies the correct transformations', () => {
     const indexerConfig = new IndexerConfig(REDIS_STREAM, ACCOUNT_ID, FUNCTION_NAME, 0, 'console.log(\'hello\')', SCHEMA, LogLevel.INFO);

--- a/runner/src/indexer-config/indexer-config.test.ts
+++ b/runner/src/indexer-config/indexer-config.test.ts
@@ -1,4 +1,4 @@
-import { LogLevel } from '../indexer-meta/indexer-meta';
+import { LogLevel } from '../indexer-meta/log-entry';
 import IndexerConfig from './indexer-config';
 
 describe('IndexerConfig unit tests', () => {

--- a/runner/src/indexer-config/indexer-config.test.ts
+++ b/runner/src/indexer-config/indexer-config.test.ts
@@ -1,0 +1,23 @@
+import { LogLevel } from '../indexer-meta/indexer-meta';
+import IndexerConfig from './indexer-config';
+
+describe('IndexerConfig unit tests', () => {
+  const REDIS_STREAM = 'test:stream';
+  const ACCOUNT_ID = 'morgs.near';
+  const FUNCTION_NAME = 'test_indexer';
+  // const CODE = '';
+  const SCHEMA = '';
+
+  test('transformedCode applies the correct transformations', () => {
+    const indexerConfig = new IndexerConfig(REDIS_STREAM, ACCOUNT_ID, FUNCTION_NAME, 0, 'console.log(\'hello\')', SCHEMA, LogLevel.INFO);
+
+    const transformedFunction = indexerConfig.transformedCode();
+
+    expect(transformedFunction).toEqual(`
+      async function f(){
+        console.log('hello')
+      };
+      f();
+    `);
+  });
+});

--- a/runner/src/indexer-config/indexer-config.test.ts
+++ b/runner/src/indexer-config/indexer-config.test.ts
@@ -33,17 +33,4 @@ describe('IndexerConfig unit tests', () => {
     expect(indexerConfig.databaseName()).toEqual('test_account_near');
     expect(indexerConfig.schemaName()).toEqual('test_account_near_test_indexer');
   });
-
-  test('transformedCode applies the correct transformations', () => {
-    const indexerConfig = new IndexerConfig(REDIS_STREAM, ACCOUNT_ID, FUNCTION_NAME, 0, 'console.log(\'hello\')', SCHEMA, LogLevel.INFO);
-
-    const transformedFunction = indexerConfig.transformedCode();
-
-    expect(transformedFunction).toEqual(`
-      async function f(){
-        console.log('hello')
-      };
-      f();
-    `);
-  });
 });

--- a/runner/src/indexer-config/indexer-config.ts
+++ b/runner/src/indexer-config/indexer-config.ts
@@ -33,10 +33,10 @@ export default class IndexerConfig {
 
   private enableAwaitTransform (code: string): string {
     return `
-            async function f(){
-                ${code}
-            };
-            f();
+      async function f(){
+        ${code}
+      };
+      f();
     `;
   }
 

--- a/runner/src/indexer-config/indexer-config.ts
+++ b/runner/src/indexer-config/indexer-config.ts
@@ -65,21 +65,6 @@ export default class IndexerConfig {
     };
   }
 
-  private enableAwaitTransform (code: string): string {
-    return `
-      async function f(){
-        ${code}
-      };
-      f();
-    `;
-  }
-
-  private transformIndexerFunction (code: string): string {
-    return [
-      this.enableAwaitTransform,
-    ].reduce((acc, val) => val(acc), code);
-  }
-
   private sanitizeNameForDatabase (name: string): string {
     // TODO: Add underscore for accounts with invalid starting character
     return name.replace(/[^a-zA-Z0-9]/g, '_');
@@ -107,9 +92,5 @@ export default class IndexerConfig {
 
   schemaName (): string {
     return this.sanitizeNameForDatabase(this.fullName());
-  }
-
-  transformedCode (): string {
-    return this.transformIndexerFunction(this.code);
   }
 }

--- a/runner/src/indexer-config/indexer-config.ts
+++ b/runner/src/indexer-config/indexer-config.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 import { type StartExecutorRequest__Output } from '../generated/runner/StartExecutorRequest';
-import { LogLevel } from '../indexer-meta/indexer-meta';
+import { LogLevel } from '../indexer-meta/log-entry';
 
 export default class IndexerConfig {
   public readonly executorId: string;

--- a/runner/src/indexer-config/indexer-config.ts
+++ b/runner/src/indexer-config/indexer-config.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
-import { LogLevel } from '../indexer-logger/indexer-logger';
 import { type StartExecutorRequest__Output } from '../generated/runner/StartExecutorRequest';
+import { LogLevel } from '../indexer-meta/indexer-meta';
 
 export default class IndexerConfig {
   public readonly executorId: string;

--- a/runner/src/indexer-config/indexer-config.ts
+++ b/runner/src/indexer-config/indexer-config.ts
@@ -2,6 +2,16 @@ import crypto from 'crypto';
 import { type StartExecutorRequest__Output } from '../generated/runner/StartExecutorRequest';
 import { LogLevel } from '../indexer-meta/log-entry';
 
+interface IndexerConfigData {
+  redisStreamKey: string
+  accountId: string
+  functionName: string
+  version: number
+  code: string
+  schema: string
+  logLevel: LogLevel
+}
+
 export default class IndexerConfig {
   public readonly executorId: string;
 
@@ -29,6 +39,30 @@ export default class IndexerConfig {
       startExecutorRequest.schema,
       LogLevel.INFO
     );
+  }
+
+  static fromObject (data: IndexerConfigData): IndexerConfig {
+    return new IndexerConfig(
+      data.redisStreamKey,
+      data.accountId,
+      data.functionName,
+      data.version,
+      data.code,
+      data.schema,
+      data.logLevel
+    );
+  }
+
+  toObject (): IndexerConfigData {
+    return {
+      redisStreamKey: this.redisStreamKey,
+      accountId: this.accountId,
+      functionName: this.functionName,
+      version: this.version,
+      code: this.code,
+      schema: this.schema,
+      logLevel: this.logLevel
+    };
   }
 
   private enableAwaitTransform (code: string): string {

--- a/runner/src/indexer-config/indexer-config.ts
+++ b/runner/src/indexer-config/indexer-config.ts
@@ -1,0 +1,81 @@
+import crypto from 'crypto';
+import { LogLevel } from '../indexer-logger/indexer-logger';
+import { type StartExecutorRequest__Output } from '../generated/runner/StartExecutorRequest';
+
+export default class IndexerConfig {
+  public readonly executorId: string;
+
+  constructor (
+    public readonly redisStreamKey: string,
+    public readonly accountId: string,
+    public readonly functionName: string,
+    public readonly version: number,
+    public readonly code: string,
+    public readonly schema: string,
+    public readonly logLevel: LogLevel
+  ) {
+    const hash = crypto.createHash('sha256');
+    hash.update(`${accountId}/${functionName}`);
+    this.executorId = hash.digest('hex');
+  }
+
+  static fromStartRequest (startExecutorRequest: StartExecutorRequest__Output): IndexerConfig {
+    return new IndexerConfig(
+      startExecutorRequest.redisStream,
+      startExecutorRequest.accountId,
+      startExecutorRequest.functionName,
+      parseInt(startExecutorRequest.version),
+      startExecutorRequest.code,
+      startExecutorRequest.schema,
+      LogLevel.INFO
+    );
+  }
+
+  private enableAwaitTransform (code: string): string {
+    return `
+            async function f(){
+                ${code}
+            };
+            f();
+    `;
+  }
+
+  private transformIndexerFunction (code: string): string {
+    return [
+      this.enableAwaitTransform,
+    ].reduce((acc, val) => val(acc), code);
+  }
+
+  private sanitizeNameForDatabase (name: string): string {
+    // TODO: Add underscore for accounts with invalid starting character
+    return name.replace(/[.-]/g, '_');
+  }
+
+  fullName (): string {
+    return `${this.accountId}/${this.functionName}`;
+  }
+
+  hasuraRoleName (): string {
+    return this.sanitizeNameForDatabase(this.accountId);
+  }
+
+  hasuraFunctionName (): string {
+    return this.sanitizeNameForDatabase(this.functionName);
+  }
+
+  postgresUserName (): string {
+    return this.sanitizeNameForDatabase(this.accountId);
+  }
+
+  postgresDatabaseName (): string {
+    return this.sanitizeNameForDatabase(this.accountId);
+  }
+
+  postgresSchemaName (): string {
+    return this.sanitizeNameForDatabase(this.fullName());
+  }
+
+  transformedCode (): string {
+    return this.transformIndexerFunction(this.code);
+  }
+}

--- a/runner/src/indexer-config/indexer-config.ts
+++ b/runner/src/indexer-config/indexer-config.ts
@@ -63,15 +63,15 @@ export default class IndexerConfig {
     return this.sanitizeNameForDatabase(this.functionName);
   }
 
-  postgresUserName (): string {
+  userName (): string {
     return this.sanitizeNameForDatabase(this.accountId);
   }
 
-  postgresDatabaseName (): string {
+  databaseName (): string {
     return this.sanitizeNameForDatabase(this.accountId);
   }
 
-  postgresSchemaName (): string {
+  schemaName (): string {
     return this.sanitizeNameForDatabase(this.fullName());
   }
 

--- a/runner/src/indexer-config/indexer-config.ts
+++ b/runner/src/indexer-config/indexer-config.ts
@@ -48,7 +48,7 @@ export default class IndexerConfig {
 
   private sanitizeNameForDatabase (name: string): string {
     // TODO: Add underscore for accounts with invalid starting character
-    return name.replace(/[.-]/g, '_');
+    return name.replace(/[^a-zA-Z0-9]/g, '_');
   }
 
   fullName (): string {

--- a/runner/src/indexer-meta/indexer-meta.test.ts
+++ b/runner/src/indexer-meta/indexer-meta.test.ts
@@ -2,6 +2,7 @@ import pgFormat from 'pg-format';
 import IndexerMeta, { IndexerStatus } from './indexer-meta';
 import type PgClient from '../pg-client';
 import LogEntry, { LogLevel } from './log-entry';
+import { type PostgresConnectionParams } from '../pg-client';
 
 describe('IndexerMeta', () => {
   let genericMockPgClient: PgClient;
@@ -15,8 +16,8 @@ describe('IndexerMeta', () => {
     } as unknown as PgClient;
   });
 
-  const mockDatabaseConnectionParameters = {
-    username: 'test_user',
+  const mockDatabaseConnectionParameters: PostgresConnectionParams = {
+    user: 'test_user',
     password: 'test_password',
     host: 'test_host',
     port: 5432,

--- a/runner/src/indexer-meta/indexer-meta.ts
+++ b/runner/src/indexer-meta/indexer-meta.ts
@@ -1,7 +1,6 @@
 import format from 'pg-format';
 import { wrapError } from '../utility';
-import PgClient from '../pg-client';
-import { type DatabaseConnectionParameters } from '../provisioner/provisioner';
+import PgClient, { type PostgresConnectionParams } from '../pg-client';
 import { trace } from '@opentelemetry/api';
 import type LogEntry from './log-entry';
 import { LogLevel } from './log-entry';
@@ -28,16 +27,10 @@ export default class IndexerMeta {
   constructor (
     functionName: string,
     loggingLevel: number,
-    databaseConnectionParameters: DatabaseConnectionParameters,
+    databaseConnectionParameters: PostgresConnectionParams,
     pgClientInstance: PgClient | undefined = undefined
   ) {
-    const pgClient = pgClientInstance ?? new PgClient({
-      user: databaseConnectionParameters.username,
-      password: databaseConnectionParameters.password,
-      host: process.env.PGHOST,
-      port: Number(databaseConnectionParameters.port),
-      database: databaseConnectionParameters.database,
-    });
+    const pgClient = pgClientInstance ?? new PgClient(databaseConnectionParameters);
 
     this.pgClient = pgClient;
     this.schemaName = functionName.replace(/[^a-zA-Z0-9]/g, '_');

--- a/runner/src/indexer/__snapshots__/indexer.test.ts.snap
+++ b/runner/src/indexer/__snapshots__/indexer.test.ts.snap
@@ -225,7 +225,7 @@ exports[`Indexer unit tests Indexer.buildContext() can fetch from the near socia
 ]
 `;
 
-exports[`Indexer unit tests Indexer.runFunctions() allows imperative execution of GraphQL operations 1`] = `
+exports[`Indexer unit tests Indexer.execute() allows imperative execution of GraphQL operations 1`] = `
 [
   [
     "mock-hasura-endpoint/v1/graphql",
@@ -295,7 +295,7 @@ exports[`Indexer unit tests Indexer.runFunctions() allows imperative execution o
 ]
 `;
 
-exports[`Indexer unit tests Indexer.runFunctions() catches errors 1`] = `
+exports[`Indexer unit tests Indexer.execute() catches errors 1`] = `
 [
   [
     "mock-hasura-endpoint/v1/graphql",
@@ -352,7 +352,7 @@ exports[`Indexer unit tests Indexer.runFunctions() catches errors 1`] = `
 ]
 `;
 
-exports[`Indexer unit tests Indexer.runFunctions() logs provisioning failures 1`] = `
+exports[`Indexer unit tests Indexer.execute() logs provisioning failures 1`] = `
 [
   [
     "mock-hasura-endpoint/v1/graphql",
@@ -422,7 +422,7 @@ exports[`Indexer unit tests Indexer.runFunctions() logs provisioning failures 1`
 ]
 `;
 
-exports[`Indexer unit tests Indexer.runFunctions() should execute all functions against the current block 1`] = `
+exports[`Indexer unit tests Indexer.execute() should execute all functions against the current block 1`] = `
 [
   [
     "mock-hasura-endpoint/v1/graphql",
@@ -479,7 +479,7 @@ exports[`Indexer unit tests Indexer.runFunctions() should execute all functions 
 ]
 `;
 
-exports[`Indexer unit tests Indexer.runFunctions() supplies the required role to the GraphQL endpoint 1`] = `
+exports[`Indexer unit tests Indexer.execute() supplies the required role to the GraphQL endpoint 1`] = `
 [
   [
     "mock-hasura-endpoint/v1/graphql",

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -213,7 +213,9 @@ CREATE TABLE
   };
 
   const genericProvisioner: any = {
-    getPgBouncerConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials)
+    getPgBouncerConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
+    fetchUserApiProvisioningStatus: jest.fn().mockResolvedValue(true),
+    provisionLogsIfNeeded: jest.fn(),
   };
 
   const config = {
@@ -910,7 +912,7 @@ CREATE TABLE
     };
     const indexer = new Indexer(simpleSchemaConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler }, undefined, config);
 
-    await indexer.execute(mockBlock, { provision: true });
+    await indexer.execute(mockBlock);
 
     expect(provisioner.fetchUserApiProvisioningStatus).toHaveBeenCalledWith(simpleSchemaConfig);
     expect(provisioner.provisionUserApi).toHaveBeenCalledTimes(1);
@@ -944,7 +946,7 @@ CREATE TABLE
     };
     const indexer = new Indexer(simpleSchemaConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler }, undefined, config);
 
-    await indexer.execute(mockBlock, { provision: true });
+    await indexer.execute(mockBlock);
 
     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
     expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
@@ -976,9 +978,9 @@ CREATE TABLE
     };
     const indexer = new Indexer(simpleSchemaConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler }, undefined, config);
 
-    await indexer.execute(mockBlock, { provision: true });
-    await indexer.execute(mockBlock, { provision: true });
-    await indexer.execute(mockBlock, { provision: true });
+    await indexer.execute(mockBlock);
+    await indexer.execute(mockBlock);
+    await indexer.execute(mockBlock);
 
     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
     expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
@@ -1013,7 +1015,7 @@ CREATE TABLE
     const indexerConfig = new IndexerConfig(SIMPLE_REDIS_STREAM, 'morgs.near', 'test', 0, code, SIMPLE_SCHEMA, LogLevel.INFO);
     const indexer = new Indexer(indexerConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler }, undefined, config);
 
-    await indexer.execute(mockBlock, { provision: true });
+    await indexer.execute(mockBlock);
 
     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
     expect(mockFetch.mock.calls).toMatchSnapshot();
@@ -1049,7 +1051,7 @@ CREATE TABLE
     const indexerConfig = new IndexerConfig(SIMPLE_REDIS_STREAM, 'morgs.near', 'test', 0, code, 'schema', LogLevel.INFO);
     const indexer = new Indexer(indexerConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler }, undefined, config);
 
-    await expect(indexer.execute(mockBlock, { provision: true })).rejects.toThrow(error);
+    await expect(indexer.execute(mockBlock)).rejects.toThrow(error);
     expect(mockFetch.mock.calls).toMatchSnapshot();
     expect(provisioner.getPgBouncerConnectionParameters).not.toHaveBeenCalled();
   });

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -253,7 +253,7 @@ CREATE TABLE
         `,
       schema: SIMPLE_SCHEMA
     };
-    await indexer.runFunctions(mockBlock, functions, false);
+    await indexer.runFunctions(mockBlock, functions);
 
     expect(mockFetch.mock.calls).toMatchSnapshot();
   });
@@ -842,7 +842,7 @@ CREATE TABLE
       schema: SIMPLE_SCHEMA
     };
 
-    await indexer.runFunctions(mockBlock, functions, false);
+    await indexer.runFunctions(mockBlock, functions);
 
     expect(mockFetch.mock.calls).toMatchSnapshot();
   });
@@ -895,7 +895,7 @@ CREATE TABLE
       schema: SIMPLE_SCHEMA
     };
 
-    await expect(indexer.runFunctions(mockBlock, functions, false)).rejects.toThrow(new Error('boom'));
+    await expect(indexer.runFunctions(mockBlock, functions)).rejects.toThrow(new Error('boom'));
     expect(mockFetch.mock.calls).toMatchSnapshot();
   });
 
@@ -932,7 +932,7 @@ CREATE TABLE
         schema: SIMPLE_SCHEMA,
       }
     };
-    await indexer.runFunctions(mockBlock, functions, false, { provision: true });
+    await indexer.runFunctions(mockBlock, functions, { provision: true });
 
     expect(provisioner.fetchUserApiProvisioningStatus).toHaveBeenCalledWith('morgs.near', 'test');
     expect(provisioner.provisionUserApi).toHaveBeenCalledTimes(1);
@@ -975,7 +975,7 @@ CREATE TABLE
         schema: SIMPLE_SCHEMA,
       }
     };
-    await indexer.runFunctions(mockBlock, functions, false, { provision: true });
+    await indexer.runFunctions(mockBlock, functions, { provision: true });
 
     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
     expect(provisioner.getDatabaseConnectionParameters).toHaveBeenCalledTimes(1);
@@ -1012,9 +1012,9 @@ CREATE TABLE
         schema: SIMPLE_SCHEMA,
       }
     };
-    await indexer.runFunctions(mockBlock, functions, false, { provision: true });
-    await indexer.runFunctions(mockBlock, functions, false, { provision: true });
-    await indexer.runFunctions(mockBlock, functions, false, { provision: true });
+    await indexer.runFunctions(mockBlock, functions, { provision: true });
+    await indexer.runFunctions(mockBlock, functions, { provision: true });
+    await indexer.runFunctions(mockBlock, functions, { provision: true });
 
     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
     expect(provisioner.getDatabaseConnectionParameters).toHaveBeenCalledTimes(1);
@@ -1053,7 +1053,7 @@ CREATE TABLE
         schema: SIMPLE_SCHEMA,
       }
     };
-    await indexer.runFunctions(mockBlock, functions, false, { provision: true });
+    await indexer.runFunctions(mockBlock, functions, { provision: true });
 
     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
     expect(mockFetch.mock.calls).toMatchSnapshot();
@@ -1094,7 +1094,7 @@ CREATE TABLE
       }
     };
 
-    await expect(indexer.runFunctions(mockBlock, functions, false, { provision: true })).rejects.toThrow(error);
+    await expect(indexer.runFunctions(mockBlock, functions, { provision: true })).rejects.toThrow(error);
     expect(mockFetch.mock.calls).toMatchSnapshot();
     expect(provisioner.getDatabaseConnectionParameters).not.toHaveBeenCalled();
   });
@@ -1162,9 +1162,9 @@ CREATE TABLE
       config
     );
 
-    await indexerDebug.runFunctions(mockBlock, functions, false);
-    await indexerInfo.runFunctions(mockBlock, functions, false);
-    await indexerError.runFunctions(mockBlock, functions, false);
+    await indexerDebug.runFunctions(mockBlock, functions);
+    await indexerInfo.runFunctions(mockBlock, functions);
+    await indexerError.runFunctions(mockBlock, functions);
 
     // There are 1 set status (no log level), 1 run function log (info level), and 1 set function state (no log level) made each run
     expect(mockFetchDebug.mock.calls).toMatchSnapshot();

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -221,7 +221,7 @@ CREATE TABLE
     hasuraAdminSecret: 'mock-hasura-secret',
   };
 
-  test('Indexer.runFunctions() should execute all functions against the current block', async () => {
+  test('Indexer.execute() should execute all functions against the current block', async () => {
     const mockFetch = jest.fn(() => ({
       status: 200,
       json: async () => ({
@@ -251,7 +251,7 @@ CREATE TABLE
       // indexerMeta: genericMockIndexerMeta ,
     }, undefined, config);
 
-    await indexer.runFunctions(mockBlock);
+    await indexer.execute(mockBlock);
 
     expect(mockFetch.mock.calls).toMatchSnapshot();
   });
@@ -728,7 +728,7 @@ CREATE TABLE
     expect(Object.keys(context.db)).toStrictEqual([]);
   });
 
-  test('Indexer.runFunctions() allows imperative execution of GraphQL operations', async () => {
+  test('Indexer.execute() allows imperative execution of GraphQL operations', async () => {
     const postId = 1;
     const commentId = 2;
     const blockHeight = 82699904;
@@ -824,12 +824,12 @@ CREATE TABLE
     const indexerConfig = new IndexerConfig(SIMPLE_REDIS_STREAM, 'buildnear.testnet', 'test', 0, code, SIMPLE_SCHEMA, LogLevel.INFO);
     const indexer = new Indexer(indexerConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner: genericProvisioner, dmlHandler: genericMockDmlHandler }, undefined, config);
 
-    await indexer.runFunctions(mockBlock);
+    await indexer.execute(mockBlock);
 
     expect(mockFetch.mock.calls).toMatchSnapshot();
   });
 
-  test('Indexer.runFunctions() console.logs', async () => {
+  test('Indexer.execute() console.logs', async () => {
     const logs: string[] = [];
     const context = {
       log: (...m: string[]) => {
@@ -850,7 +850,7 @@ CREATE TABLE
     }).toThrow('boom');
   });
 
-  test('Indexer.runFunctions() catches errors', async () => {
+  test('Indexer.execute() catches errors', async () => {
     const mockFetch = jest.fn(() => ({
       status: 200,
       json: async () => ({
@@ -881,11 +881,11 @@ CREATE TABLE
       schema: SIMPLE_SCHEMA
     };
 
-    await expect(indexer.runFunctions(mockBlock)).rejects.toThrow(new Error('boom'));
+    await expect(indexer.execute(mockBlock)).rejects.toThrow(new Error('boom'));
     expect(mockFetch.mock.calls).toMatchSnapshot();
   });
 
-  test('Indexer.runFunctions() provisions a GraphQL endpoint with the specified schema', async () => {
+  test('Indexer.execute() provisions a GraphQL endpoint with the specified schema', async () => {
     const blockHeight = 82699904;
     const mockFetch = jest.fn(() => ({
       status: 200,
@@ -910,7 +910,7 @@ CREATE TABLE
     };
     const indexer = new Indexer(simpleSchemaConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler }, undefined, config);
 
-    await indexer.runFunctions(mockBlock, { provision: true });
+    await indexer.execute(mockBlock, { provision: true });
 
     expect(provisioner.fetchUserApiProvisioningStatus).toHaveBeenCalledWith(simpleSchemaConfig);
     expect(provisioner.provisionUserApi).toHaveBeenCalledTimes(1);
@@ -918,7 +918,7 @@ CREATE TABLE
     expect(provisioner.getDatabaseConnectionParameters).toHaveBeenCalledTimes(1);
   });
 
-  test('Indexer.runFunctions() skips provisioning if the endpoint exists', async () => {
+  test('Indexer.execute() skips provisioning if the endpoint exists', async () => {
     const blockHeight = 82699904;
     const mockFetch = jest.fn(() => ({
       status: 200,
@@ -943,13 +943,13 @@ CREATE TABLE
     };
     const indexer = new Indexer(simpleSchemaConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler }, undefined, config);
 
-    await indexer.runFunctions(mockBlock, { provision: true });
+    await indexer.execute(mockBlock, { provision: true });
 
     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
     expect(provisioner.getDatabaseConnectionParameters).toHaveBeenCalledTimes(1);
   });
 
-  test('Indexer.runFunctions() skips database credentials fetch second time onward', async () => {
+  test('Indexer.execute() skips database credentials fetch second time onward', async () => {
     const blockHeight = 82699904;
     const mockFetch = jest.fn(() => ({
       status: 200,
@@ -974,15 +974,15 @@ CREATE TABLE
     };
     const indexer = new Indexer(simpleSchemaConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler }, undefined, config);
 
-    await indexer.runFunctions(mockBlock, { provision: true });
-    await indexer.runFunctions(mockBlock, { provision: true });
-    await indexer.runFunctions(mockBlock, { provision: true });
+    await indexer.execute(mockBlock, { provision: true });
+    await indexer.execute(mockBlock, { provision: true });
+    await indexer.execute(mockBlock, { provision: true });
 
     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
     expect(provisioner.getDatabaseConnectionParameters).toHaveBeenCalledTimes(1);
   });
 
-  test('Indexer.runFunctions() supplies the required role to the GraphQL endpoint', async () => {
+  test('Indexer.execute() supplies the required role to the GraphQL endpoint', async () => {
     const blockHeight = 82699904;
     const mockFetch = jest.fn(() => ({
       status: 200,
@@ -1011,14 +1011,14 @@ CREATE TABLE
     const indexerConfig = new IndexerConfig(SIMPLE_REDIS_STREAM, 'morgs.near', 'test', 0, code, SIMPLE_SCHEMA, LogLevel.INFO);
     const indexer = new Indexer(indexerConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler }, undefined, config);
 
-    await indexer.runFunctions(mockBlock, { provision: true });
+    await indexer.execute(mockBlock, { provision: true });
 
     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
     expect(mockFetch.mock.calls).toMatchSnapshot();
     expect(provisioner.getDatabaseConnectionParameters).toHaveBeenCalledTimes(1);
   });
 
-  test('Indexer.runFunctions() logs provisioning failures', async () => {
+  test('Indexer.execute() logs provisioning failures', async () => {
     const blockHeight = 82699904;
     const mockFetch = jest.fn(() => ({
       status: 200,
@@ -1047,7 +1047,7 @@ CREATE TABLE
     const indexerConfig = new IndexerConfig(SIMPLE_REDIS_STREAM, 'morgs.near', 'test', 0, code, 'schema', LogLevel.INFO);
     const indexer = new Indexer(indexerConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler }, undefined, config);
 
-    await expect(indexer.runFunctions(mockBlock, { provision: true })).rejects.toThrow(error);
+    await expect(indexer.execute(mockBlock, { provision: true })).rejects.toThrow(error);
     expect(mockFetch.mock.calls).toMatchSnapshot();
     expect(provisioner.getDatabaseConnectionParameters).not.toHaveBeenCalled();
   });
@@ -1115,9 +1115,9 @@ CREATE TABLE
       config
     );
 
-    await indexerDebug.runFunctions(mockBlock);
-    await indexerInfo.runFunctions(mockBlock);
-    await indexerError.runFunctions(mockBlock);
+    await indexerDebug.execute(mockBlock);
+    await indexerInfo.execute(mockBlock);
+    await indexerError.execute(mockBlock);
 
     // There are 1 set status (no log level), 1 run function log (info level), and 1 set function state (no log level) made each run
     expect(mockFetchDebug.mock.calls).toMatchSnapshot();

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -1212,4 +1212,17 @@ CREATE TABLE
             }
     ]);
   });
+
+  test('transformedCode applies the correct transformations', () => {
+    const indexerConfig = new IndexerConfig(SIMPLE_REDIS_STREAM, SIMPLE_ACCOUNT_ID, SIMPLE_FUNCTION_NAME, 0, 'console.log(\'hello\')', SIMPLE_SCHEMA, LogLevel.INFO);
+    const indexer = new Indexer(indexerConfig, { dmlHandler: genericMockDmlHandler }, undefined, config);
+    const transformedFunction = indexer.transformIndexerFunction();
+
+    expect(transformedFunction).toEqual(`
+      async function f(){
+        console.log('hello')
+      };
+      f();
+    `);
+  });
 });

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -337,7 +337,6 @@ CREATE TABLE
     }, undefined, config);
 
     const context = indexer.buildContext(1);
-    const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, HASURA_ROLE /** [] */);
 
     await context.fetchFromSocialApi('/index', {
       method: 'POST',
@@ -364,9 +363,9 @@ CREATE TABLE
           errors: ['boom']
         })
       });
-    const indexer = new Indexer(defaultIndexerBehavior, { fetch: mockFetch as unknown as typeof fetch, dmlHandler: genericMockDmlHandler }, undefined, config);
+    const indexer = new Indexer(simpleSchemaConfig, { fetch: mockFetch as unknown as typeof fetch, dmlHandler: genericMockDmlHandler }, undefined, config);
 
-    const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, INVALID_HASURA_ROLE /** [] */);
+    const context = indexer.buildContext(1);
 
     await expect(async () => await context.graphql('query { hello }')).rejects.toThrow('boom');
   });
@@ -382,7 +381,6 @@ CREATE TABLE
     const indexer = new Indexer(simpleSchemaConfig, { fetch: mockFetch as unknown as typeof fetch, dmlHandler: genericMockDmlHandler }, undefined, config);
 
     const context = indexer.buildContext(1);
-    const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, HASURA_ROLE /** [] */);
 
     const query = 'query($name: String) { hello(name: $name) }';
     const variables = { name: 'morgan' };
@@ -504,7 +502,6 @@ CREATE TABLE
 
     // Does not outright throw an error but instead returns an empty object
     expect(indexer.buildDatabaseContext(1))
-    expect(indexer.buildDatabaseContext('test_account', 'test_schema_name', schemaWithDuplicateSanitizedTableNames, 1 /** [] */))
       .toStrictEqual({});
   });
 
@@ -516,8 +513,6 @@ CREATE TABLE
       dmlHandler: mockDmlHandler
     }, genericDbCredentials, config);
     const context = indexer.buildContext(1);
-
-    const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres' /** [] */);
 
     const objToInsert = [{
       account_id: 'morgs_near',
@@ -552,7 +547,6 @@ CREATE TABLE
       dmlHandler: mockDmlHandler
     }, genericDbCredentials, config);
     const context = indexer.buildContext(1);
-    const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres' /** [] */);
     const promises = [];
 
     for (let i = 1; i <= 100; i++) {
@@ -588,7 +582,6 @@ CREATE TABLE
       dmlHandler: mockDmlHandler
     }, genericDbCredentials, config);
     const context = indexer.buildContext(1);
-    const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres' /** [] */);
 
     const objToSelect = {
       account_id: 'morgs_near',
@@ -615,7 +608,6 @@ CREATE TABLE
       dmlHandler: mockDmlHandler
     }, genericDbCredentials, config);
     const context = indexer.buildContext(1);
-    const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres' /** [] */);
 
     const whereObj = {
       account_id: 'morgs_near',
@@ -646,7 +638,6 @@ CREATE TABLE
       dmlHandler: mockDmlHandler
     }, genericDbCredentials, config);
     const context = indexer.buildContext(1);
-    const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres' /** [] */);
 
     const objToInsert = [{
       account_id: 'morgs_near',
@@ -679,7 +670,6 @@ CREATE TABLE
       dmlHandler: mockDmlHandler
     }, genericDbCredentials, config);
     const context = indexer.buildContext(1);
-    const context = indexer.buildContext(SOCIAL_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres'/** [] */);
 
     const deleteFilter = {
       account_id: 'morgs_near',
@@ -695,7 +685,6 @@ CREATE TABLE
       dmlHandler: genericMockDmlHandler
     }, genericDbCredentials, config);
     const context = indexer.buildContext(1);
-    const context = indexer.buildContext(STRESS_TEST_SCHEMA, 'morgs.near/social_feed1', 1, 'postgres'/** [] */);
 
     expect(Object.keys(context.db)).toStrictEqual([
       'CreatorQuest',
@@ -735,7 +724,6 @@ CREATE TABLE
       dmlHandler: genericMockDmlHandler
     }, genericDbCredentials, config);
     const context = indexer.buildContext(1);
-    const context = indexer.buildContext('', 'morgs.near/social_feed1', 1, 'postgres'/** [] */);
 
     expect(Object.keys(context.db)).toStrictEqual([]);
   });
@@ -803,7 +791,6 @@ CREATE TABLE
       },
       shards: {}
     } as unknown as StreamerMessage) as unknown as Block;
-    const indexer = new Indexer(defaultIndexerBehavior, { fetch: mockFetch as unknown as typeof fetch, provisioner: genericProvisioner, dmlHandler: genericMockDmlHandler/** , indexerMeta: genericMockIndexerMeta */ }, undefined, config);
 
     const code = `
       const { posts } = await context.graphql(\`
@@ -885,7 +872,6 @@ CREATE TABLE
     `;
     const indexerConfig = new IndexerConfig(SIMPLE_REDIS_STREAM, 'buildnear.testnet', 'test', 0, code, SIMPLE_SCHEMA, LogLevel.INFO);
     const indexer = new Indexer(indexerConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner: genericProvisioner, dmlHandler: genericMockDmlHandler }, undefined, config);
-    const indexer = new Indexer(defaultIndexerBehavior, { fetch: mockFetch as unknown as typeof fetch, provisioner: genericProvisioner, dmlHandler: genericMockDmlHandler/** , indexerMeta: genericMockIndexerMeta */ }, undefined, config);
 
     const functions: Record<string, any> = {};
     functions['buildnear.testnet/test'] = {
@@ -923,7 +909,6 @@ CREATE TABLE
       provisionLogsIfNeeded: jest.fn(),
     };
     const indexer = new Indexer(simpleSchemaConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler }, undefined, config);
-    const indexer = new Indexer(defaultIndexerBehavior, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler /** , indexerMeta: genericMockIndexerMeta */ }, undefined, config);
 
     await indexer.runFunctions(mockBlock, { provision: true });
 
@@ -957,7 +942,6 @@ CREATE TABLE
       provisionLogsIfNeeded: jest.fn(),
     };
     const indexer = new Indexer(simpleSchemaConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler }, undefined, config);
-    const indexer = new Indexer(defaultIndexerBehavior, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler /** , indexerMeta: genericMockIndexerMeta */ }, undefined, config);
 
     await indexer.runFunctions(mockBlock, { provision: true });
 
@@ -989,7 +973,6 @@ CREATE TABLE
       provisionLogsIfNeeded: jest.fn(),
     };
     const indexer = new Indexer(simpleSchemaConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler }, undefined, config);
-    const indexer = new Indexer(defaultIndexerBehavior, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler /** , indexerMeta: genericMockIndexerMeta */ }, undefined, config);
 
     await indexer.runFunctions(mockBlock, { provision: true });
     await indexer.runFunctions(mockBlock, { provision: true });
@@ -1029,17 +1012,6 @@ CREATE TABLE
     const indexer = new Indexer(indexerConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler }, undefined, config);
 
     await indexer.runFunctions(mockBlock, { provision: true });
-    const indexer = new Indexer(defaultIndexerBehavior, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler /** , indexerMeta: genericMockIndexerMeta */ }, undefined, config);
-
-    const functions: Record<string, any> = {
-      'morgs.near/test': {
-        code: `
-                    context.graphql(\`mutation { set(functionName: "buildnear.testnet/test", key: "height", data: "\${block.blockHeight}")}\`);
-                `,
-        schema: SIMPLE_SCHEMA,
-      }
-    };
-    await indexer.runFunctions(mockBlock, functions, { provision: true });
 
     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
     expect(mockFetch.mock.calls).toMatchSnapshot();
@@ -1074,16 +1046,6 @@ CREATE TABLE
     `;
     const indexerConfig = new IndexerConfig(SIMPLE_REDIS_STREAM, 'morgs.near', 'test', 0, code, 'schema', LogLevel.INFO);
     const indexer = new Indexer(indexerConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler }, undefined, config);
-    const indexer = new Indexer(defaultIndexerBehavior, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler /** , indexerMeta: genericMockIndexerMeta */ }, undefined, config);
-
-    const functions: Record<string, any> = {
-      'morgs.near/test': {
-        code: `
-                    context.graphql(\`mutation { set(functionName: "buildnear.testnet/test", key: "height", data: "\${block.blockHeight}")}\`);
-                `,
-        schema: 'schema',
-      }
-    };
 
     await expect(indexer.runFunctions(mockBlock, { provision: true })).rejects.toThrow(error);
     expect(mockFetch.mock.calls).toMatchSnapshot();
@@ -1137,24 +1099,18 @@ CREATE TABLE
     const indexerDebug = new Indexer(
       debugIndexerConfig,
       { fetch: mockFetchDebug as unknown as typeof fetch, provisioner: genericProvisioner, dmlHandler: mockDmlHandler },
-      { log_level: LogLevel.DEBUG },
-      { fetch: mockFetchDebug as unknown as typeof fetch, provisioner: genericProvisioner, dmlHandler: mockDmlHandler /** , indexerMeta: genericMockIndexerMeta */ },
       undefined,
       config
     );
     const indexerInfo = new Indexer(
       infoIndexerConfig,
       { fetch: mockFetchInfo as unknown as typeof fetch, provisioner: genericProvisioner, dmlHandler: mockDmlHandler },
-      { log_level: LogLevel.INFO },
-      { fetch: mockFetchInfo as unknown as typeof fetch, provisioner: genericProvisioner, dmlHandler: mockDmlHandler /** , indexerMeta: genericMockIndexerMeta */ },
       undefined,
       config
     );
     const indexerError = new Indexer(
       errorIndexerConfig,
       { fetch: mockFetchError as unknown as typeof fetch, provisioner: genericProvisioner, dmlHandler: mockDmlHandler },
-      { log_level: LogLevel.ERROR },
-      { fetch: mockFetchError as unknown as typeof fetch, provisioner: genericProvisioner, dmlHandler: mockDmlHandler /** , indexerMeta: genericMockIndexerMeta */ },
       undefined,
       config
     );
@@ -1184,9 +1140,6 @@ CREATE TABLE
       });
     const indexer = new Indexer(simpleSchemaConfig, { fetch: mockFetch as unknown as typeof fetch }, undefined, config);
     const context = indexer.buildContext(1);
-    const role = 'morgs_near';
-    const indexer = new Indexer(defaultIndexerBehavior, { fetch: mockFetch as unknown as typeof fetch }, undefined, config);
-    const context = indexer.buildContext(SIMPLE_SCHEMA, INDEXER_NAME, 1, HASURA_ROLE/** [] */);
 
     const mutation = `
             mutation {

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -915,6 +915,7 @@ CREATE TABLE
     expect(provisioner.fetchUserApiProvisioningStatus).toHaveBeenCalledWith(simpleSchemaConfig);
     expect(provisioner.provisionUserApi).toHaveBeenCalledTimes(1);
     expect(provisioner.provisionUserApi).toHaveBeenCalledWith(simpleSchemaConfig);
+    expect(provisioner.provisionLogsIfNeeded).toHaveBeenCalled();
     expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
   });
 
@@ -947,6 +948,7 @@ CREATE TABLE
 
     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
     expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
+    expect(provisioner.provisionLogsIfNeeded).toHaveBeenCalled();
   });
 
   test('Indexer.execute() skips database credentials fetch second time onward', async () => {

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -213,7 +213,7 @@ CREATE TABLE
   };
 
   const genericProvisioner: any = {
-    getDatabaseConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials)
+    getPgBouncerConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials)
   };
 
   const config = {
@@ -903,7 +903,7 @@ CREATE TABLE
       shards: {}
     } as unknown as StreamerMessage) as unknown as Block;
     const provisioner: any = {
-      getDatabaseConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
+      getPgBouncerConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
       fetchUserApiProvisioningStatus: jest.fn().mockReturnValue(false),
       provisionUserApi: jest.fn(),
       provisionLogsIfNeeded: jest.fn(),
@@ -915,7 +915,7 @@ CREATE TABLE
     expect(provisioner.fetchUserApiProvisioningStatus).toHaveBeenCalledWith(simpleSchemaConfig);
     expect(provisioner.provisionUserApi).toHaveBeenCalledTimes(1);
     expect(provisioner.provisionUserApi).toHaveBeenCalledWith(simpleSchemaConfig);
-    expect(provisioner.getDatabaseConnectionParameters).toHaveBeenCalledTimes(1);
+    expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
   });
 
   test('Indexer.execute() skips provisioning if the endpoint exists', async () => {
@@ -936,7 +936,7 @@ CREATE TABLE
       shards: {}
     } as unknown as StreamerMessage) as unknown as Block;
     const provisioner: any = {
-      getDatabaseConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
+      getPgBouncerConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
       fetchUserApiProvisioningStatus: jest.fn().mockReturnValue(true),
       provisionUserApi: jest.fn(),
       provisionLogsIfNeeded: jest.fn(),
@@ -946,7 +946,7 @@ CREATE TABLE
     await indexer.execute(mockBlock, { provision: true });
 
     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
-    expect(provisioner.getDatabaseConnectionParameters).toHaveBeenCalledTimes(1);
+    expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
   });
 
   test('Indexer.execute() skips database credentials fetch second time onward', async () => {
@@ -967,7 +967,7 @@ CREATE TABLE
       shards: {}
     } as unknown as StreamerMessage) as unknown as Block;
     const provisioner: any = {
-      getDatabaseConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
+      getPgBouncerConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
       fetchUserApiProvisioningStatus: jest.fn().mockReturnValue(true),
       provisionUserApi: jest.fn(),
       provisionLogsIfNeeded: jest.fn(),
@@ -979,7 +979,7 @@ CREATE TABLE
     await indexer.execute(mockBlock, { provision: true });
 
     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
-    expect(provisioner.getDatabaseConnectionParameters).toHaveBeenCalledTimes(1);
+    expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
   });
 
   test('Indexer.execute() supplies the required role to the GraphQL endpoint', async () => {
@@ -1000,7 +1000,7 @@ CREATE TABLE
       shards: {}
     } as unknown as StreamerMessage) as unknown as Block;
     const provisioner: any = {
-      getDatabaseConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
+      getPgBouncerConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
       fetchUserApiProvisioningStatus: jest.fn().mockReturnValue(true),
       provisionUserApi: jest.fn(),
       provisionLogsIfNeeded: jest.fn(),
@@ -1015,7 +1015,7 @@ CREATE TABLE
 
     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
     expect(mockFetch.mock.calls).toMatchSnapshot();
-    expect(provisioner.getDatabaseConnectionParameters).toHaveBeenCalledTimes(1);
+    expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
   });
 
   test('Indexer.execute() logs provisioning failures', async () => {
@@ -1037,7 +1037,7 @@ CREATE TABLE
     } as unknown as StreamerMessage) as unknown as Block;
     const error = new Error('something went wrong with provisioning');
     const provisioner: any = {
-      getDatabaseConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
+      getPgBouncerConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
       fetchUserApiProvisioningStatus: jest.fn().mockReturnValue(false),
       provisionUserApi: jest.fn().mockRejectedValue(error),
     };
@@ -1049,7 +1049,7 @@ CREATE TABLE
 
     await expect(indexer.execute(mockBlock, { provision: true })).rejects.toThrow(error);
     expect(mockFetch.mock.calls).toMatchSnapshot();
-    expect(provisioner.getDatabaseConnectionParameters).not.toHaveBeenCalled();
+    expect(provisioner.getPgBouncerConnectionParameters).not.toHaveBeenCalled();
   });
 
   test('Indexer log level respected by writeLog', async () => {

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -153,7 +153,7 @@ export default class Indexer {
         const resourceCreationSpan = this.tracer.startSpan('prepare vm and context to run indexer code');
         simultaneousPromises.push(this.setStatus(functionName, blockHeight, IndexerStatus.RUNNING));
         const vm = new VM({ allowAsync: true });
-        const context = this.buildContext(indexerFunction.schema, functionName, blockHeight, hasuraRoleName /** , logEntries */);
+        const context = this.buildContext(indexerFunction.schema, functionName, blockHeight, hasuraRoleName /* ,logEntries */);
 
         vm.freeze(block, 'block');
         vm.freeze(lakePrimitives, 'primitives');

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -322,7 +322,7 @@ export default class Indexer {
                   // const insertLogEntry = LogEntry.systemDebug(`Inserting object ${JSON.stringify(objectsToInsert)} into table ${tableName}`, blockHeight);
                   // await this.writeLog(insertLogEntry, logEntries, functionName);
                   // Call insert with parameters
-                  return await dmlHandler.insert(this.indexerConfig.postgresSchemaName(), tableDefinitionNames, Array.isArray(objectsToInsert) ? objectsToInsert : [objectsToInsert]);
+                  return await dmlHandler.insert(this.indexerConfig.schemaName(), tableDefinitionNames, Array.isArray(objectsToInsert) ? objectsToInsert : [objectsToInsert]);
                 } finally {
                   insertSpan.end();
                 }
@@ -337,7 +337,7 @@ export default class Indexer {
                   // const selectLogEntry = LogEntry.systemDebug(`Selecting objects in table ${tableName} with values ${JSON.stringify(filterObj)} with ${limit === null ? 'no' : limit} limit`, blockHeight);
                   // await this.writeLog(selectLogEntry, logEntries, functionName);
                   // Call select with parameters
-                  return await dmlHandler.select(this.indexerConfig.postgresSchemaName(), tableDefinitionNames, filterObj, limit);
+                  return await dmlHandler.select(this.indexerConfig.schemaName(), tableDefinitionNames, filterObj, limit);
                 } finally {
                   selectSpan.end();
                 }
@@ -352,7 +352,7 @@ export default class Indexer {
                   // const updateLogEntry = LogEntry.systemDebug(`Updating objects in table ${tableName} that match ${JSON.stringify(filterObj)} with values ${JSON.stringify(updateObj)}`, blockHeight);
                   // await this.writeLog(updateLogEntry, logEntries, functionName);
                   // Call update with parameters
-                  return await dmlHandler.update(this.indexerConfig.postgresSchemaName(), tableDefinitionNames, filterObj, updateObj);
+                  return await dmlHandler.update(this.indexerConfig.schemaName(), tableDefinitionNames, filterObj, updateObj);
                 } finally {
                   updateSpan.end();
                 }
@@ -367,7 +367,7 @@ export default class Indexer {
                   // const upsertLogEntry = LogEntry.systemDebug(`Inserting objects into table ${tableName} with values ${JSON.stringify(objectsToInsert)}. Conflict on columns ${conflictColumns.join(', ')} will update values in columns ${updateColumns.join(', ')}`, blockHeight);
                   // await this.writeLog(upsertLogEntry, logEntries, functionName);
                   // Call upsert with parameters
-                  return await dmlHandler.upsert(this.indexerConfig.postgresSchemaName(), tableDefinitionNames, Array.isArray(objectsToInsert) ? objectsToInsert : [objectsToInsert], conflictColumns, updateColumns);
+                  return await dmlHandler.upsert(this.indexerConfig.schemaName(), tableDefinitionNames, Array.isArray(objectsToInsert) ? objectsToInsert : [objectsToInsert], conflictColumns, updateColumns);
                 } finally {
                   upsertSpan.end();
                 }
@@ -382,7 +382,7 @@ export default class Indexer {
                   // const deleteLogEntry = LogEntry.systemDebug(`Deleting objects from table ${tableName} with values ${JSON.stringify(filterObj)}`, blockHeight);
                   // await this.writeLog(deleteLogEntry, logEntries, functionName);
                   // Call delete with parameters
-                  return await dmlHandler.delete(this.indexerConfig.postgresSchemaName(), tableDefinitionNames, filterObj);
+                  return await dmlHandler.delete(this.indexerConfig.schemaName(), tableDefinitionNames, filterObj);
                 } finally {
                   deleteSpan.end();
                 }

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -196,7 +196,6 @@ export default class Indexer {
         // return await this.writeLog(debugLogEntry, logEntries as LogEntry[], functionName);
       },
       log: async (...log) => {
-        console.log('log', log);
         return await this.writeLog(LogLevel.INFO, blockHeight, ...log);
         // const infoLogEntry = LogEntry.systemInfo(log.join(' '), blockHeight);
         // return await this.writeLog(infoLogEntry, logEntries as LogEntry[], functionName);

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -74,7 +74,7 @@ export default class Indexer {
     this.database_connection_parameters = databaseConnectionParameters;
   }
 
-  async runFunctions (
+  async execute (
     block: lakePrimitives.Block,
     options: { provision?: boolean } = { provision: false }
   ): Promise<string[]> {

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -162,18 +162,7 @@ export default class Indexer {
     return allMutations;
   }
 
-  // async getDatabaseConnectionParams(hasuraRoleName: string): Promise<DatabaseConnectionParameters>  {
-  //   const { username, password, database, host, port } = await this.deps.provisioner.getDatabaseConnectionParameters(hasuraRoleName) as DatabaseConnectionParameters;
-  //   return {
-  //     username,
-  //     password,
-  //     database,
-  //     host: this.config.hasuraHostOverride ?? host,
-  //     port: this.config.hasuraPortOverride ?? port
-  //   }
-  // }
-
-  buildContext (blockHeight: number /** logEntries: LogEntry[] */): Context {
+  buildContext (blockHeight: number /*, logEntries: LogEntry[] */): Context {
     return {
       graphql: async (operation, variables) => {
         const graphqlSpan = this.tracer.startSpan(`Call graphql ${operation.includes('mutation') ? 'mutation' : 'query'} through Hasura`);
@@ -187,7 +176,7 @@ export default class Indexer {
         const setSpan = this.tracer.startSpan('Call insert mutation through Hasura');
         const mutation = `
           mutation SetKeyValue($function_name: String!, $key: String!, $value: String!) {
-            insert_${this.indexerConfig.hasuraRoleName()}_${this.indexerConfig.hasuraFunctionName()}_indexer_storage_one(object: {function_name: $function_name, key_name: $key, value: $value} on_conflict: {constraint: indexer_storage_pkey, update_columns: value}) {key_name}
+            insert_${this.indexerConfig.hasuraRoleName()}_${this.indexerConfig.hasuraRoleName()}_indexer_storage_one(object: {function_name: $function_name, key_name: $key, value: $value} on_conflict: {constraint: indexer_storage_pkey, update_columns: value}) {key_name}
           }`;
         const variables = {
           function_name: this.indexerConfig.fullName(),

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -488,6 +488,8 @@ export default class Indexer {
     } finally {
       setStatusSpan.end();
     }
+
+    await this.indexer_logger?.updateIndexerStatus(status);
   }
 
   // async writeLog (logEntry: LogEntry, logEntries: LogEntry[], functionName: string): Promise<any> {
@@ -540,6 +542,8 @@ export default class Indexer {
     } finally {
       setBlockHeightSpan.end();
     }
+
+    await this.indexer_logger?.updateIndexerBlockheight(blockHeight);
   }
 
   // todo rename to writeLogOld
@@ -572,6 +576,7 @@ export default class Indexer {
   }
 
   async runGraphQLQuery (operation: string, variables: any, functionName: string, blockHeight: number, hasuraRoleName: string | null, logError: boolean = true): Promise<any> {
+    console.log('runGraphQLQuery', operation, variables, functionName, blockHeight, hasuraRoleName, logError);
     const response: Response = await this.deps.fetch(`${this.config.hasuraEndpoint}/v1/graphql`, {
       method: 'POST',
       headers: {

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -403,7 +403,7 @@ export default class Indexer {
     return {}; // Default to empty object if error
   }
 
-  async setStatus (functionName: string, blockHeight: number, status: IndexerStatus): Promise<any> {
+  async setStatus (blockHeight: number, status: IndexerStatus): Promise<any> {
     if (this.currentStatus === status) {
       return;
     }
@@ -431,8 +431,6 @@ export default class Indexer {
     } finally {
       setStatusSpan.end();
     }
-
-    await this.indexer_logger?.updateIndexerStatus(status);
   }
 
   // async writeLog (logEntry: LogEntry, logEntries: LogEntry[], functionName: string): Promise<any> {
@@ -471,8 +469,6 @@ export default class Indexer {
     } finally {
       setBlockHeightSpan.end();
     }
-
-    await this.indexer_logger?.updateIndexerBlockheight(blockHeight);
   }
 
   // todo rename to writeLogOld

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -100,6 +100,7 @@ export default class Indexer {
             simultaneousPromises.push(this.writeLog(LogLevel.INFO, blockHeight, 'Provisioning endpoint: successful'));
             // logEntries.push({ blockHeight, logTimestamp: new Date(), logType: LogType.SYSTEM, logLevel: LogLevel.INFO, message: 'Provisioning endpoint: successful' });
           }
+          await this.deps.provisioner.provisionLogsIfNeeded(this.indexerConfig.accountId, this.indexerConfig.functionName);
         } catch (e) {
           const error = e as Error;
           simultaneousPromises.push(this.writeLog(LogLevel.ERROR, blockHeight, 'Provisioning endpoint: failure', error.message));

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -87,7 +87,6 @@ export default class Indexer {
   async runFunctions (
     block: lakePrimitives.Block,
     functions: Record<string, IndexerFunction>,
-    isHistorical: boolean,
     options: { provision?: boolean } = { provision: false }
   ): Promise<string[]> {
     const blockHeight: number = block.blockHeight;
@@ -503,6 +502,7 @@ export default class Indexer {
   // }
 
   async updateIndexerBlockHeight (functionName: string, blockHeight: number, isHistorical: boolean): Promise<void> {
+  async writeFunctionState (functionName: string, blockHeight: number): Promise<any> {
     const realTimeMutation: string = `
       mutation WriteBlock($function_name: String!, $block_height: numeric!) {
         insert_indexer_state(
@@ -515,20 +515,6 @@ export default class Indexer {
           }
         }
       }`;
-    const historicalMutation: string = `
-      mutation WriteBlock($function_name: String!, $block_height: numeric!) {
-        insert_indexer_state(
-          objects: {current_historical_block_height: $block_height, current_block_height: 0, function_name: $function_name}
-          on_conflict: {constraint: indexer_state_pkey, update_columns: current_historical_block_height}
-        ) {
-          returning {
-            current_block_height
-            current_historical_block_height
-            function_name
-          }
-        }
-      }
-    `;
     const variables: any = {
       function_name: functionName,
       block_height: blockHeight,

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -5,7 +5,7 @@ import { Parser } from 'node-sql-parser';
 
 import Provisioner from '../provisioner';
 import DmlHandler from '../dml-handler/dml-handler';
-import /**LogEntry,*/ { LogLevel } from '../indexer-meta/log-entry';
+import /** LogEntry, */ { LogLevel } from '../indexer-meta/log-entry';
 
 import /** IndexerMeta, */ { IndexerStatus } from '../indexer-meta/indexer-meta';
 import { trace, type Span } from '@opentelemetry/api';
@@ -113,7 +113,7 @@ export default class Indexer {
       // Cache database credentials after provisioning
       const credentialsFetchSpan = this.tracer.startSpan('fetch database connection parameters');
       try {
-        this.database_connection_parameters ??= await this.deps.provisioner.getDatabaseConnectionParameters(this.indexerConfig.hasuraRoleName()) as PostgresConnectionParams;
+        this.database_connection_parameters ??= await this.deps.provisioner.getDatabaseConnectionParameters(this.indexerConfig.hasuraRoleName());
         // this.database_connection_parameters = await this.getDatabaseConnectionParams(hasuraRoleName);
         // this.deps.indexerMeta ??= new IndexerMeta(functionName, this.indexer_behavior.log_level, this.database_connection_parameters);
         this.deps.dmlHandler ??= new DmlHandler(this.database_connection_parameters);
@@ -196,6 +196,7 @@ export default class Indexer {
         // return await this.writeLog(debugLogEntry, logEntries as LogEntry[], functionName);
       },
       log: async (...log) => {
+        console.log('log', log);
         return await this.writeLog(LogLevel.INFO, blockHeight, ...log);
         // const infoLogEntry = LogEntry.systemInfo(log.join(' '), blockHeight);
         // return await this.writeLog(infoLogEntry, logEntries as LogEntry[], functionName);

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -113,7 +113,7 @@ export default class Indexer {
       // Cache database credentials after provisioning
       const credentialsFetchSpan = this.tracer.startSpan('fetch database connection parameters');
       try {
-        this.database_connection_parameters ??= await this.deps.provisioner.getDatabaseConnectionParameters(this.indexerConfig.hasuraRoleName());
+        this.database_connection_parameters ??= await this.deps.provisioner.getPgBouncerConnectionParameters(this.indexerConfig.hasuraRoleName());
         // this.database_connection_parameters = await this.getDatabaseConnectionParams(hasuraRoleName);
         // this.deps.indexerMeta ??= new IndexerMeta(functionName, this.indexer_behavior.log_level, this.database_connection_parameters);
         this.deps.dmlHandler ??= new DmlHandler(this.database_connection_parameters);

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -8,9 +8,9 @@ import DmlHandler from '../dml-handler/dml-handler';
 import /**LogEntry,*/ { LogLevel } from '../indexer-meta/log-entry';
 
 import /** IndexerMeta, */ { IndexerStatus } from '../indexer-meta/indexer-meta';
-import { type DatabaseConnectionParameters } from '../provisioner/provisioner';
 import { trace, type Span } from '@opentelemetry/api';
 import type IndexerConfig from '../indexer-config';
+import { type PostgresConnectionParams } from '../pg-client';
 
 interface Dependencies {
   fetch: typeof fetch
@@ -54,7 +54,7 @@ export default class Indexer {
 
   private readonly deps: Dependencies;
 
-  private database_connection_parameters: DatabaseConnectionParameters | undefined;
+  private database_connection_parameters: PostgresConnectionParams | undefined;
 
   private currentStatus?: string;
 
@@ -113,7 +113,7 @@ export default class Indexer {
       // Cache database credentials after provisioning
       const credentialsFetchSpan = this.tracer.startSpan('fetch database connection parameters');
       try {
-        this.database_connection_parameters ??= await this.deps.provisioner.getDatabaseConnectionParameters(this.indexerConfig.hasuraRoleName()) as DatabaseConnectionParameters;
+        this.database_connection_parameters ??= await this.deps.provisioner.getDatabaseConnectionParameters(this.indexerConfig.hasuraRoleName()) as PostgresConnectionParams;
         // this.database_connection_parameters = await this.getDatabaseConnectionParams(hasuraRoleName);
         // this.deps.indexerMeta ??= new IndexerMeta(functionName, this.indexer_behavior.log_level, this.database_connection_parameters);
         this.deps.dmlHandler ??= new DmlHandler(this.database_connection_parameters);

--- a/runner/src/lake-client/lake-client.test.ts
+++ b/runner/src/lake-client/lake-client.test.ts
@@ -3,9 +3,15 @@ import LakeClient from './lake-client';
 import type RedisClient from '../redis-client';
 
 describe('LakeClient', () => {
-  const transparentRedis = {
+  let transparentRedis = {
     getStreamerMessage: jest.fn()
   } as unknown as RedisClient;
+
+  beforeEach(() => {
+    transparentRedis = {
+      getStreamerMessage: jest.fn()
+    } as unknown as RedisClient;
+  });
 
   test('Indexer.fetchBlock() should fetch the block and shards from S3 upon cache miss', async () => {
     const blockHeight = 85233529;
@@ -32,7 +38,7 @@ describe('LakeClient', () => {
     } as unknown as S3Client;
     const client = new LakeClient('mainnet', mockS3, transparentRedis);
 
-    const block = await client.fetchBlock(blockHeight, true);
+    const block = await client.fetchBlock(blockHeight);
 
     expect(mockSend).toHaveBeenCalledTimes(5);
     expect(JSON.stringify(mockSend.mock.calls[0][0])).toStrictEqual(JSON.stringify(new GetObjectCommand({
@@ -70,7 +76,7 @@ describe('LakeClient', () => {
     const mockS3 = {} as unknown as S3Client;
     const client = new LakeClient('mainnet', mockS3, mockRedis);
 
-    const block = await client.fetchBlock(blockHeight, false);
+    const block = await client.fetchBlock(blockHeight);
 
     expect(getMessage).toHaveBeenCalledTimes(1);
     expect(JSON.stringify(getMessage.mock.calls[0])).toEqual(
@@ -106,7 +112,7 @@ describe('LakeClient', () => {
     } as unknown as S3Client;
     const client = new LakeClient('mainnet', mockS3, transparentRedis);
 
-    const block = await client.fetchBlock(blockHeight, false);
+    const block = await client.fetchBlock(blockHeight);
 
     expect(mockSend).toHaveBeenCalledTimes(5);
     expect(JSON.stringify(mockSend.mock.calls[0][0])).toStrictEqual(JSON.stringify(new GetObjectCommand({
@@ -118,51 +124,6 @@ describe('LakeClient', () => {
       Key: `${blockHeight.toString().padStart(12, '0')}/shard_0.json`
     })));
     expect(transparentRedis.getStreamerMessage).toHaveBeenCalledTimes(1);
-
-    expect(block.blockHeight).toEqual(blockHeight);
-    expect(block.blockHash).toEqual(blockHash);
-  });
-
-  test('fetchBlock should not hit cache and instead fetch the block and shards from S3 if historical', async () => {
-    const blockHeight = 85233529;
-    const blockHash = 'xyz';
-    const mockSend = jest.fn()
-      .mockReturnValueOnce({ // block
-        Body: {
-          transformToString: () => JSON.stringify({
-            chunks: [0, 1, 2, 3],
-            header: {
-              height: blockHeight,
-              hash: blockHash,
-            }
-          })
-        }
-      })
-      .mockReturnValue({ // shard
-        Body: {
-          transformToString: () => JSON.stringify({})
-        }
-      });
-    const mockS3 = {
-      send: mockSend,
-    } as unknown as S3Client;
-    const mockRedis = {
-      getStreamerMessage: jest.fn()
-    } as unknown as RedisClient;
-    const client = new LakeClient('mainnet', mockS3, mockRedis);
-
-    const block = await client.fetchBlock(blockHeight, true);
-
-    expect(mockSend).toHaveBeenCalledTimes(5);
-    expect(JSON.stringify(mockSend.mock.calls[0][0])).toStrictEqual(JSON.stringify(new GetObjectCommand({
-      Bucket: 'near-lake-data-mainnet',
-      Key: `${blockHeight.toString().padStart(12, '0')}/block.json`
-    })));
-    expect(JSON.stringify(mockSend.mock.calls[1][0])).toStrictEqual(JSON.stringify(new GetObjectCommand({
-      Bucket: 'near-lake-data-mainnet',
-      Key: `${blockHeight.toString().padStart(12, '0')}/shard_0.json`
-    })));
-    expect(mockRedis.getStreamerMessage).toHaveBeenCalledTimes(0);
 
     expect(block.blockHeight).toEqual(blockHeight);
     expect(block.blockHash).toEqual(blockHash);

--- a/runner/src/lake-client/lake-client.ts
+++ b/runner/src/lake-client/lake-client.ts
@@ -64,16 +64,14 @@ export default class LakeClient {
     return value;
   }
 
-  async fetchBlock (blockHeight: number, isHistorical: boolean): Promise<Block> {
-    if (!isHistorical) {
-      const cachedMessage = await this.redisClient.getStreamerMessage(blockHeight);
-      if (cachedMessage) {
-        METRICS.CACHE_HIT.inc();
-        const parsedMessage = JSON.parse(cachedMessage);
-        return Block.fromStreamerMessage(parsedMessage);
-      } else {
-        METRICS.CACHE_MISS.inc();
-      }
+  async fetchBlock (blockHeight: number): Promise<Block> {
+    const cachedMessage = await this.redisClient.getStreamerMessage(blockHeight);
+    if (cachedMessage) {
+      METRICS.CACHE_HIT.inc();
+      const parsedMessage = JSON.parse(cachedMessage);
+      return Block.fromStreamerMessage(parsedMessage);
+    } else {
+      METRICS.CACHE_MISS.inc();
     }
 
     const block = await this.fetchBlockPromise(blockHeight);

--- a/runner/src/metrics.ts
+++ b/runner/src/metrics.ts
@@ -4,25 +4,25 @@ import { Gauge, Histogram, Counter, AggregatorRegistry } from 'prom-client';
 const HEAP_TOTAL_ALLOCATION = new Gauge({
   name: 'queryapi_runner_heap_total_allocation_megabytes',
   help: 'Size of heap allocation for indexer function',
-  labelNames: ['indexer', 'type'],
+  labelNames: ['indexer'],
 });
 
 const HEAP_USED = new Gauge({
   name: 'queryapi_runner_heap_used_megabytes',
   help: 'Size of used heap space for indexer function',
-  labelNames: ['indexer', 'type'],
+  labelNames: ['indexer'],
 });
 
 const PREFETCH_QUEUE_COUNT = new Gauge({
   name: 'queryapi_runner_prefetch_queue_count',
   help: 'Count of items in prefetch queue for indexer function',
-  labelNames: ['indexer', 'type'],
+  labelNames: ['indexer'],
 });
 
 const BLOCK_WAIT_DURATION = new Histogram({
   name: 'queryapi_runner_block_wait_duration_milliseconds',
   help: 'Time an indexer function waited for a block before processing',
-  labelNames: ['indexer', 'type'],
+  labelNames: ['indexer'],
   buckets: [1, 10, 100, 300, 500, 1000, 3000, 5000, 10000, 30000],
 });
 
@@ -39,19 +39,19 @@ const CACHE_MISS = new Counter({
 const UNPROCESSED_STREAM_MESSAGES = new Gauge({
   name: 'queryapi_runner_unprocessed_stream_messages',
   help: 'Number of Redis Stream messages not yet processed',
-  labelNames: ['indexer', 'type'],
+  labelNames: ['indexer'],
 });
 
 const LAST_PROCESSED_BLOCK_HEIGHT = new Gauge({
   name: 'queryapi_runner_last_processed_block_height',
   help: 'Previous block height processed by an indexer',
-  labelNames: ['indexer', 'type'],
+  labelNames: ['indexer'],
 });
 
 const EXECUTION_DURATION = new Histogram({
   name: 'queryapi_runner_execution_duration_milliseconds',
   help: 'Time taken to execute an indexer function',
-  labelNames: ['indexer', 'type'],
+  labelNames: ['indexer'],
 });
 
 export const METRICS = {

--- a/runner/src/pg-client.ts
+++ b/runner/src/pg-client.ts
@@ -1,7 +1,7 @@
 import { Pool, type PoolConfig, type QueryResult, type QueryResultRow } from 'pg';
 import pgFormatModule from 'pg-format';
 
-interface ConnectionParams {
+export interface PostgresConnectionParams {
   user: string
   password: string
   host: string
@@ -14,7 +14,7 @@ export default class PgClient {
   public format: typeof pgFormatModule;
 
   constructor (
-    connectionParams: ConnectionParams,
+    connectionParams: PostgresConnectionParams,
     poolConfig: PoolConfig = { max: Number(process.env.MAX_PG_POOL_SIZE ?? 10), idleTimeoutMillis: 3000 },
     PgPool: typeof Pool = Pool,
     pgFormat: typeof pgFormatModule = pgFormatModule,

--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -2,7 +2,7 @@ import pgFormat from 'pg-format';
 
 import Provisioner from './provisioner';
 import IndexerConfig from '../indexer-config/indexer-config';
-import { LogLevel } from '../indexer-meta/indexer-meta';
+import { LogLevel } from '../indexer-meta/log-entry';
 // import { logsTableDDL } from './schemas/logs-table';
 // import { metadataTableDDL } from './schemas/metadata-table';
 

--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -118,7 +118,7 @@ describe('Provisioner', () => {
       expect(hasuraClient.createSchema).toBeCalledWith(indexerConfig.userName(), indexerConfig.schemaName());
       // expect(hasuraClient.executeSqlOnSchema).toBeCalledWith(sanitizedAccountId, schemaName, metadataTableDDL());
       expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(1, indexerConfig.userName(), indexerConfig.schemaName(), databaseSchema);
-      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(2, sanitizedAccountId, schemaName, logsDDL);
+      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(2, indexerConfig.userName(), indexerConfig.schemaName(), logsDDL);
       expect(hasuraClient.getTableNames).toBeCalledWith(indexerConfig.schemaName(), indexerConfig.databaseName());
       expect(hasuraClient.trackTables).toBeCalledWith(indexerConfig.schemaName(), tableNames, indexerConfig.databaseName());
       expect(hasuraClient.addPermissionsToTables).toBeCalledWith(

--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -114,18 +114,18 @@ describe('Provisioner', () => {
         ["SELECT cron.schedule_in_database('morgs_near_test_function_logs_create_partition', '0 1 * * *', $$SELECT fn_create_partition('morgs_near_test_function.__logs', CURRENT_DATE, '1 day', '2 day')$$, 'morgs_near');"],
         ["SELECT cron.schedule_in_database('morgs_near_test_function_logs_delete_partition', '0 2 * * *', $$SELECT fn_delete_partition('morgs_near_test_function.__logs', CURRENT_DATE, '-15 day', '-14 day')$$, 'morgs_near');"]
       ]);
-      expect(hasuraClient.addDatasource).toBeCalledWith(indexerConfig.postgresUserName(), password, indexerConfig.postgresDatabaseName());
-      expect(hasuraClient.createSchema).toBeCalledWith(indexerConfig.postgresUserName(), indexerConfig.postgresSchemaName());
+      expect(hasuraClient.addDatasource).toBeCalledWith(indexerConfig.userName(), password, indexerConfig.databaseName());
+      expect(hasuraClient.createSchema).toBeCalledWith(indexerConfig.userName(), indexerConfig.schemaName());
       // expect(hasuraClient.executeSqlOnSchema).toBeCalledWith(sanitizedAccountId, schemaName, metadataTableDDL());
-      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(1, indexerConfig.postgresUserName(), indexerConfig.postgresSchemaName(), databaseSchema);
+      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(1, indexerConfig.userName(), indexerConfig.schemaName(), databaseSchema);
       expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(2, sanitizedAccountId, schemaName, logsDDL);
-      expect(hasuraClient.getTableNames).toBeCalledWith(indexerConfig.postgresSchemaName(), indexerConfig.postgresDatabaseName());
-      expect(hasuraClient.trackTables).toBeCalledWith(indexerConfig.postgresSchemaName(), tableNames, indexerConfig.postgresDatabaseName());
+      expect(hasuraClient.getTableNames).toBeCalledWith(indexerConfig.schemaName(), indexerConfig.databaseName());
+      expect(hasuraClient.trackTables).toBeCalledWith(indexerConfig.schemaName(), tableNames, indexerConfig.databaseName());
       expect(hasuraClient.addPermissionsToTables).toBeCalledWith(
-        indexerConfig.postgresSchemaName(),
-        indexerConfig.postgresDatabaseName(),
+        indexerConfig.schemaName(),
+        indexerConfig.databaseName(),
         tableNames,
-        indexerConfig.postgresUserName(),
+        indexerConfig.userName(),
         [
           'select',
           'insert',
@@ -144,17 +144,17 @@ describe('Provisioner', () => {
       expect(adminPgClient.query).not.toBeCalled();
       expect(hasuraClient.addDatasource).not.toBeCalled();
 
-      expect(hasuraClient.createSchema).toBeCalledWith(indexerConfig.postgresUserName(), indexerConfig.postgresSchemaName());
+      expect(hasuraClient.createSchema).toBeCalledWith(indexerConfig.userName(), indexerConfig.schemaName());
       // expect(hasuraClient.executeSqlOnSchema).toBeCalledWith(sanitizedAccountId, schemaName, logsTableDDL(schemaName));
       // expect(hasuraClient.executeSqlOnSchema).toBeCalledWith(sanitizedAccountId, schemaName, metadataTableDDL());
-      expect(hasuraClient.executeSqlOnSchema).toBeCalledWith(indexerConfig.postgresDatabaseName(), indexerConfig.postgresSchemaName(), databaseSchema);
-      expect(hasuraClient.getTableNames).toBeCalledWith(indexerConfig.postgresSchemaName(), indexerConfig.postgresDatabaseName());
-      expect(hasuraClient.trackTables).toBeCalledWith(indexerConfig.postgresSchemaName(), tableNames, indexerConfig.postgresDatabaseName());
+      expect(hasuraClient.executeSqlOnSchema).toBeCalledWith(indexerConfig.databaseName(), indexerConfig.schemaName(), databaseSchema);
+      expect(hasuraClient.getTableNames).toBeCalledWith(indexerConfig.schemaName(), indexerConfig.databaseName());
+      expect(hasuraClient.trackTables).toBeCalledWith(indexerConfig.schemaName(), tableNames, indexerConfig.databaseName());
       expect(hasuraClient.addPermissionsToTables).toBeCalledWith(
-        indexerConfig.postgresSchemaName(),
-        indexerConfig.postgresDatabaseName(),
+        indexerConfig.schemaName(),
+        indexerConfig.databaseName(),
         tableNames,
-        indexerConfig.postgresUserName(),
+        indexerConfig.userName(),
         [
           'select',
           'insert',

--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -1,6 +1,8 @@
 import pgFormat from 'pg-format';
 
 import Provisioner from './provisioner';
+import IndexerConfig from '../indexer-config/indexer-config';
+import { LogLevel } from '../indexer-meta/indexer-meta';
 // import { logsTableDDL } from './schemas/logs-table';
 // import { metadataTableDDL } from './schemas/metadata-table';
 
@@ -10,16 +12,14 @@ describe('Provisioner', () => {
   let hasuraClient: any;
   let provisioner: Provisioner;
   let userPgClientQuery: any;
+  let indexerConfig: any;
 
   const tableNames = ['blocks'];
   const accountId = 'morgs.near';
-  const sanitizedAccountId = 'morgs_near';
   const functionName = 'test-function';
-  const sanitizedFunctionName = 'test_function';
   const databaseSchema = 'CREATE TABLE blocks (height numeric)';
   const logsDDL = expect.any(String);
   const error = new Error('some error');
-  const schemaName = `${sanitizedAccountId}_${sanitizedFunctionName}`;
 
   const password = 'password';
   const crypto: any = {
@@ -66,36 +66,38 @@ describe('Provisioner', () => {
     });
 
     provisioner = new Provisioner(hasuraClient, adminPgClient, cronPgClient, undefined, crypto, pgFormat, PgClient as any);
+
+    indexerConfig = new IndexerConfig('', accountId, functionName, 0, '', databaseSchema, LogLevel.INFO);
   });
 
   describe('isUserApiProvisioned', () => {
     it('returns false if datasource doesnt exists', async () => {
       hasuraClient.doesSourceExist = jest.fn().mockReturnValueOnce(false);
 
-      await expect(provisioner.fetchUserApiProvisioningStatus(accountId, functionName)).resolves.toBe(false);
-      expect(provisioner.isUserApiProvisioned(accountId, functionName)).toBe(false);
+      await expect(provisioner.fetchUserApiProvisioningStatus(indexerConfig)).resolves.toBe(false);
+      expect(provisioner.isUserApiProvisioned(indexerConfig.accountId, indexerConfig.functionName)).toBe(false);
     });
 
     it('returns false if datasource and schema dont exists', async () => {
       hasuraClient.doesSourceExist = jest.fn().mockReturnValueOnce(false);
       hasuraClient.doesSchemaExist = jest.fn().mockReturnValueOnce(false);
 
-      await expect(provisioner.fetchUserApiProvisioningStatus(accountId, functionName)).resolves.toBe(false);
-      expect(provisioner.isUserApiProvisioned(accountId, functionName)).toBe(false);
+      await expect(provisioner.fetchUserApiProvisioningStatus(indexerConfig)).resolves.toBe(false);
+      expect(provisioner.isUserApiProvisioned(indexerConfig.accountId, indexerConfig.functionName)).toBe(false);
     });
 
     it('returns true if datasource and schema exists', async () => {
       hasuraClient.doesSourceExist = jest.fn().mockReturnValueOnce(true);
       hasuraClient.doesSchemaExist = jest.fn().mockReturnValueOnce(true);
 
-      await expect(provisioner.fetchUserApiProvisioningStatus(accountId, functionName)).resolves.toBe(true);
-      expect(provisioner.isUserApiProvisioned(accountId, functionName)).toBe(true);
+      await expect(provisioner.fetchUserApiProvisioningStatus(indexerConfig)).resolves.toBe(true);
+      expect(provisioner.isUserApiProvisioned(indexerConfig.accountId, indexerConfig.functionName)).toBe(true);
     });
   });
 
   describe('provisionUserApi', () => {
     it('provisions an API for the user', async () => {
-      await provisioner.provisionUserApi(accountId, functionName, databaseSchema);
+      await provisioner.provisionUserApi(indexerConfig);
 
       expect(adminPgClient.query.mock.calls).toEqual([
         ['CREATE DATABASE morgs_near'],
@@ -112,18 +114,18 @@ describe('Provisioner', () => {
         ["SELECT cron.schedule_in_database('morgs_near_test_function_logs_create_partition', '0 1 * * *', $$SELECT fn_create_partition('morgs_near_test_function.__logs', CURRENT_DATE, '1 day', '2 day')$$, 'morgs_near');"],
         ["SELECT cron.schedule_in_database('morgs_near_test_function_logs_delete_partition', '0 2 * * *', $$SELECT fn_delete_partition('morgs_near_test_function.__logs', CURRENT_DATE, '-15 day', '-14 day')$$, 'morgs_near');"]
       ]);
-      expect(hasuraClient.addDatasource).toBeCalledWith(sanitizedAccountId, password, sanitizedAccountId);
-      expect(hasuraClient.createSchema).toBeCalledWith(sanitizedAccountId, schemaName);
+      expect(hasuraClient.addDatasource).toBeCalledWith(indexerConfig.postgresUserName(), password, indexerConfig.postgresDatabaseName());
+      expect(hasuraClient.createSchema).toBeCalledWith(indexerConfig.postgresUserName(), indexerConfig.postgresSchemaName());
       // expect(hasuraClient.executeSqlOnSchema).toBeCalledWith(sanitizedAccountId, schemaName, metadataTableDDL());
-      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(1, sanitizedAccountId, schemaName, databaseSchema);
+      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(1, indexerConfig.postgresUserName(), indexerConfig.postgresSchemaName(), databaseSchema);
       expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(2, sanitizedAccountId, schemaName, logsDDL);
-      expect(hasuraClient.getTableNames).toBeCalledWith(schemaName, sanitizedAccountId);
-      expect(hasuraClient.trackTables).toBeCalledWith(schemaName, tableNames, sanitizedAccountId);
+      expect(hasuraClient.getTableNames).toBeCalledWith(indexerConfig.postgresSchemaName(), indexerConfig.postgresDatabaseName());
+      expect(hasuraClient.trackTables).toBeCalledWith(indexerConfig.postgresSchemaName(), tableNames, indexerConfig.postgresDatabaseName());
       expect(hasuraClient.addPermissionsToTables).toBeCalledWith(
-        schemaName,
-        sanitizedAccountId,
+        indexerConfig.postgresSchemaName(),
+        indexerConfig.postgresDatabaseName(),
         tableNames,
-        sanitizedAccountId,
+        indexerConfig.postgresUserName(),
         [
           'select',
           'insert',
@@ -137,22 +139,22 @@ describe('Provisioner', () => {
     it('skips provisioning the datasource if it already exists', async () => {
       hasuraClient.doesSourceExist = jest.fn().mockReturnValueOnce(true);
 
-      await provisioner.provisionUserApi(accountId, functionName, databaseSchema);
+      await provisioner.provisionUserApi(indexerConfig);
 
       expect(adminPgClient.query).not.toBeCalled();
       expect(hasuraClient.addDatasource).not.toBeCalled();
 
-      expect(hasuraClient.createSchema).toBeCalledWith(sanitizedAccountId, schemaName);
+      expect(hasuraClient.createSchema).toBeCalledWith(indexerConfig.postgresUserName(), indexerConfig.postgresSchemaName());
       // expect(hasuraClient.executeSqlOnSchema).toBeCalledWith(sanitizedAccountId, schemaName, logsTableDDL(schemaName));
       // expect(hasuraClient.executeSqlOnSchema).toBeCalledWith(sanitizedAccountId, schemaName, metadataTableDDL());
-      expect(hasuraClient.executeSqlOnSchema).toBeCalledWith(sanitizedAccountId, schemaName, databaseSchema);
-      expect(hasuraClient.getTableNames).toBeCalledWith(schemaName, sanitizedAccountId);
-      expect(hasuraClient.trackTables).toBeCalledWith(schemaName, tableNames, sanitizedAccountId);
+      expect(hasuraClient.executeSqlOnSchema).toBeCalledWith(indexerConfig.postgresDatabaseName(), indexerConfig.postgresSchemaName(), databaseSchema);
+      expect(hasuraClient.getTableNames).toBeCalledWith(indexerConfig.postgresSchemaName(), indexerConfig.postgresDatabaseName());
+      expect(hasuraClient.trackTables).toBeCalledWith(indexerConfig.postgresSchemaName(), tableNames, indexerConfig.postgresDatabaseName());
       expect(hasuraClient.addPermissionsToTables).toBeCalledWith(
-        schemaName,
-        sanitizedAccountId,
+        indexerConfig.postgresSchemaName(),
+        indexerConfig.postgresDatabaseName(),
         tableNames,
-        sanitizedAccountId,
+        indexerConfig.postgresUserName(),
         [
           'select',
           'insert',
@@ -171,13 +173,25 @@ describe('Provisioner', () => {
     it('throws an error when it fails to create a postgres db', async () => {
       adminPgClient.query = jest.fn().mockRejectedValue(error);
 
-      await expect(provisioner.provisionUserApi(accountId, functionName, databaseSchema)).rejects.toThrow('Failed to provision endpoint: Failed to create user db: some error');
+      await expect(provisioner.provisionUserApi(indexerConfig)).rejects.toThrow('Failed to provision endpoint: Failed to create user db: some error');
     });
 
     it('throws an error when it fails to add the db to hasura', async () => {
       hasuraClient.addDatasource = jest.fn().mockRejectedValue(error);
 
-      await expect(provisioner.provisionUserApi(accountId, functionName, databaseSchema)).rejects.toThrow('Failed to provision endpoint: Failed to add datasource: some error');
+      await expect(provisioner.provisionUserApi(indexerConfig)).rejects.toThrow('Failed to provision endpoint: Failed to add datasource: some error');
+    });
+
+    it('throws an error when it fails to run sql to create indexer sql', async () => {
+      hasuraClient.executeSqlOnSchema = jest.fn().mockRejectedValue(error);
+
+      await expect(provisioner.runIndexerSql(accountId, functionName, databaseSchema)).rejects.toThrow('Failed to run user script: some error');
+    });
+
+    it('throws an error when it fails to run sql to create logs sql', async () => {
+      hasuraClient.executeSqlOnSchema = jest.fn().mockRejectedValue(error);
+
+      await expect(provisioner.runLogsSql(accountId, functionName)).rejects.toThrow('Failed to run logs script: some error');
     });
 
     it('throws an error when it fails to run sql to create indexer sql', async () => {
@@ -195,43 +209,43 @@ describe('Provisioner', () => {
     it('throws an error when it fails to fetch table names', async () => {
       hasuraClient.getTableNames = jest.fn().mockRejectedValue(error);
 
-      await expect(provisioner.provisionUserApi(accountId, functionName, databaseSchema)).rejects.toThrow('Failed to provision endpoint: Failed to fetch table names: some error');
+      await expect(provisioner.provisionUserApi(indexerConfig)).rejects.toThrow('Failed to provision endpoint: Failed to fetch table names: some error');
     });
 
     it('throws an error when it fails to track tables', async () => {
       hasuraClient.trackTables = jest.fn().mockRejectedValue(error);
 
-      await expect(provisioner.provisionUserApi(accountId, functionName, databaseSchema)).rejects.toThrow('Failed to provision endpoint: Failed to track tables: some error');
+      await expect(provisioner.provisionUserApi(indexerConfig)).rejects.toThrow('Failed to provision endpoint: Failed to track tables: some error');
     });
 
     it('throws an error when it fails to track foreign key relationships', async () => {
       hasuraClient.trackForeignKeyRelationships = jest.fn().mockRejectedValue(error);
 
-      await expect(provisioner.provisionUserApi(accountId, functionName, databaseSchema)).rejects.toThrow('Failed to provision endpoint: Failed to track foreign key relationships: some error');
+      await expect(provisioner.provisionUserApi(indexerConfig)).rejects.toThrow('Failed to provision endpoint: Failed to track foreign key relationships: some error');
     });
 
     it('throws an error when it fails to add permissions to tables', async () => {
       hasuraClient.addPermissionsToTables = jest.fn().mockRejectedValue(error);
 
-      await expect(provisioner.provisionUserApi(accountId, functionName, databaseSchema)).rejects.toThrow('Failed to provision endpoint: Failed to add permissions to tables: some error');
+      await expect(provisioner.provisionUserApi(indexerConfig)).rejects.toThrow('Failed to provision endpoint: Failed to add permissions to tables: some error');
     });
 
     it.skip('throws an error when it fails to create metadata table', async () => {
       hasuraClient.executeSqlOnSchema = jest.fn().mockResolvedValueOnce(null).mockRejectedValue(error);
 
-      await expect(provisioner.provisionUserApi(accountId, functionName, databaseSchema)).rejects.toThrow('Failed to provision endpoint: Failed to create metadata table in morgs_near.morgs_near_test_function: some error');
+      await expect(provisioner.provisionUserApi(indexerConfig)).rejects.toThrow('Failed to provision endpoint: Failed to create metadata table in morgs_near.morgs_near_test_function: some error');
     });
 
     it('throws when grant cron access fails', async () => {
       cronPgClient.query = jest.fn().mockRejectedValue(error);
 
-      await expect(provisioner.provisionUserApi(accountId, functionName, databaseSchema)).rejects.toThrow('Failed to provision endpoint: Failed to setup partitioned logs table: Failed to grant cron access: some error');
+      await expect(provisioner.provisionUserApi(indexerConfig)).rejects.toThrow('Failed to provision endpoint: Failed to setup partitioned logs table: Failed to grant cron access: some error');
     });
 
     it('throws when scheduling cron jobs fails', async () => {
       userPgClientQuery = jest.fn().mockRejectedValueOnce(error);
 
-      await expect(provisioner.provisionUserApi(accountId, functionName, databaseSchema)).rejects.toThrow('Failed to provision endpoint: Failed to setup partitioned logs table: Failed to schedule log partition jobs: some error');
+      await expect(provisioner.provisionUserApi(indexerConfig)).rejects.toThrow('Failed to provision endpoint: Failed to setup partitioned logs table: Failed to schedule log partition jobs: some error');
     });
   });
 });

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -3,7 +3,7 @@ import pgFormatLib from 'pg-format';
 
 import { wrapError } from '../utility';
 import cryptoModule from 'crypto';
-import HasuraClient, { type DatabaseConnectionParameters } from '../hasura-client';
+import HasuraClient, { type HasuraDatabaseConnectionParameters } from '../hasura-client';
 import { logsTableDDL } from './schemas/logs-table';
 // import { metadataTableDDL } from './schemas/metadata-table';
 import PgClientClass, { type PostgresConnectionParams } from '../pg-client';
@@ -105,8 +105,10 @@ export default class Provisioner {
   async scheduleLogPartitionJobs (userName: string, databaseName: string, schemaName: string): Promise<void> {
     await wrapError(
       async () => {
-        const userDbConnectionParameters = await this.getPostgresConnectionParameters(userName);
-        userDbConnectionParameters.database = this.config.cronDatabase;
+        const userDbConnectionParameters = {
+          ...(await this.getPostgresConnectionParameters(userName)),
+          database: this.config.cronDatabase
+        };
 
         const userCronPgClient = new this.PgClient(userDbConnectionParameters);
         await userCronPgClient.query(
@@ -293,7 +295,7 @@ export default class Provisioner {
   }
 
   async getPostgresConnectionParameters (userName: string): Promise<PostgresConnectionParams> {
-    const userDbConnectionParameters: DatabaseConnectionParameters = await this.hasuraClient.getDbConnectionParameters(userName);
+    const userDbConnectionParameters: HasuraDatabaseConnectionParameters = await this.hasuraClient.getDbConnectionParameters(userName);
     return {
       user: userDbConnectionParameters.username,
       password: userDbConnectionParameters.password,
@@ -304,7 +306,7 @@ export default class Provisioner {
   }
 
   async getPgBouncerConnectionParameters (userName: string): Promise<PostgresConnectionParams> {
-    const userDbConnectionParameters: DatabaseConnectionParameters = await this.hasuraClient.getDbConnectionParameters(userName);
+    const userDbConnectionParameters: HasuraDatabaseConnectionParameters = await this.hasuraClient.getDbConnectionParameters(userName);
     return {
       user: userDbConnectionParameters.username,
       password: userDbConnectionParameters.password,

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -165,8 +165,8 @@ export default class Provisioner {
       return true;
     }
 
-    const databaseName = indexerConfig.postgresDatabaseName();
-    const schemaName = indexerConfig.postgresSchemaName();
+    const databaseName = indexerConfig.databaseName();
+    const schemaName = indexerConfig.schemaName();
 
     const sourceExists = await this.hasuraClient.doesSourceExist(databaseName);
     if (!sourceExists) {
@@ -265,9 +265,9 @@ export default class Provisioner {
 
   async provisionUserApi (indexerConfig: IndexerConfig): Promise<void> { // replace any with actual type
     const provisioningSpan = this.tracer.startSpan('Provision indexer resources');
-    const userName = indexerConfig.postgresUserName();
-    const databaseName = indexerConfig.postgresDatabaseName();
-    const schemaName = indexerConfig.postgresSchemaName();
+    const userName = indexerConfig.userName();
+    const databaseName = indexerConfig.databaseName();
+    const schemaName = indexerConfig.schemaName();
 
     try {
       await wrapError(

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -301,6 +301,13 @@ export default class Provisioner {
   }
 
   async getDatabaseConnectionParameters (userName: string): Promise<any> {
-    return await this.hasuraClient.getDbConnectionParameters(userName);
+    const userDbConnectionParameters = await this.hasuraClient.getDbConnectionParameters(userName);
+    return {
+      username: userDbConnectionParameters.username,
+      password: userDbConnectionParameters.password,
+      database: userDbConnectionParameters.database,
+      host: this.config.hasuraHostOverride ?? userDbConnectionParameters.host,
+      port: this.config.hasuraPortOverride ?? userDbConnectionParameters.port,
+    };
   }
 }

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -36,8 +36,8 @@ interface Config {
 
 const defaultConfig: Config = {
   cronDatabase: process.env.CRON_DATABASE,
-  hasuraHostOverride: process.env.HASURA_HOST_OVERRIDE,
-  hasuraPortOverride: process.env.HASURA_PORT_OVERRIDE ? Number(process.env.HASURA_PORT_OVERRIDE) : undefined
+  hasuraHostOverride: process.env.PGHOST,
+  hasuraPortOverride: process.env.PGPORT ? Number(process.env.PGPORT) : undefined
 };
 
 export default class Provisioner {

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -38,8 +38,8 @@ interface Config {
 
 const defaultConfig: Config = {
   cronDatabase: process.env.CRON_DATABASE,
-  pgBouncerHost: process.env.PGBOUNCER_HOST ?? process.env.PGHOST,
-  pgBouncerPort: Number(process.env.PGBOUNCER_PORT ?? process.env.PGPORT),
+  pgBouncerHost: process.env.PGHOST_PGBOUNCER ?? process.env.PGHOST,
+  pgBouncerPort: Number(process.env.PGPORT_PGBOUNCER ?? process.env.PGPORT),
   postgresHost: process.env.PGHOST,
   postgresPort: Number(process.env.PGPORT)
 };

--- a/runner/src/redis-client/index.ts
+++ b/runner/src/redis-client/index.ts
@@ -1,1 +1,1 @@
-export { default, type StreamType } from './redis-client';
+export { default } from './redis-client';

--- a/runner/src/redis-client/redis-client.ts
+++ b/runner/src/redis-client/redis-client.ts
@@ -7,8 +7,6 @@ interface StreamMessage {
   }
 }
 
-export type StreamType = 'historical' | 'real-time';
-
 export default class RedisClient {
   SMALLEST_STREAM_ID = '0';
   LARGEST_STREAM_ID = '+';
@@ -20,13 +18,6 @@ export default class RedisClient {
   ) {
     client.on('error', (err) => { console.log('Redis Client Error', err); });
     client.connect().catch(console.error);
-  }
-
-  getStreamType (streamKey: string): StreamType {
-    if (streamKey.endsWith(':historical:stream')) {
-      return 'historical';
-    }
-    return 'real-time';
   }
 
   async disconnect (): Promise<void> {

--- a/runner/src/server/runner-service.test.ts
+++ b/runner/src/server/runner-service.test.ts
@@ -3,6 +3,7 @@ import { IndexerStatus } from '../indexer-meta/indexer-meta';
 import { LogLevel } from '../indexer-meta/log-entry';
 import getRunnerService from './runner-service';
 import * as grpc from '@grpc/grpc-js';
+import IndexerConfig from '../indexer-config/indexer-config';
 
 const BASIC_REDIS_STREAM = 'test-redis-stream';
 const BASIC_ACCOUNT_ID = 'test-account-id';
@@ -12,31 +13,22 @@ const BASIC_EXECUTOR_ID = '964551da443042a0c834d5fe9bb2c07023b69f1528404f0f0a3fc
 const BASIC_CODE = 'test-code';
 const BASIC_SCHEMA = 'test-schema';
 const BASIC_VERSION = 1;
-const BASIC_INDEXER_CONFIG = {
-  account_id: BASIC_ACCOUNT_ID,
-  function_name: BASIC_FUNCTION_NAME,
-  code: BASIC_CODE,
-  schema: BASIC_SCHEMA,
-  version: BASIC_VERSION,
-};
 const BASIC_EXECUTOR_CONTEXT = {
   status: IndexerStatus.RUNNING,
 };
 
 describe('Runner gRPC Service', () => {
   let genericStreamHandlerType: typeof StreamHandler;
-
-  const genericIndexerBehavior = {
-    log_level: LogLevel.INFO
-  };
+  let genericIndexerConfig: IndexerConfig;
 
   beforeEach(() => {
-    genericStreamHandlerType = jest.fn().mockImplementation((...args) => {
+    genericStreamHandlerType = jest.fn().mockImplementation((indexerConfig) => {
       return {
-        updateIndexerConfig: jest.fn(),
-        indexerConfig: { account_id: args[1].account_id, function_name: args[1].function_name }
+        indexerConfig,
+        stop: jest.fn(),
       };
     });
+    genericIndexerConfig = new IndexerConfig(BASIC_REDIS_STREAM, BASIC_ACCOUNT_ID, BASIC_FUNCTION_NAME, BASIC_VERSION, BASIC_CODE, BASIC_SCHEMA, LogLevel.INFO);
   });
 
   it('starts a executor with correct settings', () => {
@@ -46,7 +38,7 @@ describe('Runner gRPC Service', () => {
 
     service.StartExecutor(request, mockCallback);
 
-    expect(genericStreamHandlerType).toHaveBeenCalledWith(BASIC_REDIS_STREAM, BASIC_INDEXER_CONFIG, genericIndexerBehavior);
+    expect(genericStreamHandlerType).toHaveBeenCalledWith(genericIndexerConfig);
     expect(mockCallback).toHaveBeenCalledWith(null, { executorId: BASIC_EXECUTOR_ID });
   });
 
@@ -109,7 +101,7 @@ describe('Runner gRPC Service', () => {
     service.StartExecutor(startRequest, mockCallback);
 
     expect(genericStreamHandlerType).toHaveBeenCalledTimes(1);
-    expect(genericStreamHandlerType).toHaveBeenCalledWith(BASIC_REDIS_STREAM, BASIC_INDEXER_CONFIG, genericIndexerBehavior);
+    expect(genericStreamHandlerType).toHaveBeenCalledWith(genericIndexerConfig);
     expect(mockCallback.mock.calls).toEqual([
       [null, { executorId: BASIC_EXECUTOR_ID }],
       [{
@@ -175,10 +167,10 @@ describe('Runner gRPC Service', () => {
     });
     const service = getRunnerService(new Map(), streamHandlerType);
 
-    service.StopExecutor({ request: { executorId: 'non-existant' } } as any, (err) => {
+    service.StopExecutor({ request: { executorId: 'non-existent' } } as any, (err) => {
       expect(err).toEqual({
         code: grpc.status.NOT_FOUND,
-        message: 'Executor non-existant cannot be stopped as it does not exist.'
+        message: 'Executor non-existent cannot be stopped as it does not exist.'
       });
       expect(stop).toHaveBeenCalledTimes(0);
 
@@ -217,14 +209,10 @@ describe('Runner gRPC Service', () => {
     const stop = jest.fn().mockImplementation(async () => {
       await Promise.resolve();
     });
-    const streamHandlerType = jest.fn().mockImplementation((_, indexerConfig) => {
+    const streamHandlerType = jest.fn().mockImplementation((indexerConfig) => {
       return {
         stop,
-        indexerConfig: {
-          account_id: indexerConfig.account_id,
-          function_name: indexerConfig.function_name,
-          version: indexerConfig.version
-        },
+        indexerConfig,
         executorContext: BASIC_EXECUTOR_CONTEXT
       };
     });
@@ -244,8 +232,8 @@ describe('Runner gRPC Service', () => {
         expect(response).toEqual({
           executors: [{
             executorId: BASIC_EXECUTOR_ID,
-            accountId: BASIC_INDEXER_CONFIG.account_id,
-            functionName: BASIC_INDEXER_CONFIG.function_name,
+            accountId: genericIndexerConfig.accountId,
+            functionName: genericIndexerConfig.functionName,
             status: IndexerStatus.RUNNING,
             version: '1'
           }]

--- a/runner/src/server/runner-service.ts
+++ b/runner/src/server/runner-service.ts
@@ -1,8 +1,5 @@
 import { type ServerUnaryCall, type sendUnaryData } from '@grpc/grpc-js';
 import * as grpc from '@grpc/grpc-js';
-import { IndexerStatus } from '../indexer-meta/indexer-meta';
-import { LogLevel } from '../indexer-meta/log-entry';
-import crypto from 'crypto';
 
 import { type RunnerHandlers } from '../generated/runner/Runner';
 import { type StartExecutorResponse__Output, type StartExecutorResponse } from '../generated/runner/StartExecutorResponse';

--- a/runner/src/server/runner-service.ts
+++ b/runner/src/server/runner-service.ts
@@ -13,12 +13,7 @@ import { type ListExecutorsRequest__Output } from '../generated/runner/ListExecu
 import { type ListExecutorsResponse__Output, type ListExecutorsResponse } from '../generated/runner/ListExecutorsResponse';
 import { type ExecutorInfo__Output } from '../generated/runner/ExecutorInfo';
 import StreamHandler from '../stream-handler';
-
-const hashString = (input: string): string => {
-  const hash = crypto.createHash('sha256');
-  hash.update(input);
-  return hash.digest('hex');
-};
+import IndexerConfig from '../indexer-config';
 
 function getRunnerService (executors: Map<string, StreamHandler>, StreamHandlerType: typeof StreamHandler = StreamHandler): RunnerHandlers {
   const RunnerService: RunnerHandlers = {
@@ -30,35 +25,25 @@ function getRunnerService (executors: Map<string, StreamHandler>, StreamHandlerT
         return;
       }
 
-      const { accountId, functionName, code, schema, redisStream, version } = call.request;
-      const executorId = hashString(`${accountId}/${functionName}`);
+      const indexerConfig: IndexerConfig = IndexerConfig.fromStartRequest(call.request);
 
-      if (executors.has(executorId)) {
+      if (executors.has(indexerConfig.executorId)) {
         const alreadyExistsError = {
           code: grpc.status.ALREADY_EXISTS,
-          message: `Executor ${executorId} can't be started as it already exists.`
+          message: `Executor ${indexerConfig.executorId} can't be started as it already exists.`
         };
         callback(alreadyExistsError, null);
 
         return;
       }
 
-      console.log('Starting executor: ', { accountId, functionName, executorId, version });
+      console.log('Starting executor: ', indexerConfig);
 
       // Handle request
       try {
-        const streamHandler = new StreamHandlerType(redisStream, {
-          account_id: accountId,
-          function_name: functionName,
-          version: Number(version),
-          code,
-          schema,
-        },
-        {
-          log_level: LogLevel.INFO, // TODO: Pass this in from Coordinator
-        });
-        executors.set(executorId, streamHandler);
-        callback(null, { executorId });
+        const streamHandler = new StreamHandlerType(indexerConfig);
+        executors.set(indexerConfig.executorId, streamHandler);
+        callback(null, { executorId: indexerConfig.executorId });
       } catch (error) {
         callback(handleInternalError(error), null);
       }
@@ -98,29 +83,14 @@ function getRunnerService (executors: Map<string, StreamHandler>, StreamHandlerT
       const response: ExecutorInfo__Output[] = [];
       try {
         executors.forEach((handler, executorId) => {
-          let config = handler.indexerConfig;
-          let context = handler.executorContext;
-          if (config === undefined) {
-            // TODO: Throw error instead when V1 is deprecated
-            const [accountId, functionName] = executorId.substring(0, executorId.indexOf(':')).split('/', 2);
-            config = {
-              account_id: accountId,
-              function_name: functionName,
-              version: 0, // Ensure Coordinator V2 sees version mismatch
-              code: '',
-              schema: '',
-            };
-            context = {
-              status: IndexerStatus.RUNNING,
-              block_height: context.block_height,
-            };
-          }
+          const indexerConfig = handler.indexerConfig;
+          const indexerContext = handler.executorContext;
           response.push({
             executorId,
-            accountId: config.account_id,
-            functionName: config.function_name,
-            version: config.version.toString(),
-            status: context.status
+            accountId: indexerConfig.accountId,
+            functionName: indexerConfig.functionName,
+            version: indexerConfig.version.toString(),
+            status: indexerContext.status
           });
         });
         callback(null, {

--- a/runner/src/stream-handler/stream-handler.ts
+++ b/runner/src/stream-handler/stream-handler.ts
@@ -34,7 +34,7 @@ export default class StreamHandler {
     if (isMainThread) {
       this.worker = new Worker(path.join(__dirname, 'worker.js'), {
         workerData: {
-          indexerConfig,
+          indexerConfigData: indexerConfig.toObject(),
         },
       });
       this.executorContext = {
@@ -56,7 +56,7 @@ export default class StreamHandler {
   }
 
   private handleError (error: Error): void {
-    console.error(`Encountered error processing stream: ${this.indexerConfig.redisStreamKey}, terminating thread`, error);
+    console.error(`Encountered error processing stream: ${this.indexerConfig.fullName()}, terminating thread`, error);
     this.executorContext.status = IndexerStatus.STOPPED;
     const indexer = new Indexer(this.indexerConfig);
 
@@ -68,7 +68,7 @@ export default class StreamHandler {
       indexer.writeLog(
         LogLevel.ERROR,
         this.executorContext.block_height,
-        `Encountered error processing stream: ${this.indexerConfig.redisStreamKey}, terminating thread\n${error.toString()}`
+        `Encountered error processing stream: ${this.indexerConfig.fullName()}, terminating thread\n${error.toString()}`
       ),
       // indexer.callWriteLog({
       //   blockHeight: this.executorContext.block_height,

--- a/runner/src/stream-handler/stream-handler.ts
+++ b/runner/src/stream-handler/stream-handler.ts
@@ -8,12 +8,6 @@ import { /* LogType, */ LogLevel } from '../indexer-meta/log-entry';
 
 import type IndexerConfig from '../indexer-config';
 
-export enum Status {
-  RUNNING = 'RUNNING',
-  FAILING = 'FAILING',
-  STOPPED = 'STOPPED',
-}
-
 export enum WorkerMessageType {
   METRICS = 'METRICS',
   BLOCK_HEIGHT = 'BLOCK_HEIGHT',

--- a/runner/src/stream-handler/stream-handler.ts
+++ b/runner/src/stream-handler/stream-handler.ts
@@ -6,13 +6,7 @@ import Indexer from '../indexer';
 import { IndexerStatus } from '../indexer-meta/indexer-meta';
 import { /* LogType, */ LogLevel } from '../indexer-meta/log-entry';
 
-export interface IndexerConfig {
-  account_id: string
-  function_name: string
-  code: string
-  schema: string
-  version: number
-}
+import type IndexerConfig from '../indexer-config';
 
 export enum Status {
   RUNNING = 'RUNNING',

--- a/runner/src/stream-handler/worker.ts
+++ b/runner/src/stream-handler/worker.ts
@@ -128,7 +128,7 @@ async function blockQueueConsumer (workerContext: WorkerContext): Promise<void> 
 
         await tracer.startActiveSpan(`Process Block ${currBlockHeight}`, async (executeSpan: Span) => {
           try {
-            await indexer.execute(block, { provision: true });
+            await indexer.execute(block);
           } finally {
             executeSpan.end();
           }

--- a/runner/src/stream-handler/worker.ts
+++ b/runner/src/stream-handler/worker.ts
@@ -9,7 +9,7 @@ import { WorkerMessageType, type WorkerMessage } from './stream-handler';
 import { trace, type Span, context } from '@opentelemetry/api';
 import setUpTracerExport from '../instrumentation';
 import { IndexerStatus } from '../indexer-meta/indexer-meta';
-import type IndexerConfig from '../indexer-config';
+import IndexerConfig from '../indexer-config';
 
 if (isMainThread) {
   throw new Error('Worker should not be run on main thread');
@@ -32,7 +32,7 @@ setUpTracerExport();
 const tracer = trace.getTracer('queryapi-runner-worker');
 
 void (async function main () {
-  const { indexerConfig } = workerData;
+  const indexerConfig: IndexerConfig = IndexerConfig.fromObject(workerData.indexerConfigData);
   const redisClient = new RedisClient();
   const workerContext: WorkerContext = {
     redisClient,
@@ -41,7 +41,7 @@ void (async function main () {
     indexerConfig
   };
 
-  console.log('Started processing stream: ', indexerConfig.account_id, indexerConfig.function_name, indexerConfig.version);
+  console.log('Started processing stream: ', workerContext.indexerConfig.fullName(), workerContext.indexerConfig.version);
 
   await handleStream(workerContext);
 })();
@@ -83,7 +83,7 @@ async function blockQueueProducer (workerContext: WorkerContext): Promise<void> 
 
 async function blockQueueConsumer (workerContext: WorkerContext): Promise<void> {
   let previousError: string = '';
-  const indexerConfig = workerContext.indexerConfig;
+  const indexerConfig: IndexerConfig = workerContext.indexerConfig;
   const indexer = new Indexer(indexerConfig);
   let streamMessageId = '';
   let currBlockHeight = 0;

--- a/runner/src/stream-handler/worker.ts
+++ b/runner/src/stream-handler/worker.ts
@@ -126,11 +126,11 @@ async function blockQueueConsumer (workerContext: WorkerContext): Promise<void> 
 
         METRICS.BLOCK_WAIT_DURATION.labels({ indexer: indexerConfig.fullName() }).observe(performance.now() - blockStartTime);
 
-        await tracer.startActiveSpan(`Process Block ${currBlockHeight}`, async (runFunctionsSpan: Span) => {
+        await tracer.startActiveSpan(`Process Block ${currBlockHeight}`, async (executeSpan: Span) => {
           try {
-            await indexer.runFunctions(block, { provision: true });
+            await indexer.execute(block, { provision: true });
           } finally {
-            runFunctionsSpan.end();
+            executeSpan.end();
           }
         });
 

--- a/runner/src/utility.ts
+++ b/runner/src/utility.ts
@@ -4,6 +4,7 @@ export async function wrapError<T> (fn: () => Promise<T>, errorMessage: string):
   try {
     return await fn();
   } catch (error) {
+    console.log('ERROR', error);
     if (error instanceof Error) {
       throw new VError(error, errorMessage);
     }

--- a/runner/src/utility.ts
+++ b/runner/src/utility.ts
@@ -4,7 +4,6 @@ export async function wrapError<T> (fn: () => Promise<T>, errorMessage: string):
   try {
     return await fn();
   } catch (error) {
-    console.log('ERROR', error);
     if (error instanceof Error) {
       throw new VError(error, errorMessage);
     }

--- a/runner/tests/integration.test.ts
+++ b/runner/tests/integration.test.ts
@@ -153,7 +153,6 @@ describe('Indexer integration', () => {
           `,
         }
       },
-      false,
       {
         provision: true
       }

--- a/runner/tests/integration.test.ts
+++ b/runner/tests/integration.test.ts
@@ -45,112 +45,114 @@ describe('Indexer integration', () => {
     await network.stop();
   });
 
-  // it('works', async () => {
-  //   const hasuraClient = new HasuraClient({}, {
-  //     adminSecret: hasuraContainer.getAdminSecret(),
-  //     endpoint: hasuraContainer.getEndpoint(),
-  //     pgHostHasura: postgresContainer.getIpAddress(network.getName()),
-  //     pgPortHasura: postgresContainer.getPort(network.getName()),
-  //     pgHost: postgresContainer.getIpAddress(),
-  //     pgPort: postgresContainer.getPort()
-  //   });
+  it('works', async () => {
+    const hasuraClient = new HasuraClient({}, {
+      adminSecret: hasuraContainer.getAdminSecret(),
+      endpoint: hasuraContainer.getEndpoint(),
+      pgHostHasura: postgresContainer.getIpAddress(network.getName()),
+      pgPortHasura: postgresContainer.getPort(network.getName()),
+      pgHost: postgresContainer.getIpAddress(),
+      pgPort: postgresContainer.getPort()
+    });
 
-  //   const pgClient = new PgClient({
-  //     user: postgresContainer.getUsername(),
-  //     password: postgresContainer.getPassword(),
-  //     host: postgresContainer.getIpAddress(),
-  //     port: postgresContainer.getPort(),
-  //     database: postgresContainer.getDatabase(),
-  //   });
+    const pgClient = new PgClient({
+      user: postgresContainer.getUsername(),
+      password: postgresContainer.getPassword(),
+      host: postgresContainer.getIpAddress(),
+      port: postgresContainer.getPort(),
+      database: postgresContainer.getDatabase(),
+    });
 
-  //   const provisioner = new Provisioner(
-  //     hasuraClient,
-  //     pgClient,
-  //     pgClient,
-  //     {
-  //       cronDatabase: postgresContainer.getDatabase(),
-  //       hasuraHostOverride: postgresContainer.getIpAddress(),
-  //       hasuraPortOverride: Number(postgresContainer.getPort()),
-  //     }
-  //   );
+    const provisioner = new Provisioner(
+      hasuraClient,
+      pgClient,
+      pgClient,
+      {
+        cronDatabase: postgresContainer.getDatabase(),
+        postgresHost: postgresContainer.getIpAddress(),
+        postgresPort: Number(postgresContainer.getPort()),
+        pgBouncerHost: postgresContainer.getIpAddress(), // TODO: Enable pgBouncer in Integ Tests
+        pgBouncerPort: Number(postgresContainer.getPort()),
+      }
+    );
 
-  //   const code = `
-  //     await context.graphql(
-  //       \`
-  //         mutation ($height:numeric){
-  //           insert_morgs_near_test_blocks_one(object:{height:$height}) {
-  //             height
-  //           }
-  //         }
-  //       \`,
-  //       {
-  //         height: block.blockHeight
-  //       }
-  //     );
-  //   `;
-  //   const schema = 'CREATE TABLE blocks (height numeric)';
+    const code = `
+      await context.graphql(
+        \`
+          mutation ($height:numeric){
+            insert_morgs_near_test_blocks_one(object:{height:$height}) {
+              height
+            }
+          }
+        \`,
+        {
+          height: block.blockHeight
+        }
+      );
+    `;
+    const schema = 'CREATE TABLE blocks (height numeric)';
 
-  //   const indexerConfig = new IndexerConfig(
-  //     'test:stream',
-  //     'morgs.near',
-  //     'test',
-  //     0,
-  //     code,
-  //     schema,
-  //     LogLevel.INFO
-  //   );
+    const indexerConfig = new IndexerConfig(
+      'test:stream',
+      'morgs.near',
+      'test',
+      0,
+      code,
+      schema,
+      LogLevel.INFO
+    );
 
-  //   const indexer = new Indexer(
-  //     indexerConfig,
-  //     {
-  //       provisioner
-  //     },
-  //     undefined,
-  //     {
-  //       hasuraAdminSecret: hasuraContainer.getAdminSecret(),
-  //       hasuraEndpoint: hasuraContainer.getEndpoint(),
-  //     }
-  //   );
+    const indexer = new Indexer(
+      indexerConfig,
+      {
+        provisioner
+      },
+      undefined,
+      {
+        hasuraAdminSecret: hasuraContainer.getAdminSecret(),
+        hasuraEndpoint: hasuraContainer.getEndpoint(),
+      }
+    );
 
-  //   await indexer.execute(
-  //     Block.fromStreamerMessage(block115185108 as any as StreamerMessage),
-  //     {
-  //       provision: true
-  //     }
-  //   );
+    await indexer.execute(
+      Block.fromStreamerMessage(block115185108 as any as StreamerMessage),
+      {
+        provision: true
+      }
+    );
 
-  //   const { morgs_near_test_blocks: blocks }: any = await graphqlClient.request(gql`
-  //     query {
-  //       morgs_near_test_blocks {
-  //         height
-  //       }
-  //     }
-  //   `);
+    const { morgs_near_test_blocks: blocks }: any = await graphqlClient.request(gql`
+      query {
+        morgs_near_test_blocks {
+          height
+        }
+      }
+    `);
 
-  //   expect(blocks[0].height).toEqual(115185108);
+    expect(blocks[0].height).toEqual(115185108);
 
-  //   const { indexer_state: [state] }: any = await graphqlClient.request(gql`
-  //     query {
-  //       indexer_state(where: { function_name: { _eq: "morgs.near/test" } }) {
-  //         current_block_height
-  //         status
-  //       }
-  //     }
-  //   `);
+    const { indexer_state: [state] }: any = await graphqlClient.request(gql`
+      query {
+        indexer_state(where: { function_name: { _eq: "morgs.near/test" } }) {
+          current_block_height
+          status
+        }
+      }
+    `);
 
-  //   expect(state.current_block_height).toEqual(115185108);
-  //   expect(state.status).toEqual('RUNNING');
+    expect(state.current_block_height).toEqual(115185108);
+    expect(state.status).toEqual('RUNNING');
 
-  //   const { indexer_log_entries: logs }: any = await graphqlClient.request(gql`
-  //     query {
-  //       indexer_log_entries(where: { function_name: { _eq:"morgs.near/test" } }) {
-  //         message
-  //       }
-  //     }
-  //   `);
+    const { indexer_log_entries: logs }: any = await graphqlClient.request(gql`
+      query {
+        indexer_log_entries(where: { function_name: { _eq:"morgs.near/test" } }) {
+          message
+        }
+      }
+    `);
 
-  //   expect(logs.length).toEqual(3);
-  // });
+    expect(logs.length).toEqual(3);
+  });
 
   it('test context db', async () => {
     const hasuraClient = new HasuraClient({}, {
@@ -176,8 +178,10 @@ describe('Indexer integration', () => {
       pgClient,
       {
         cronDatabase: postgresContainer.getDatabase(),
-        hasuraHostOverride: postgresContainer.getIpAddress(),
-        hasuraPortOverride: Number(postgresContainer.getPort()),
+        postgresHost: postgresContainer.getIpAddress(),
+        postgresPort: Number(postgresContainer.getPort()),
+        pgBouncerHost: postgresContainer.getIpAddress(), // TODO: Enable pgBouncer in Integ Tests
+        pgBouncerPort: Number(postgresContainer.getPort()),
       }
     );
 

--- a/runner/tests/integration.test.ts
+++ b/runner/tests/integration.test.ts
@@ -74,27 +74,31 @@ describe('Indexer integration', () => {
       }
     );
 
+    const code = `
+      await context.graphql(
+        \`
+          mutation ($height:numeric){
+            insert_morgs_near_test_blocks_one(object:{height:$height}) {
+              height
+            }
+          }
+        \`,
+        {
+          height: block.blockHeight
+        }
+      );
+    `;
+    const schema = 'CREATE TABLE blocks (height numeric)';
+
     const indexerConfig = new IndexerConfig(
       'test:stream',
       'morgs.near',
       'test',
       0,
-      'CREATE TABLE blocks (height numeric)',
-      `
-        await context.graphql(
-          \`
-            mutation ($height:numeric){
-              insert_morgs_near_test_blocks_one(object:{height:$height}) {
-                height
-              }
-            }
-          \`,
-          {
-            height: block.blockHeight
-          }
-        );
-      `,
-      LogLevel.INFO);
+      code,
+      schema,
+      LogLevel.INFO
+    );
 
     const indexer = new Indexer(
       indexerConfig,
@@ -146,6 +150,9 @@ describe('Indexer integration', () => {
 
     await indexer.runFunctions(
       Block.fromStreamerMessage(block115185109 as any as StreamerMessage),
+      {
+        provision: true
+      }
     );
 
     const { morgs_near_test_blocks: blocks }: any = await graphqlClient.request(gql`

--- a/runner/tests/integration.test.ts
+++ b/runner/tests/integration.test.ts
@@ -114,12 +114,9 @@ describe('Indexer integration', () => {
       }
     );
 
-    await indexer.execute(
-      Block.fromStreamerMessage(block115185108 as any as StreamerMessage),
-      {
-        provision: true
-      }
-    );
+    await indexer.execute(Block.fromStreamerMessage(block115185108 as any as StreamerMessage));
+
+    await indexer.execute(Block.fromStreamerMessage(block115185109 as any as StreamerMessage));
 
     const { morgs_near_test_blocks: blocks }: any = await graphqlClient.request(gql`
       query {
@@ -129,7 +126,7 @@ describe('Indexer integration', () => {
       }
     `);
 
-    expect(blocks[0].height).toEqual(115185108);
+    expect(blocks.map(({ height }: any) => height)).toEqual([115185108, 115185109]);
 
     const { indexer_state: [state] }: any = await graphqlClient.request(gql`
       query {
@@ -140,7 +137,7 @@ describe('Indexer integration', () => {
       }
     `);
 
-    expect(state.current_block_height).toEqual(115185108);
+    expect(state.current_block_height).toEqual(115185109);
     expect(state.status).toEqual('RUNNING');
 
     const { indexer_log_entries: logs }: any = await graphqlClient.request(gql`
@@ -151,7 +148,7 @@ describe('Indexer integration', () => {
       }
     `);
 
-    expect(logs.length).toEqual(3);
+    expect(logs.length).toEqual(4);
   });
 
   it('test context db', async () => {
@@ -250,23 +247,11 @@ describe('Indexer integration', () => {
       {
         hasuraAdminSecret: hasuraContainer.getAdminSecret(),
         hasuraEndpoint: hasuraContainer.getEndpoint(),
-        hasuraHostOverride: postgresContainer.getIpAddress(),
-        hasuraPortOverride: Number(postgresContainer.getPort())
       }
     );
 
-    await indexer.execute(
-      Block.fromStreamerMessage(block115185108 as any as StreamerMessage),
-      {
-        provision: true
-      }
-    );
-    await indexer.execute(
-      Block.fromStreamerMessage(block115185109 as any as StreamerMessage),
-      {
-        provision: true
-      }
-    );
+    await indexer.execute(Block.fromStreamerMessage(block115185108 as any as StreamerMessage));
+    await indexer.execute(Block.fromStreamerMessage(block115185109 as any as StreamerMessage));
 
     const { morgs_near_test_context_db_indexer_storage: sampleRows }: any = await graphqlClient.request(gql`
       query MyQuery {

--- a/runner/tests/integration.test.ts
+++ b/runner/tests/integration.test.ts
@@ -45,7 +45,114 @@ describe('Indexer integration', () => {
     await network.stop();
   });
 
-  it('works', async () => {
+  // it('works', async () => {
+  //   const hasuraClient = new HasuraClient({}, {
+  //     adminSecret: hasuraContainer.getAdminSecret(),
+  //     endpoint: hasuraContainer.getEndpoint(),
+  //     pgHostHasura: postgresContainer.getIpAddress(network.getName()),
+  //     pgPortHasura: postgresContainer.getPort(network.getName()),
+  //     pgHost: postgresContainer.getIpAddress(),
+  //     pgPort: postgresContainer.getPort()
+  //   });
+
+  //   const pgClient = new PgClient({
+  //     user: postgresContainer.getUsername(),
+  //     password: postgresContainer.getPassword(),
+  //     host: postgresContainer.getIpAddress(),
+  //     port: postgresContainer.getPort(),
+  //     database: postgresContainer.getDatabase(),
+  //   });
+
+  //   const provisioner = new Provisioner(
+  //     hasuraClient,
+  //     pgClient,
+  //     pgClient,
+  //     {
+  //       cronDatabase: postgresContainer.getDatabase(),
+  //       hasuraHostOverride: postgresContainer.getIpAddress(),
+  //       hasuraPortOverride: Number(postgresContainer.getPort()),
+  //     }
+  //   );
+
+  //   const code = `
+  //     await context.graphql(
+  //       \`
+  //         mutation ($height:numeric){
+  //           insert_morgs_near_test_blocks_one(object:{height:$height}) {
+  //             height
+  //           }
+  //         }
+  //       \`,
+  //       {
+  //         height: block.blockHeight
+  //       }
+  //     );
+  //   `;
+  //   const schema = 'CREATE TABLE blocks (height numeric)';
+
+  //   const indexerConfig = new IndexerConfig(
+  //     'test:stream',
+  //     'morgs.near',
+  //     'test',
+  //     0,
+  //     code,
+  //     schema,
+  //     LogLevel.INFO
+  //   );
+
+  //   const indexer = new Indexer(
+  //     indexerConfig,
+  //     {
+  //       provisioner
+  //     },
+  //     undefined,
+  //     {
+  //       hasuraAdminSecret: hasuraContainer.getAdminSecret(),
+  //       hasuraEndpoint: hasuraContainer.getEndpoint(),
+  //     }
+  //   );
+
+  //   await indexer.runFunctions(
+  //     Block.fromStreamerMessage(block1 as any as StreamerMessage),
+  //     {
+  //       provision: true
+  //     }
+  //   );
+
+  //   const { morgs_near_test_blocks: blocks }: any = await graphqlClient.request(gql`
+  //     query {
+  //       morgs_near_test_blocks {
+  //         height
+  //       }
+  //     }
+  //   `);
+
+  //   expect(blocks[0].height).toEqual(115185108);
+
+  //   const { indexer_state: [state] }: any = await graphqlClient.request(gql`
+  //     query {
+  //       indexer_state(where: { function_name: { _eq: "morgs.near/test" } }) {
+  //         current_block_height
+  //         status
+  //       }
+  //     }
+  //   `);
+
+  //   expect(state.current_block_height).toEqual(115185108);
+  //   expect(state.status).toEqual('RUNNING');
+
+  //   const { indexer_log_entries: logs }: any = await graphqlClient.request(gql`
+  //     query {
+  //       indexer_log_entries(where: { function_name: { _eq:"morgs.near/test" } }) {
+  //         message
+  //       }
+  //     }
+  //   `);
+
+  //   expect(logs.length).toEqual(3);
+  // });
+
+  it('test context db', async () => {
     const hasuraClient = new HasuraClient({}, {
       adminSecret: hasuraContainer.getAdminSecret(),
       endpoint: hasuraContainer.getEndpoint(),
@@ -74,21 +181,51 @@ describe('Indexer integration', () => {
       }
     );
 
+    const schema = `
+      CREATE TABLE
+        "indexer_storage" (
+          "function_name" TEXT NOT NULL,
+          "key_name" TEXT NOT NULL,
+          "value" TEXT NOT NULL,
+          PRIMARY KEY ("function_name", "key_name")
+        );
+    `;
+
     const code = `
-      await context.graphql(
-        \`
-          mutation ($height:numeric){
-            insert_morgs_near_test_blocks_one(object:{height:$height}) {
-              height
-            }
-          }
-        \`,
+      await context.db.IndexerStorage.insert({
+        function_name: "sample_indexer",
+        key_name: Date.now().toString(),
+        value: "testing_value"
+      });
+      await context.db.IndexerStorage.upsert({
+        function_name: "sample_indexer",
+        key_name: "test_key",
+        value: "testing_value"
+      }, ["function_name", "key_name"], ["value"]);
+      await context.db.IndexerStorage.insert({
+        function_name: "sample_indexer",
+        key_name: "del_key",
+        value: "del_value"
+      });
+      await console.log(context.db.IndexerStorage.select({
+        function_name: "sample_indexer",
+        key_name: "del_key",
+      }));
+      await context.db.IndexerStorage.update(
         {
-          height: block.blockHeight
+          function_name: "sample_indexer",
+          key_name: "del_key",
+        },
+        {
+          value: "updated_value"
         }
       );
+      await context.db.IndexerStorage.delete({
+        function_name: "sample_indexer",
+        key_name: "del_key",
+        value: "updated_value"
+      });
     `;
-    const schema = 'CREATE TABLE blocks (height numeric)';
 
     const indexerConfig = new IndexerConfig(
       'test:stream',
@@ -99,6 +236,9 @@ describe('Indexer integration', () => {
       schema,
       LogLevel.INFO
     );
+
+    // process.env.PGHOST = postgresContainer.getIpAddress(network.getName());
+    // process.env.PGPORT = postgresContainer.getPort(network.getName());
 
     const indexer = new Indexer(
       indexerConfig,
@@ -154,37 +294,33 @@ describe('Indexer integration', () => {
         provision: true
       }
     );
+    await indexer.runFunctions(
+      Block.fromStreamerMessage(block1 as any as StreamerMessage),
+      {
+        provision: true
+      }
+    );
 
-    const { morgs_near_test_blocks: blocks }: any = await graphqlClient.request(gql`
-      query {
-        morgs_near_test_blocks {
-          height
+    const { morgs_near_test_indexer_storage: sampleRows }: any = await graphqlClient.request(gql`
+      query MyQuery {
+        morgs_near_test_indexer_storage(where: {key_name: {_eq: "test_key"}, function_name: {_eq: "sample_indexer"}}) {
+          function_name
+          key_name
+          value
         }
       }
     `);
+    expect(sampleRows[0].value).toEqual('testing_value');
 
-    expect(blocks.map(({ height }: any) => height)).toEqual([115185108, 115185109]);
-
-    const { indexer_state: [state] }: any = await graphqlClient.request(gql`
-      query {
-        indexer_state(where: { function_name: { _eq: "morgs.near/test" } }) {
-          current_block_height
-          status
+    const { morgs_near_test_indexer_storage: totalRows }: any = await graphqlClient.request(gql`
+      query MyQuery {
+        morgs_near_test_indexer_storage {
+          function_name
+          key_name
+          value
         }
       }
     `);
-
-    expect(state.current_block_height).toEqual(115185109);
-    expect(state.status).toEqual('RUNNING');
-
-    const { indexer_log_entries: logs }: any = await graphqlClient.request(gql`
-      query {
-        indexer_log_entries(where: { function_name: { _eq:"morgs.near/test" } }) {
-          message
-        }
-      }
-    `);
-
-    expect(logs.length).toEqual(4);
+    expect(totalRows.length).toEqual(3); // Two inserts, and the overwritten upsert
   });
 });

--- a/runner/tests/integration.test.ts
+++ b/runner/tests/integration.test.ts
@@ -112,7 +112,7 @@ describe('Indexer integration', () => {
   //     }
   //   );
 
-  //   await indexer.runFunctions(
+  //   await indexer.execute(
   //     Block.fromStreamerMessage(block115185108 as any as StreamerMessage),
   //     {
   //       provision: true
@@ -251,13 +251,13 @@ describe('Indexer integration', () => {
       }
     );
 
-    await indexer.runFunctions(
+    await indexer.execute(
       Block.fromStreamerMessage(block115185108 as any as StreamerMessage),
       {
         provision: true
       }
     );
-    await indexer.runFunctions(
+    await indexer.execute(
       Block.fromStreamerMessage(block115185109 as any as StreamerMessage),
       {
         provision: true


### PR DESCRIPTION
Migrating any data related to the Indexer into a common class to simplify data interactions with things like AccountId, which are common.

I've also added an integ test for context DB.