### PR TITLE
feat: Add GCP compatible logging format to Block Streamer

### DIFF
--- a/block-streamer/Cargo.lock
+++ b/block-streamer/Cargo.lock
@@ -3,6 +3,16 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "actix-codec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,6 +882,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tracing",
+ "tracing-stackdriver",
  "tracing-subscriber",
  "wildmatch",
 ]
@@ -3756,6 +3767,21 @@ checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
  "serde",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-stackdriver"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80048836e000e1f058562f01d69cc46f476955bf389c0dc2d2d7edb98ca63ac1"
+dependencies = [
+ "Inflector",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/block-streamer/Cargo.toml
+++ b/block-streamer/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.55"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-stackdriver = "0.10.0"
 tokio = { version = "1.28.0", features = ["full"]}
 tokio-util = "0.7.10"
 tokio-stream = "0.1.14"

--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -148,7 +148,8 @@ pub(crate) async fn start_block_stream(
         indexer,
         redis_stream.clone(),
     )
-    .await?;
+    .await
+    .context("Failed during Delta Lake processing")?;
 
     let last_indexed_near_lake_block = process_near_lake_blocks(
         last_indexed_delta_lake_block,
@@ -159,7 +160,8 @@ pub(crate) async fn start_block_stream(
         redis_stream,
         chain_id,
     )
-    .await?;
+    .await
+    .context("Failed during Near Lake processing")?;
 
     tracing::debug!(
         last_indexed_block = last_indexed_near_lake_block,
@@ -192,7 +194,7 @@ async fn process_delta_lake_blocks(
             ..
         } => {
             if affected_account_id
-                .split(",")
+                .split(',')
                 .any(|account_id| DELTA_LAKE_SKIP_ACCOUNTS.contains(&account_id.trim()))
             {
                 tracing::debug!(

--- a/block-streamer/src/delta_lake_client.rs
+++ b/block-streamer/src/delta_lake_client.rs
@@ -194,6 +194,7 @@ impl DeltaLakeClientImpl {
                     .await
             }
         }
+        .context("Failed to list matching index files")
     }
 
     fn date_from_s3_path(&self, path: &str) -> Option<chrono::NaiveDate> {


### PR DESCRIPTION
This PR adds [tracing-stackdriver](https://github.com/NAlexPear/tracing-stackdriver), which outputs logs in a GCP compatible JSON format. To enable this, the `GCP_LOGGING_ENABLED` environment variable must be set.

Further, I've added additional context to errors to aid debugging.

https://github.com/near/near-ops/pull/1695