### PR TITLE
feat: Introduce wrapSpan utility and Refactor DmlHandler tracing

### DIFF
--- a/runner/src/dml-handler/dml-handler.test.ts
+++ b/runner/src/dml-handler/dml-handler.test.ts
@@ -3,19 +3,21 @@ import DmlHandler from './dml-handler';
 import type PgClient from '../pg-client';
 import { type TableDefinitionNames } from '../indexer';
 import { type PostgresConnectionParams } from '../pg-client';
+import IndexerConfig from '../indexer-config/indexer-config';
+import { LogLevel } from '../indexer-meta/log-entry';
 
 describe('DML Handler tests', () => {
   const getDbConnectionParameters: PostgresConnectionParams = {
-    database: 'test_near',
+    database: 'test_account',
     host: 'postgres',
     password: 'test_pass',
     port: 5432,
-    user: 'test_near'
+    user: 'test_account'
   };
   let pgClient: PgClient;
   let query: any;
 
-  const SCHEMA = 'test_schema';
+  const TEST_INDEXER_CONFIG = new IndexerConfig('', 'test_account', 'test_function', 0, '', '', LogLevel.INFO);
   let TABLE_DEFINITION_NAMES: TableDefinitionNames;
 
   beforeEach(() => {
@@ -47,11 +49,11 @@ describe('DML Handler tests', () => {
       accounts_liked: JSON.stringify(['cwpuzzles.near', 'devbose.near'])
     };
 
-    const dmlHandler = new DmlHandler(getDbConnectionParameters, pgClient);
+    const dmlHandler = new DmlHandler(getDbConnectionParameters, TEST_INDEXER_CONFIG, pgClient);
 
-    await dmlHandler.insert(SCHEMA, TABLE_DEFINITION_NAMES, [inputObj]);
+    await dmlHandler.insert(TABLE_DEFINITION_NAMES, [inputObj]);
     expect(query.mock.calls).toEqual([
-      ['INSERT INTO test_schema."test_table" (account_id, "block_height", block_timestamp, "content", receipt_id, "accounts_liked") VALUES (\'test_acc_near\', \'999\', \'UTC\', \'test_content\', \'111\', \'["cwpuzzles.near","devbose.near"]\') RETURNING *', []]
+      ['INSERT INTO test_account_test_function."test_table" (account_id, "block_height", block_timestamp, "content", receipt_id, "accounts_liked") VALUES (\'test_acc_near\', \'999\', \'UTC\', \'test_content\', \'111\', \'["cwpuzzles.near","devbose.near"]\') RETURNING *', []]
     ]);
   });
 
@@ -67,11 +69,11 @@ describe('DML Handler tests', () => {
       receipt_id: 'abc',
     }];
 
-    const dmlHandler = new DmlHandler(getDbConnectionParameters, pgClient);
+    const dmlHandler = new DmlHandler(getDbConnectionParameters, TEST_INDEXER_CONFIG, pgClient);
 
-    await dmlHandler.insert(SCHEMA, TABLE_DEFINITION_NAMES, inputObj);
+    await dmlHandler.insert(TABLE_DEFINITION_NAMES, inputObj);
     expect(query.mock.calls).toEqual([
-      ['INSERT INTO test_schema."test_table" (account_id, "block_height", receipt_id) VALUES (\'morgs_near\', \'1\', \'abc\'), (\'morgs_near\', \'2\', \'abc\') RETURNING *', []]
+      ['INSERT INTO test_account_test_function."test_table" (account_id, "block_height", receipt_id) VALUES (\'morgs_near\', \'1\', \'abc\'), (\'morgs_near\', \'2\', \'abc\') RETURNING *', []]
     ]);
   });
 
@@ -83,11 +85,11 @@ describe('DML Handler tests', () => {
 
     TABLE_DEFINITION_NAMES.originalTableName = 'test_table';
 
-    const dmlHandler = new DmlHandler(getDbConnectionParameters, pgClient);
+    const dmlHandler = new DmlHandler(getDbConnectionParameters, TEST_INDEXER_CONFIG, pgClient);
 
-    await dmlHandler.select(SCHEMA, TABLE_DEFINITION_NAMES, inputObj);
+    await dmlHandler.select(TABLE_DEFINITION_NAMES, inputObj);
     expect(query.mock.calls).toEqual([
-      ['SELECT * FROM test_schema.test_table WHERE account_id=$1 AND "block_height"=$2', Object.values(inputObj)]
+      ['SELECT * FROM test_account_test_function.test_table WHERE account_id=$1 AND "block_height"=$2', Object.values(inputObj)]
     ]);
   });
 
@@ -97,11 +99,11 @@ describe('DML Handler tests', () => {
       block_height: 999,
     };
 
-    const dmlHandler = new DmlHandler(getDbConnectionParameters, pgClient);
+    const dmlHandler = new DmlHandler(getDbConnectionParameters, TEST_INDEXER_CONFIG, pgClient);
 
-    await dmlHandler.select(SCHEMA, TABLE_DEFINITION_NAMES, inputObj);
+    await dmlHandler.select(TABLE_DEFINITION_NAMES, inputObj);
     expect(query.mock.calls).toEqual([
-      ['SELECT * FROM test_schema."test_table" WHERE account_id IN ($1,$2) AND "block_height"=$3', [...inputObj.account_id, inputObj.block_height]]
+      ['SELECT * FROM test_account_test_function."test_table" WHERE account_id IN ($1,$2) AND "block_height"=$3', [...inputObj.account_id, inputObj.block_height]]
     ]);
   });
 
@@ -111,11 +113,11 @@ describe('DML Handler tests', () => {
       block_height: [998, 999],
     };
 
-    const dmlHandler = new DmlHandler(getDbConnectionParameters, pgClient);
+    const dmlHandler = new DmlHandler(getDbConnectionParameters, TEST_INDEXER_CONFIG, pgClient);
 
-    await dmlHandler.select(SCHEMA, TABLE_DEFINITION_NAMES, inputObj);
+    await dmlHandler.select(TABLE_DEFINITION_NAMES, inputObj);
     expect(query.mock.calls).toEqual([
-      ['SELECT * FROM test_schema."test_table" WHERE account_id IN ($1,$2) AND "block_height" IN ($3,$4)', [...inputObj.account_id, ...inputObj.block_height]]
+      ['SELECT * FROM test_account_test_function."test_table" WHERE account_id IN ($1,$2) AND "block_height" IN ($3,$4)', [...inputObj.account_id, ...inputObj.block_height]]
     ]);
   });
 
@@ -125,11 +127,11 @@ describe('DML Handler tests', () => {
       block_height: 999,
     };
 
-    const dmlHandler = new DmlHandler(getDbConnectionParameters, pgClient);
+    const dmlHandler = new DmlHandler(getDbConnectionParameters, TEST_INDEXER_CONFIG, pgClient);
 
-    await dmlHandler.select(SCHEMA, TABLE_DEFINITION_NAMES, inputObj, 1);
+    await dmlHandler.select(TABLE_DEFINITION_NAMES, inputObj, 1);
     expect(query.mock.calls).toEqual([
-      ['SELECT * FROM test_schema."test_table" WHERE account_id=$1 AND "block_height"=$2 LIMIT 1', Object.values(inputObj)]
+      ['SELECT * FROM test_account_test_function."test_table" WHERE account_id=$1 AND "block_height"=$2 LIMIT 1', Object.values(inputObj)]
     ]);
   });
 
@@ -144,11 +146,11 @@ describe('DML Handler tests', () => {
       receipt_id: 111,
     };
 
-    const dmlHandler = new DmlHandler(getDbConnectionParameters, pgClient);
+    const dmlHandler = new DmlHandler(getDbConnectionParameters, TEST_INDEXER_CONFIG, pgClient);
 
-    await dmlHandler.update(SCHEMA, TABLE_DEFINITION_NAMES, whereObj, updateObj);
+    await dmlHandler.update(TABLE_DEFINITION_NAMES, whereObj, updateObj);
     expect(query.mock.calls).toEqual([
-      ['UPDATE test_schema."test_table" SET "content"=$1, receipt_id=$2 WHERE account_id=$3 AND "block_height"=$4 RETURNING *', [...Object.values(updateObj), ...Object.values(whereObj)]]
+      ['UPDATE test_account_test_function."test_table" SET "content"=$1, receipt_id=$2 WHERE account_id=$3 AND "block_height"=$4 RETURNING *', [...Object.values(updateObj), ...Object.values(whereObj)]]
     ]);
   });
 
@@ -167,11 +169,11 @@ describe('DML Handler tests', () => {
     const conflictCol = ['account_id', 'block_height'];
     const updateCol = ['receipt_id'];
 
-    const dmlHandler = new DmlHandler(getDbConnectionParameters, pgClient);
+    const dmlHandler = new DmlHandler(getDbConnectionParameters, TEST_INDEXER_CONFIG, pgClient);
 
-    await dmlHandler.upsert(SCHEMA, TABLE_DEFINITION_NAMES, inputObj, conflictCol, updateCol);
+    await dmlHandler.upsert(TABLE_DEFINITION_NAMES, inputObj, conflictCol, updateCol);
     expect(query.mock.calls).toEqual([
-      ['INSERT INTO test_schema."test_table" (account_id, "block_height", receipt_id) VALUES (\'morgs_near\', \'1\', \'abc\'), (\'morgs_near\', \'2\', \'abc\') ON CONFLICT (account_id, "block_height") DO UPDATE SET receipt_id = excluded.receipt_id RETURNING *', []]
+      ['INSERT INTO test_account_test_function."test_table" (account_id, "block_height", receipt_id) VALUES (\'morgs_near\', \'1\', \'abc\'), (\'morgs_near\', \'2\', \'abc\') ON CONFLICT (account_id, "block_height") DO UPDATE SET receipt_id = excluded.receipt_id RETURNING *', []]
     ]);
   });
 
@@ -181,11 +183,11 @@ describe('DML Handler tests', () => {
       block_height: [998, 999],
     };
 
-    const dmlHandler = new DmlHandler(getDbConnectionParameters, pgClient);
+    const dmlHandler = new DmlHandler(getDbConnectionParameters, TEST_INDEXER_CONFIG, pgClient);
 
-    await dmlHandler.delete(SCHEMA, TABLE_DEFINITION_NAMES, inputObj);
+    await dmlHandler.delete(TABLE_DEFINITION_NAMES, inputObj);
     expect(query.mock.calls).toEqual([
-      ['DELETE FROM test_schema."test_table" WHERE account_id=$1 AND "block_height" IN ($2,$3) RETURNING *', [inputObj.account_id, ...inputObj.block_height]]
+      ['DELETE FROM test_account_test_function."test_table" WHERE account_id=$1 AND "block_height" IN ($2,$3) RETURNING *', [inputObj.account_id, ...inputObj.block_height]]
     ]);
   });
 });

--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -1,10 +1,10 @@
 import { wrapError } from '../utility';
 import PgClient, { type PostgresConnectionParams } from '../pg-client';
 import { type TableDefinitionNames } from '../indexer';
+import type IndexerConfig from '../indexer-config/indexer-config';
 
 import { type Tracer, trace, type Span } from '@opentelemetry/api';
 import { type QueryResult } from 'pg';
-import type IndexerConfig from '../indexer-config/indexer-config';
 
 type WhereClauseMulti = Record<string, (string | number | Array<string | number>)>;
 type WhereClauseSingle = Record<string, (string | number)>;

--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -2,7 +2,9 @@ import { wrapError } from '../utility';
 import PgClient, { type PostgresConnectionParams } from '../pg-client';
 import { type TableDefinitionNames } from '../indexer';
 
-import { type Tracer, trace } from '@opentelemetry/api';
+import { type Tracer, trace, type Span } from '@opentelemetry/api';
+import { type QueryResult } from 'pg';
+import type IndexerConfig from '../indexer-config/indexer-config';
 
 type WhereClauseMulti = Record<string, (string | number | Array<string | number>)>;
 type WhereClauseSingle = Record<string, (string | number)>;
@@ -14,10 +16,22 @@ export default class DmlHandler {
 
   constructor (
     databaseConnectionParameters: PostgresConnectionParams,
+    private readonly indexerConfig: IndexerConfig,
     pgClientInstance: PgClient | undefined = undefined,
   ) {
     this.pgClient = pgClientInstance ?? new PgClient(databaseConnectionParameters);
     this.tracer = trace.getTracer('queryapi-runner-dml-handler');
+  }
+
+  private async query (query: string, queryVars: Array<string | number>, tableName: string, operation: string): Promise<QueryResult<any>> {
+    return await this.tracer.startActiveSpan(`context db ${operation}`, async (operationSpan: Span) => {
+      operationSpan.setAttribute('sql query', query);
+      try {
+        return await wrapError(async () => await this.pgClient.query(query, queryVars), `Failed to execute '${query}' on ${this.indexerConfig.schemaName()}.${tableName}.`);
+      } finally {
+        operationSpan.end();
+      }
+    });
   }
 
   private getWhereClause (whereObject: WhereClauseMulti, columnLookup: Map<string, string>): { queryVars: Array<string | number>, whereClause: string } {
@@ -39,7 +53,7 @@ export default class DmlHandler {
     return { queryVars, whereClause };
   }
 
-  async insert (schemaName: string, tableDefinitionNames: TableDefinitionNames, rowsToInsert: any[]): Promise<any[]> {
+  async insert (tableDefinitionNames: TableDefinitionNames, rowsToInsert: any[]): Promise<any[]> {
     if (!rowsToInsert?.length) {
       return [];
     }
@@ -47,37 +61,37 @@ export default class DmlHandler {
     const columnNames = Object.keys(rowsToInsert[0]);
     const originalColumnNames = columnNames.map((col) => tableDefinitionNames.originalColumnNames.get(col) ?? col);
     const rowValues = rowsToInsert.map(row => columnNames.map(col => row[col]));
-    const query = `INSERT INTO ${schemaName}.${tableDefinitionNames.originalTableName} (${originalColumnNames.join(', ')}) VALUES %L RETURNING *`;
+    const query = `INSERT INTO ${this.indexerConfig.schemaName()}.${tableDefinitionNames.originalTableName} (${originalColumnNames.join(', ')}) VALUES %L RETURNING *`;
 
-    const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query, rowValues), []), `Failed to execute '${query}' on ${schemaName}.${tableDefinitionNames.originalTableName}.`);
+    const result = await this.query(this.pgClient.format(query, rowValues), [], tableDefinitionNames.originalTableName, 'insert');
     return result.rows;
   }
 
-  async select (schemaName: string, tableDefinitionNames: TableDefinitionNames, whereObject: WhereClauseMulti, limit: number | null = null): Promise<any[]> {
+  async select (tableDefinitionNames: TableDefinitionNames, whereObject: WhereClauseMulti, limit: number | null = null): Promise<any[]> {
     const { queryVars, whereClause } = this.getWhereClause(whereObject, tableDefinitionNames.originalColumnNames);
-    let query = `SELECT * FROM ${schemaName}.${tableDefinitionNames.originalTableName} WHERE ${whereClause}`;
+    let query = `SELECT * FROM ${this.indexerConfig.schemaName()}.${tableDefinitionNames.originalTableName} WHERE ${whereClause}`;
     if (limit !== null) {
       query = query.concat(' LIMIT ', Math.round(limit).toString());
     }
 
-    const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query), queryVars), `Failed to execute '${query}' on ${schemaName}.${tableDefinitionNames.originalTableName}.`);
+    const result = await this.query(this.pgClient.format(query), queryVars, tableDefinitionNames.originalTableName, 'select');
     return result.rows;
   }
 
-  async update (schemaName: string, tableDefinitionNames: TableDefinitionNames, whereObject: WhereClauseSingle, updateObject: any): Promise<any[]> {
+  async update (tableDefinitionNames: TableDefinitionNames, whereObject: WhereClauseSingle, updateObject: any): Promise<any[]> {
     const updateKeys = Object.keys(updateObject).map((col) => tableDefinitionNames.originalColumnNames.get(col) ?? col);
     const updateParam = Array.from({ length: updateKeys.length }, (_, index) => `${updateKeys[index]}=$${index + 1}`).join(', ');
     const whereKeys = Object.keys(whereObject).map((col) => tableDefinitionNames.originalColumnNames.get(col) ?? col);
     const whereParam = Array.from({ length: whereKeys.length }, (_, index) => `${whereKeys[index]}=$${index + 1 + updateKeys.length}`).join(' AND ');
 
-    const queryValues = [...Object.values(updateObject), ...Object.values(whereObject)];
-    const query = `UPDATE ${schemaName}.${tableDefinitionNames.originalTableName} SET ${updateParam} WHERE ${whereParam} RETURNING *`;
+    const queryValues = [...Object.values(updateObject), ...Object.values(whereObject)] as Array<string | number>;
+    const query = `UPDATE ${this.indexerConfig.schemaName()}.${tableDefinitionNames.originalTableName} SET ${updateParam} WHERE ${whereParam} RETURNING *`;
 
-    const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query), queryValues), `Failed to execute '${query}' on ${schemaName}.${tableDefinitionNames.originalTableName}.`);
+    const result = await this.query(this.pgClient.format(query), queryValues, tableDefinitionNames.originalTableName, 'update');
     return result.rows;
   }
 
-  async upsert (schemaName: string, tableDefinitionNames: TableDefinitionNames, rowsToUpsert: any[], conflictColumns: string[], updateColumns: string[]): Promise<any[]> {
+  async upsert (tableDefinitionNames: TableDefinitionNames, rowsToUpsert: any[], conflictColumns: string[], updateColumns: string[]): Promise<any[]> {
     if (!rowsToUpsert?.length) {
       return [];
     }
@@ -88,17 +102,17 @@ export default class DmlHandler {
     const originalColumns = columns.map((col) => tableDefinitionNames.originalColumnNames.get(col) ?? col);
     const rowValues = rowsToUpsert.map(row => columns.map(col => row[col]));
     const updatePlaceholders = updateColumns.map(col => `${col} = excluded.${col}`).join(', ');
-    const query = `INSERT INTO ${schemaName}.${tableDefinitionNames.originalTableName} (${originalColumns.join(', ')}) VALUES %L ON CONFLICT (${conflictColumns.join(', ')}) DO UPDATE SET ${updatePlaceholders} RETURNING *`;
+    const query = `INSERT INTO ${this.indexerConfig.schemaName()}.${tableDefinitionNames.originalTableName} (${originalColumns.join(', ')}) VALUES %L ON CONFLICT (${conflictColumns.join(', ')}) DO UPDATE SET ${updatePlaceholders} RETURNING *`;
 
-    const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query, rowValues), []), `Failed to execute '${query}' on ${schemaName}.${tableDefinitionNames.originalTableName}.`);
+    const result = await this.query(this.pgClient.format(query, rowValues), [], tableDefinitionNames.originalTableName, 'upsert');
     return result.rows;
   }
 
-  async delete (schemaName: string, tableDefinitionNames: TableDefinitionNames, whereObject: WhereClauseMulti): Promise<any[]> {
+  async delete (tableDefinitionNames: TableDefinitionNames, whereObject: WhereClauseMulti): Promise<any[]> {
     const { queryVars, whereClause } = this.getWhereClause(whereObject, tableDefinitionNames.originalColumnNames);
-    const query = `DELETE FROM ${schemaName}.${tableDefinitionNames.originalTableName} WHERE ${whereClause} RETURNING *`;
+    const query = `DELETE FROM ${this.indexerConfig.schemaName()}.${tableDefinitionNames.originalTableName} WHERE ${whereClause} RETURNING *`;
 
-    const result = await wrapError(async () => await this.pgClient.query(this.pgClient.format(query), queryVars), `Failed to execute '${query}' on ${schemaName}.${tableDefinitionNames.originalTableName}.`);
+    const result = await this.query(this.pgClient.format(query), queryVars, tableDefinitionNames.originalTableName, 'delete');
     return result.rows;
   }
 }

--- a/runner/src/dml-handler/dml-handler.ts
+++ b/runner/src/dml-handler/dml-handler.ts
@@ -2,18 +2,22 @@ import { wrapError } from '../utility';
 import PgClient, { type PostgresConnectionParams } from '../pg-client';
 import { type TableDefinitionNames } from '../indexer';
 
+import { type Tracer, trace } from '@opentelemetry/api';
+
 type WhereClauseMulti = Record<string, (string | number | Array<string | number>)>;
 type WhereClauseSingle = Record<string, (string | number)>;
 
 export default class DmlHandler {
   validTableNameRegex = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
   pgClient: PgClient;
+  tracer: Tracer;
 
   constructor (
     databaseConnectionParameters: PostgresConnectionParams,
     pgClientInstance: PgClient | undefined = undefined,
   ) {
     this.pgClient = pgClientInstance ?? new PgClient(databaseConnectionParameters);
+    this.tracer = trace.getTracer('queryapi-runner-dml-handler');
   }
 
   private getWhereClause (whereObject: WhereClauseMulti, columnLookup: Map<string, string>): { queryVars: Array<string | number>, whereClause: string } {

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -554,7 +554,7 @@ describe('Indexer unit tests', () => {
       query: jest.fn().mockReturnValue({ rows: [] }),
       format: jest.fn().mockReturnValue('mock')
     } as unknown as PgClient;
-    const mockDmlHandler: any = new DmlHandler(genericDbCredentials, mockPgClient);
+    const mockDmlHandler: any = new DmlHandler(genericDbCredentials, socialSchemaConfig, mockPgClient);
     const upsertSpy = jest.spyOn(mockDmlHandler, 'upsert');
     const indexer = new Indexer(socialSchemaConfig, {
       fetch: genericMockFetch as unknown as typeof fetch,
@@ -609,7 +609,7 @@ describe('Indexer unit tests', () => {
 
   test('indexer builds context and updates multiple objects from existing table', async () => {
     const mockDmlHandler: any = {
-      update: jest.fn().mockImplementation((_, __, whereObj, updateObj) => {
+      update: jest.fn().mockImplementation((_, whereObj, updateObj) => {
         if (whereObj.account_id === 'morgs_near' && updateObj.content === 'test_content') {
           return [{ colA: 'valA' }, { colA: 'valA' }];
         }
@@ -637,7 +637,7 @@ describe('Indexer unit tests', () => {
 
   test('indexer builds context and upserts on existing table', async () => {
     const mockDmlHandler: any = {
-      upsert: jest.fn().mockImplementation((_, __, objects, conflict, update) => {
+      upsert: jest.fn().mockImplementation((_, objects, conflict, update) => {
         if (objects.length === 2 && conflict.includes('account_id') && update.includes('content')) {
           return [{ colA: 'valA' }, { colA: 'valA' }];
         } else if (objects.length === 1 && conflict.includes('account_id') && update.includes('content')) {

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -110,7 +110,7 @@ export default class Indexer {
       try {
         this.database_connection_parameters ??= await this.deps.provisioner.getPgBouncerConnectionParameters(this.indexerConfig.hasuraRoleName());
         this.deps.indexerMeta ??= new IndexerMeta(this.indexerConfig, this.database_connection_parameters);
-        this.deps.dmlHandler ??= new DmlHandler(this.database_connection_parameters);
+        this.deps.dmlHandler ??= new DmlHandler(this.database_connection_parameters, this.indexerConfig);
       } catch (e) {
         const error = e as Error;
         logEntries.push(LogEntry.systemError(`Failed to get database connection parameters: ${error.message}`, blockHeight));
@@ -309,31 +309,31 @@ export default class Indexer {
               const insertLogEntry = LogEntry.userDebug(`Inserting object ${JSON.stringify(objectsToInsert)} into table ${tableName}`, blockHeight);
               logEntries.push(insertLogEntry);
 
-              return await dmlHandler.insert(this.indexerConfig.schemaName(), tableDefinitionNames, Array.isArray(objectsToInsert) ? objectsToInsert : [objectsToInsert]);
+              return await dmlHandler.insert(tableDefinitionNames, Array.isArray(objectsToInsert) ? objectsToInsert : [objectsToInsert]);
             },
             select: async (filterObj: any, limit = null) => {
               const selectLogEntry = LogEntry.userDebug(`Selecting objects in table ${tableName} with values ${JSON.stringify(filterObj)} with ${limit === null ? 'no' : limit} limit`, blockHeight);
               logEntries.push(selectLogEntry);
 
-              return await dmlHandler.select(this.indexerConfig.schemaName(), tableDefinitionNames, filterObj, limit);
+              return await dmlHandler.select(tableDefinitionNames, filterObj, limit);
             },
             update: async (filterObj: any, updateObj: any) => {
               const updateLogEntry = LogEntry.userDebug(`Updating objects in table ${tableName} that match ${JSON.stringify(filterObj)} with values ${JSON.stringify(updateObj)}`, blockHeight);
               logEntries.push(updateLogEntry);
 
-              return await dmlHandler.update(this.indexerConfig.schemaName(), tableDefinitionNames, filterObj, updateObj);
+              return await dmlHandler.update(tableDefinitionNames, filterObj, updateObj);
             },
             upsert: async (objectsToInsert: any, conflictColumns: string[], updateColumns: string[]) => {
               const upsertLogEntry = LogEntry.userDebug(`Inserting objects into table ${tableName} with values ${JSON.stringify(objectsToInsert)}. Conflict on columns ${conflictColumns.join(', ')} will update values in columns ${updateColumns.join(', ')}`, blockHeight);
               logEntries.push(upsertLogEntry);
 
-              return await dmlHandler.upsert(this.indexerConfig.schemaName(), tableDefinitionNames, Array.isArray(objectsToInsert) ? objectsToInsert : [objectsToInsert], conflictColumns, updateColumns);
+              return await dmlHandler.upsert(tableDefinitionNames, Array.isArray(objectsToInsert) ? objectsToInsert : [objectsToInsert], conflictColumns, updateColumns);
             },
             delete: async (filterObj: any) => {
               const deleteLogEntry = LogEntry.userDebug(`Deleting objects from table ${tableName} with values ${JSON.stringify(filterObj)}`, blockHeight);
               logEntries.push(deleteLogEntry);
 
-              return await dmlHandler.delete(this.indexerConfig.schemaName(), tableDefinitionNames, filterObj);
+              return await dmlHandler.delete(tableDefinitionNames, filterObj);
             }
           }
         };

--- a/runner/src/utility.ts
+++ b/runner/src/utility.ts
@@ -12,7 +12,7 @@ export async function wrapError<T> (fn: () => Promise<T>, errorMessage: string):
   }
 }
 
-export async function wrapSpan<T> (fn: () => Promise<T>, tracer: Tracer, spanName: string): Promise<T> {
+export async function wrapSpan<T> (fn: (...vars: any[]) => Promise<T>, tracer: Tracer, spanName: string): Promise<T> {
   const span = tracer.startSpan(spanName);
   try {
     return await fn();

--- a/runner/src/utility.ts
+++ b/runner/src/utility.ts
@@ -1,3 +1,4 @@
+import { type Tracer } from '@opentelemetry/api';
 import VError from 'verror';
 
 export async function wrapError<T> (fn: () => Promise<T>, errorMessage: string): Promise<T> {
@@ -8,5 +9,14 @@ export async function wrapError<T> (fn: () => Promise<T>, errorMessage: string):
       throw new VError(error, errorMessage);
     }
     throw new VError(errorMessage);
+  }
+}
+
+export async function wrapSpan<T> (fn: () => Promise<T>, tracer: Tracer, spanName: string): Promise<T> {
+  const span = tracer.startSpan(spanName);
+  try {
+    return await fn();
+  } finally {
+    span.end();
   }
 }


### PR DESCRIPTION
Many areas in Runner involve adding a try finally block to support tracing it. I added a wrapSpan utility function to simplify the code a little bit. I also refactored DmlHandler's tracing. I was previously tracing it in Indexer which adds to clutter and isn't the right place for it. I instead added a private function which does the tracing for DmlHandler functions. I also add the SQL query as an attribute for the span. 