### PR TITLE
feat: Enable Metadata Table Writes

### DIFF
--- a/runner/src/indexer-meta/index.ts
+++ b/runner/src/indexer-meta/index.ts
@@ -1,2 +1,2 @@
 export { default } from './indexer-meta';
-export { IndexerStatus } from './indexer-meta';
+export { IndexerStatus, METADATA_TABLE_UPSERT, MetadataFields } from './indexer-meta';

--- a/runner/src/indexer-meta/index.ts
+++ b/runner/src/indexer-meta/index.ts
@@ -1,0 +1,2 @@
+export { default } from './indexer-meta';
+export { IndexerStatus } from './indexer-meta';

--- a/runner/src/indexer-meta/indexer-meta.test.ts
+++ b/runner/src/indexer-meta/indexer-meta.test.ts
@@ -21,7 +21,6 @@ describe('IndexerMeta', () => {
   const accountId = 'some_account';
   const functionName = 'some_indexer';
 
-  // const debugIndexerConfig: IndexerConfig = new IndexerConfig('stream', accountId, functionName, 0, '', '', LogLevel.DEBUG);
   const infoIndexerConfig: IndexerConfig = new IndexerConfig('stream', accountId, functionName, 0, '', '', LogLevel.INFO);
   const errorIndexerConfig: IndexerConfig = new IndexerConfig('stream', accountId, functionName, 0, '', '', LogLevel.ERROR);
 

--- a/runner/src/indexer-meta/indexer-meta.test.ts
+++ b/runner/src/indexer-meta/indexer-meta.test.ts
@@ -119,7 +119,7 @@ describe('IndexerMeta', () => {
 
     it('writes last processed block height for indexer', async () => {
       const indexerMeta = new IndexerMeta(indexerConfig, mockDatabaseConnectionParameters, genericMockPgClient);
-      await indexerMeta.updateBlockheight(123);
+      await indexerMeta.updateBlockHeight(123);
       expect(query).toBeCalledWith(
         `INSERT INTO ${schemaName}.__metadata (attribute, value) VALUES ('LAST_PROCESSED_BLOCK_HEIGHT', '123') ON CONFLICT (attribute) DO UPDATE SET value = EXCLUDED.value RETURNING *`
       );

--- a/runner/src/indexer-meta/indexer-meta.ts
+++ b/runner/src/indexer-meta/indexer-meta.ts
@@ -4,7 +4,7 @@ import PgClient, { type PostgresConnectionParams } from '../pg-client';
 import { trace } from '@opentelemetry/api';
 import type LogEntry from './log-entry';
 import { LogLevel } from './log-entry';
-import type IndexerConfig from '../indexer-config/indexer-config';
+import type IndexerConfig from '../indexer-config';
 
 export enum IndexerStatus {
   PROVISIONING = 'PROVISIONING',
@@ -78,7 +78,7 @@ export default class IndexerMeta {
     }
   }
 
-  async updateBlockheight (blockHeight: number): Promise<void> {
+  async updateBlockHeight (blockHeight: number): Promise<void> {
     const setLastProcessedBlockSpan = this.tracer.startSpan(`set last processed block to ${blockHeight} through postgres`);
     const values = [[LAST_PROCESSED_BLOCK_HEIGHT_ATTRIBUTE, blockHeight.toString()]];
     const query = format(METADATA_TABLE_UPSERT, this.indexerConfig.schemaName(), values);

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -983,7 +983,7 @@ describe('Indexer unit tests', () => {
       fetch: mockFetch as unknown as typeof fetch,
       provisioner,
       dmlHandler: genericMockDmlHandler,
-      genericMockIndexerMeta,
+      indexerMeta: genericMockIndexerMeta,
     }, undefined, config);
 
     await indexer.execute(mockBlock);

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -4,10 +4,12 @@ import type fetch from 'node-fetch';
 import Indexer from './indexer';
 import { VM } from 'vm2';
 import DmlHandler from '../dml-handler/dml-handler';
-import type IndexerMeta from '../indexer-meta/indexer-meta';
 import type PgClient from '../pg-client';
 import { LogLevel } from '../indexer-meta/log-entry';
 import IndexerConfig from '../indexer-config/indexer-config';
+import type IndexerMeta from '../indexer-meta';
+import { IndexerStatus } from '../indexer-meta';
+import type Provisioner from '../provisioner';
 
 describe('Indexer unit tests', () => {
   const SIMPLE_SCHEMA = `CREATE TABLE
@@ -60,127 +62,136 @@ describe('Indexer unit tests', () => {
       );`;
 
   const CASE_SENSITIVE_SCHEMA = `
-      CREATE TABLE
-        Posts (
-          "id" SERIAL NOT NULL,
-          "AccountId" VARCHAR NOT NULL,
-          BlockHeight DECIMAL(58, 0) NOT NULL,
-          "receiptId" VARCHAR NOT NULL,
-          content TEXT NOT NULL,
-          block_Timestamp DECIMAL(20, 0) NOT NULL,
-          "Accounts_Liked" JSONB NOT NULL DEFAULT '[]',
-          "LastCommentTimestamp" DECIMAL(20, 0),
-          CONSTRAINT "posts_pkey" PRIMARY KEY ("id")
-        );
-  
-      CREATE TABLE
-        "CommentsTable" (
-          "id" SERIAL NOT NULL,
-          PostId SERIAL NOT NULL,
-          "accountId" VARCHAR NOT NULL,
-          blockHeight DECIMAL(58, 0) NOT NULL,
-          CONSTRAINT "comments_pkey" PRIMARY KEY ("id")
-        );`;
+    CREATE TABLE
+      Posts (
+        "id" SERIAL NOT NULL,
+        "AccountId" VARCHAR NOT NULL,
+        BlockHeight DECIMAL(58, 0) NOT NULL,
+        "receiptId" VARCHAR NOT NULL,
+        content TEXT NOT NULL,
+        block_Timestamp DECIMAL(20, 0) NOT NULL,
+        "Accounts_Liked" JSONB NOT NULL DEFAULT '[]',
+        "LastCommentTimestamp" DECIMAL(20, 0),
+        CONSTRAINT "posts_pkey" PRIMARY KEY ("id")
+      );
+
+    CREATE TABLE
+      "CommentsTable" (
+        "id" SERIAL NOT NULL,
+        PostId SERIAL NOT NULL,
+        "accountId" VARCHAR NOT NULL,
+        blockHeight DECIMAL(58, 0) NOT NULL,
+        CONSTRAINT "comments_pkey" PRIMARY KEY ("id")
+      );`;
 
   const STRESS_TEST_SCHEMA = `
-CREATE TABLE creator_quest (
-    account_id VARCHAR PRIMARY KEY,
-    num_components_created INTEGER NOT NULL DEFAULT 0,
-    completed BOOLEAN NOT NULL DEFAULT FALSE
-  );
+    CREATE TABLE creator_quest (
+        account_id VARCHAR PRIMARY KEY,
+        num_components_created INTEGER NOT NULL DEFAULT 0,
+        completed BOOLEAN NOT NULL DEFAULT FALSE
+      );
 
-CREATE TABLE
-  composer_quest (
-    account_id VARCHAR PRIMARY KEY,
-    num_widgets_composed INTEGER NOT NULL DEFAULT 0,
-    completed BOOLEAN NOT NULL DEFAULT FALSE
-  );
+    CREATE TABLE
+      composer_quest (
+        account_id VARCHAR PRIMARY KEY,
+        num_widgets_composed INTEGER NOT NULL DEFAULT 0,
+        completed BOOLEAN NOT NULL DEFAULT FALSE
+      );
 
-CREATE TABLE
-  "contractor - quest" (
-    account_id VARCHAR PRIMARY KEY,
-    num_contracts_deployed INTEGER NOT NULL DEFAULT 0,
-    completed BOOLEAN NOT NULL DEFAULT FALSE
-  );
+    CREATE TABLE
+      "contractor - quest" (
+        account_id VARCHAR PRIMARY KEY,
+        num_contracts_deployed INTEGER NOT NULL DEFAULT 0,
+        completed BOOLEAN NOT NULL DEFAULT FALSE
+      );
 
-CREATE TABLE
-  "posts" (
-    "id" SERIAL NOT NULL,
-    "account_id" VARCHAR NOT NULL,
-    "block_height" DECIMAL(58, 0) NOT NULL,
-    "receipt_id" VARCHAR NOT NULL,
-    "content" TEXT NOT NULL,
-    "block_timestamp" DECIMAL(20, 0) NOT NULL,
-    "accounts_liked" JSONB NOT NULL DEFAULT '[]',
-    "last_comment_timestamp" DECIMAL(20, 0),
-    CONSTRAINT "posts_pkey" PRIMARY KEY ("id")
-  );
+    CREATE TABLE
+      "posts" (
+        "id" SERIAL NOT NULL,
+        "account_id" VARCHAR NOT NULL,
+        "block_height" DECIMAL(58, 0) NOT NULL,
+        "receipt_id" VARCHAR NOT NULL,
+        "content" TEXT NOT NULL,
+        "block_timestamp" DECIMAL(20, 0) NOT NULL,
+        "accounts_liked" JSONB NOT NULL DEFAULT '[]',
+        "last_comment_timestamp" DECIMAL(20, 0),
+        CONSTRAINT "posts_pkey" PRIMARY KEY ("id")
+      );
 
-CREATE TABLE
-  "comments" (
-    "id" SERIAL NOT NULL,
-    "post_id" SERIAL NOT NULL,
-    "account_id" VARCHAR NOT NULL,
-    "block_height" DECIMAL(58, 0) NOT NULL,
-    "content" TEXT NOT NULL,
-    "block_timestamp" DECIMAL(20, 0) NOT NULL,
-    "receipt_id" VARCHAR NOT NULL,
-    CONSTRAINT "comments_pkey" PRIMARY KEY ("id")
-  );
+    CREATE TABLE
+      "comments" (
+        "id" SERIAL NOT NULL,
+        "post_id" SERIAL NOT NULL,
+        "account_id" VARCHAR NOT NULL,
+        "block_height" DECIMAL(58, 0) NOT NULL,
+        "content" TEXT NOT NULL,
+        "block_timestamp" DECIMAL(20, 0) NOT NULL,
+        "receipt_id" VARCHAR NOT NULL,
+        CONSTRAINT "comments_pkey" PRIMARY KEY ("id")
+      );
 
-CREATE TABLE
-  "post_likes" (
-    "post_id" SERIAL NOT NULL,
-    "account_id" VARCHAR NOT NULL,
-    "block_height" DECIMAL(58, 0),
-    "block_timestamp" DECIMAL(20, 0) NOT NULL,
-    "receipt_id" VARCHAR NOT NULL,
-    CONSTRAINT "post_likes_pkey" PRIMARY KEY ("post_id", "account_id")
-  );
+    CREATE TABLE
+      "post_likes" (
+        "post_id" SERIAL NOT NULL,
+        "account_id" VARCHAR NOT NULL,
+        "block_height" DECIMAL(58, 0),
+        "block_timestamp" DECIMAL(20, 0) NOT NULL,
+        "receipt_id" VARCHAR NOT NULL,
+        CONSTRAINT "post_likes_pkey" PRIMARY KEY ("post_id", "account_id")
+      );
 
-CREATE UNIQUE INDEX "posts_account_id_block_height_key" ON "posts" ("account_id" ASC, "block_height" ASC);
+    CREATE UNIQUE INDEX "posts_account_id_block_height_key" ON "posts" ("account_id" ASC, "block_height" ASC);
 
-CREATE UNIQUE INDEX "comments_post_id_account_id_block_height_key" ON "comments" (
-  "post_id" ASC,
-  "account_id" ASC,
-  "block_height" ASC
-);
+    CREATE UNIQUE INDEX "comments_post_id_account_id_block_height_key" ON "comments" (
+      "post_id" ASC,
+      "account_id" ASC,
+      "block_height" ASC
+    );
 
-CREATE INDEX
-  "posts_last_comment_timestamp_idx" ON "posts" ("last_comment_timestamp" DESC);
+    CREATE INDEX
+      "posts_last_comment_timestamp_idx" ON "posts" ("last_comment_timestamp" DESC);
 
-ALTER TABLE
-  "comments"
-ADD
-  CONSTRAINT "comments_post_id_fkey" FOREIGN KEY ("post_id") REFERENCES "posts" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION;
+    ALTER TABLE
+      "comments"
+    ADD
+      CONSTRAINT "comments_post_id_fkey" FOREIGN KEY ("post_id") REFERENCES "posts" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION;
 
-ALTER TABLE
-  "post_likes"
-ADD
-  CONSTRAINT "post_likes_post_id_fkey" FOREIGN KEY ("post_id") REFERENCES "posts" ("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+    ALTER TABLE
+      "post_likes"
+    ADD
+      CONSTRAINT "post_likes_post_id_fkey" FOREIGN KEY ("post_id") REFERENCES "posts" ("id") ON DELETE CASCADE ON UPDATE NO ACTION;
 
-CREATE TABLE IF NOT EXISTS
-  "My Table1" (id serial PRIMARY KEY);
+    CREATE TABLE IF NOT EXISTS
+      "My Table1" (id serial PRIMARY KEY);
 
-CREATE TABLE
-  "Another-Table" (id serial PRIMARY KEY);
+    CREATE TABLE
+      "Another-Table" (id serial PRIMARY KEY);
 
-CREATE TABLE
-IF NOT EXISTS
-  "Third-Table" (id serial PRIMARY KEY);
+    CREATE TABLE
+    IF NOT EXISTS
+      "Third-Table" (id serial PRIMARY KEY);
 
-CREATE TABLE
-  yet_another_table (id serial PRIMARY KEY);
-`;
+    CREATE TABLE
+      yet_another_table (id serial PRIMARY KEY);
+    `;
+
   const SIMPLE_REDIS_STREAM = 'test:stream';
   const SIMPLE_ACCOUNT_ID = 'morgs.near';
   const SIMPLE_FUNCTION_NAME = 'test_indexer';
-  const SIMPLE_CODE = '';
+  const SIMPLE_CODE = 'const a = 1;';
 
   const simpleSchemaConfig: IndexerConfig = new IndexerConfig(SIMPLE_REDIS_STREAM, SIMPLE_ACCOUNT_ID, SIMPLE_FUNCTION_NAME, 0, SIMPLE_CODE, SIMPLE_SCHEMA, LogLevel.INFO);
   const socialSchemaConfig: IndexerConfig = new IndexerConfig(SIMPLE_REDIS_STREAM, SIMPLE_ACCOUNT_ID, SIMPLE_FUNCTION_NAME, 0, SIMPLE_CODE, SOCIAL_SCHEMA, LogLevel.INFO);
   const caseSensitiveConfig: IndexerConfig = new IndexerConfig(SIMPLE_REDIS_STREAM, SIMPLE_ACCOUNT_ID, SIMPLE_FUNCTION_NAME, 0, SIMPLE_CODE, CASE_SENSITIVE_SCHEMA, LogLevel.INFO);
   const stressTestConfig: IndexerConfig = new IndexerConfig(SIMPLE_REDIS_STREAM, SIMPLE_ACCOUNT_ID, SIMPLE_FUNCTION_NAME, 0, SIMPLE_CODE, STRESS_TEST_SCHEMA, LogLevel.INFO);
+
+  const genericDbCredentials: any = {
+    database: 'test_near',
+    host: 'postgres',
+    password: 'test_pass',
+    port: 5432,
+    username: 'test_near'
+  };
 
   const genericMockFetch = jest.fn()
     .mockResolvedValue({
@@ -188,9 +199,9 @@ CREATE TABLE
       json: async () => ({
         data: 'mock',
       }),
-    });
+    }) as unknown as typeof fetch;
 
-  const genericMockDmlHandler: any = {
+  const genericMockDmlHandler = {
     insert: jest.fn().mockReturnValue([]),
     select: jest.fn().mockReturnValue([]),
     update: jest.fn().mockReturnValue([]),
@@ -201,23 +212,15 @@ CREATE TABLE
   const genericMockIndexerMeta: any = {
     writeLogs: jest.fn(),
     setStatus: jest.fn(),
-    updateBlockheight: jest.fn()
+    updateBlockHeight: jest.fn()
   } as unknown as IndexerMeta;
 
-  const genericDbCredentials: any = {
-    database: 'test_near',
-    host: 'postgres',
-    password: 'test_pass',
-    port: 5432,
-    username: 'test_near'
-  };
-
-  const genericProvisioner: any = {
+  const genericProvisioner = {
     getPgBouncerConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
     fetchUserApiProvisioningStatus: jest.fn().mockResolvedValue(true),
     provisionLogsIfNeeded: jest.fn(),
     provisionMetadataIfNeeded: jest.fn(),
-  };
+  } as unknown as Provisioner;
 
   const config = {
     hasuraEndpoint: 'mock-hasura-endpoint',
@@ -246,17 +249,24 @@ CREATE TABLE
       const foo = 3;
       block.result = context.graphql(\`mutation { set(functionName: "buildnear.testnet/test", key: "height", data: "\${block.blockHeight}")}\`);
     `;
+    const indexerMeta = {
+      writeLogs: jest.fn(),
+      setStatus: jest.fn(),
+      updateBlockHeight: jest.fn()
+    } as unknown as IndexerMeta;
     const indexerConfig = new IndexerConfig(SIMPLE_REDIS_STREAM, 'buildnear.testnet', 'test', 0, code, SIMPLE_SCHEMA, LogLevel.INFO);
     const indexer = new Indexer(indexerConfig, {
       fetch: mockFetch as unknown as typeof fetch,
       provisioner: genericProvisioner,
       dmlHandler: genericMockDmlHandler,
-      indexerMeta: genericMockIndexerMeta,
+      indexerMeta,
     }, undefined, config);
 
     await indexer.execute(mockBlock);
 
     expect(mockFetch.mock.calls).toMatchSnapshot();
+    expect(indexerMeta.setStatus).toHaveBeenCalledWith(IndexerStatus.RUNNING);
+    expect(indexerMeta.updateBlockHeight).toHaveBeenCalledWith(blockHeight);
   });
 
   test('Indexer.buildContext() allows execution of arbitrary GraphQL operations', async () => {
@@ -825,7 +835,12 @@ CREATE TABLE
       return (\`Created comment \${id} on post \${post.id}\`)
     `;
     const indexerConfig = new IndexerConfig(SIMPLE_REDIS_STREAM, 'buildnear.testnet', 'test', 0, code, SIMPLE_SCHEMA, LogLevel.INFO);
-    const indexer = new Indexer(indexerConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner: genericProvisioner, dmlHandler: genericMockDmlHandler, indexerMeta: genericMockIndexerMeta }, undefined, config);
+    const indexer = new Indexer(indexerConfig, {
+      fetch: mockFetch as unknown as typeof fetch,
+      provisioner: genericProvisioner,
+      dmlHandler: genericMockDmlHandler,
+      indexerMeta: genericMockIndexerMeta
+    }, undefined, config);
 
     await indexer.execute(mockBlock);
 
@@ -873,19 +888,24 @@ CREATE TABLE
     const code = `
         throw new Error('boom');
     `;
+    const indexerMeta = {
+      writeLogs: jest.fn(),
+      setStatus: jest.fn(),
+      updateBlockHeight: jest.fn()
+    } as unknown as IndexerMeta;
     const indexerConfig = new IndexerConfig(SIMPLE_REDIS_STREAM, 'buildnear.testnet', 'test', 0, code, SIMPLE_SCHEMA, LogLevel.INFO);
-    const indexer = new Indexer(indexerConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner: genericProvisioner, dmlHandler: genericMockDmlHandler, indexerMeta: genericMockIndexerMeta }, undefined, config);
-
-    const functions: Record<string, any> = {};
-    functions['buildnear.testnet/test'] = {
-      code: `
-            throw new Error('boom');
-        `,
-      schema: SIMPLE_SCHEMA
-    };
+    const indexer = new Indexer(indexerConfig, {
+      fetch: mockFetch as unknown as typeof fetch,
+      provisioner: genericProvisioner,
+      dmlHandler: genericMockDmlHandler,
+      indexerMeta,
+    }, undefined, config);
 
     await expect(indexer.execute(mockBlock)).rejects.toThrow(new Error('boom'));
     expect(mockFetch.mock.calls).toMatchSnapshot();
+    expect(indexerMeta.setStatus).toHaveBeenNthCalledWith(1, IndexerStatus.RUNNING);
+    expect(indexerMeta.setStatus).toHaveBeenNthCalledWith(2, IndexerStatus.FAILING);
+    expect(indexerMeta.updateBlockHeight).not.toHaveBeenCalled();
   });
 
   test('Indexer.execute() provisions a GraphQL endpoint with the specified schema', async () => {
@@ -912,11 +932,22 @@ CREATE TABLE
       provisionLogsIfNeeded: jest.fn(),
       provisionMetadataIfNeeded: jest.fn(),
     };
-    const indexer = new Indexer(simpleSchemaConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler, indexerMeta: genericMockIndexerMeta }, undefined, config);
+    const indexerMeta = {
+      writeLogs: jest.fn(),
+      setStatus: jest.fn(),
+      updateBlockHeight: jest.fn()
+    } as unknown as IndexerMeta;
+    const indexer = new Indexer(simpleSchemaConfig, {
+      fetch: mockFetch as unknown as typeof fetch,
+      provisioner,
+      dmlHandler: genericMockDmlHandler,
+      indexerMeta,
+    }, undefined, config);
 
     await indexer.execute(mockBlock);
 
     expect(provisioner.fetchUserApiProvisioningStatus).toHaveBeenCalledWith(simpleSchemaConfig);
+    expect(indexerMeta.setStatus).toHaveBeenNthCalledWith(2, IndexerStatus.RUNNING);
     expect(provisioner.provisionUserApi).toHaveBeenCalledTimes(1);
     expect(provisioner.provisionUserApi).toHaveBeenCalledWith(simpleSchemaConfig);
     expect(provisioner.provisionLogsIfNeeded).toHaveBeenCalled();
@@ -948,7 +979,12 @@ CREATE TABLE
       provisionLogsIfNeeded: jest.fn(),
       provisionMetadataIfNeeded: jest.fn(),
     };
-    const indexer = new Indexer(simpleSchemaConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler, indexerMeta: genericMockIndexerMeta }, undefined, config);
+    const indexer = new Indexer(simpleSchemaConfig, {
+      fetch: mockFetch as unknown as typeof fetch,
+      provisioner,
+      dmlHandler: genericMockDmlHandler,
+      genericMockIndexerMeta,
+    }, undefined, config);
 
     await indexer.execute(mockBlock);
 
@@ -982,7 +1018,17 @@ CREATE TABLE
       provisionLogsIfNeeded: jest.fn(),
       provisionMetadataIfNeeded: jest.fn(),
     };
-    const indexer = new Indexer(simpleSchemaConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler, indexerMeta: genericMockIndexerMeta }, undefined, config);
+    const indexerMeta = {
+      writeLogs: jest.fn(),
+      setStatus: jest.fn(),
+      updateBlockHeight: jest.fn()
+    } as unknown as IndexerMeta;
+    const indexer = new Indexer(simpleSchemaConfig, {
+      fetch: mockFetch as unknown as typeof fetch,
+      provisioner,
+      dmlHandler: genericMockDmlHandler,
+      indexerMeta,
+    }, undefined, config);
 
     await indexer.execute(mockBlock);
     await indexer.execute(mockBlock);
@@ -992,6 +1038,10 @@ CREATE TABLE
     expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
     expect(provisioner.provisionLogsIfNeeded).toHaveBeenCalled();
     expect(provisioner.provisionMetadataIfNeeded).toHaveBeenCalled();
+    expect(indexerMeta.setStatus).toHaveBeenCalledTimes(1); // Status is cached, so only called once
+    expect(indexerMeta.setStatus).toHaveBeenCalledWith(IndexerStatus.RUNNING);
+    expect(indexerMeta.updateBlockHeight).toHaveBeenCalledTimes(3);
+    expect(indexerMeta.updateBlockHeight).toHaveBeenCalledWith(blockHeight);
   });
 
   test('Indexer.execute() supplies the required role to the GraphQL endpoint', async () => {
@@ -1018,19 +1068,31 @@ CREATE TABLE
       provisionLogsIfNeeded: jest.fn(),
       provisionMetadataIfNeeded: jest.fn(),
     };
+    const indexerMeta = {
+      writeLogs: jest.fn(),
+      setStatus: jest.fn(),
+      updateBlockHeight: jest.fn()
+    } as unknown as IndexerMeta;
     const code = `
       context.graphql(\`mutation { set(functionName: "buildnear.testnet/test", key: "height", data: "\${block.blockHeight}")}\`);
     `;
     const indexerConfig = new IndexerConfig(SIMPLE_REDIS_STREAM, 'morgs.near', 'test', 0, code, SIMPLE_SCHEMA, LogLevel.INFO);
-    const indexer = new Indexer(indexerConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler, indexerMeta: genericMockIndexerMeta }, undefined, config);
+    const indexer = new Indexer(indexerConfig, {
+      fetch: mockFetch as unknown as typeof fetch,
+      provisioner,
+      dmlHandler: genericMockDmlHandler,
+      indexerMeta,
+    }, undefined, config);
 
     await indexer.execute(mockBlock);
 
     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
+    expect(indexerMeta.setStatus).toHaveBeenNthCalledWith(1, IndexerStatus.RUNNING);
     expect(mockFetch.mock.calls).toMatchSnapshot();
     expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
     expect(provisioner.provisionLogsIfNeeded).toHaveBeenCalled();
     expect(provisioner.provisionMetadataIfNeeded).toHaveBeenCalled();
+    expect(indexerMeta.updateBlockHeight).toHaveBeenCalledWith(blockHeight);
   });
 
   test('Indexer.execute() logs provisioning failures', async () => {
@@ -1055,15 +1117,31 @@ CREATE TABLE
       getPgBouncerConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
       fetchUserApiProvisioningStatus: jest.fn().mockReturnValue(false),
       provisionUserApi: jest.fn().mockRejectedValue(error),
+      provisionLogsIfNeeded: jest.fn(),
+      provisionMetadataIfNeeded: jest.fn(),
     };
+    const indexerMeta = {
+      writeLogs: jest.fn(),
+      setStatus: jest.fn(),
+      updateBlockHeight: jest.fn()
+    } as unknown as IndexerMeta;
     const code = `
       context.graphql(\`mutation { set(functionName: "buildnear.testnet/test", key: "height", data: "\${block.blockHeight}")}\`);
     `;
     const indexerConfig = new IndexerConfig(SIMPLE_REDIS_STREAM, 'morgs.near', 'test', 0, code, 'schema', LogLevel.INFO);
-    const indexer = new Indexer(indexerConfig, { fetch: mockFetch as unknown as typeof fetch, provisioner, dmlHandler: genericMockDmlHandler, indexerMeta: genericMockIndexerMeta }, undefined, config);
+    const indexer = new Indexer(indexerConfig, {
+      fetch: mockFetch as unknown as typeof fetch,
+      provisioner,
+      dmlHandler: genericMockDmlHandler,
+      indexerMeta,
+    }, undefined, config);
 
     await expect(indexer.execute(mockBlock)).rejects.toThrow(error);
+
     expect(mockFetch.mock.calls).toMatchSnapshot();
+    expect(indexerMeta.updateBlockHeight).not.toHaveBeenCalled();
+    expect(provisioner.provisionLogsIfNeeded).not.toHaveBeenCalled();
+    expect(provisioner.provisionMetadataIfNeeded).not.toHaveBeenCalled();
     expect(provisioner.getPgBouncerConnectionParameters).not.toHaveBeenCalled();
   });
 
@@ -1113,19 +1191,34 @@ CREATE TABLE
 
     const indexerDebug = new Indexer(
       debugIndexerConfig,
-      { fetch: mockFetchDebug as unknown as typeof fetch, provisioner: genericProvisioner, dmlHandler: mockDmlHandler, indexerMeta: genericMockIndexerMeta },
+      {
+        fetch: mockFetchDebug as unknown as typeof fetch,
+        provisioner: genericProvisioner,
+        dmlHandler: mockDmlHandler,
+        indexerMeta: genericMockIndexerMeta
+      },
       undefined,
       config
     );
     const indexerInfo = new Indexer(
       infoIndexerConfig,
-      { fetch: mockFetchInfo as unknown as typeof fetch, provisioner: genericProvisioner, dmlHandler: mockDmlHandler, indexerMeta: genericMockIndexerMeta },
+      {
+        fetch: mockFetchInfo as unknown as typeof fetch,
+        provisioner: genericProvisioner,
+        dmlHandler: mockDmlHandler,
+        indexerMeta: genericMockIndexerMeta
+      },
       undefined,
       config
     );
     const indexerError = new Indexer(
       errorIndexerConfig,
-      { fetch: mockFetchError as unknown as typeof fetch, provisioner: genericProvisioner, dmlHandler: mockDmlHandler, indexerMeta: genericMockIndexerMeta },
+      {
+        fetch: mockFetchError as unknown as typeof fetch,
+        provisioner: genericProvisioner,
+        dmlHandler: mockDmlHandler,
+        indexerMeta: genericMockIndexerMeta
+      },
       undefined,
       config
     );

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -1294,6 +1294,8 @@ describe('Indexer unit tests', () => {
 
     const indexerMeta: any = {
       writeLogs: jest.fn(),
+      setStatus: jest.fn(),
+      updateBlockHeight: jest.fn(),
     };
 
     const code = `

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -10,6 +10,7 @@ import IndexerConfig from '../indexer-config/indexer-config';
 import type IndexerMeta from '../indexer-meta';
 import { IndexerStatus } from '../indexer-meta';
 import type Provisioner from '../provisioner';
+import { type PostgresConnectionParams } from '../pg-client';
 
 describe('Indexer unit tests', () => {
   const SIMPLE_SCHEMA = `CREATE TABLE
@@ -185,12 +186,12 @@ describe('Indexer unit tests', () => {
   const caseSensitiveConfig: IndexerConfig = new IndexerConfig(SIMPLE_REDIS_STREAM, SIMPLE_ACCOUNT_ID, SIMPLE_FUNCTION_NAME, 0, SIMPLE_CODE, CASE_SENSITIVE_SCHEMA, LogLevel.INFO);
   const stressTestConfig: IndexerConfig = new IndexerConfig(SIMPLE_REDIS_STREAM, SIMPLE_ACCOUNT_ID, SIMPLE_FUNCTION_NAME, 0, SIMPLE_CODE, STRESS_TEST_SCHEMA, LogLevel.INFO);
 
-  const genericDbCredentials: any = {
+  const genericDbCredentials: PostgresConnectionParams = {
     database: 'test_near',
     host: 'postgres',
     password: 'test_pass',
     port: 5432,
-    username: 'test_near'
+    user: 'test_near'
   };
 
   const genericMockFetch = jest.fn()

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -48,7 +48,7 @@ const defaultConfig: Config = {
 
 export default class Indexer {
   DEFAULT_HASURA_ROLE: string;
-  LOGGGED_CONTEXT_DB_WARNING: boolean = false;
+  IS_FIRST_EXECUTION: boolean = false;
   tracer = trace.getTracer('queryapi-runner-indexer');
 
   private readonly deps: Dependencies;
@@ -386,9 +386,9 @@ export default class Indexer {
       return result;
     } catch (error) {
       const errorContent = error as { message: string, location: Record<string, any> };
-      if (!this.LOGGGED_CONTEXT_DB_WARNING) {
+      if (!this.IS_FIRST_EXECUTION) {
         console.warn(`${this.indexerConfig.fullName()}: Caught error when generating context.db methods. Building no functions. You can still use other context object methods.\nError: ${errorContent.message}\nLocation: `, errorContent.location);
-        this.LOGGGED_CONTEXT_DB_WARNING = true;
+        this.IS_FIRST_EXECUTION = true;
       }
     }
     return {}; // Default to empty object if error

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -60,7 +60,7 @@ export default class Indexer {
   constructor (
     private readonly indexerConfig: IndexerConfig,
     deps?: Partial<Dependencies>,
-    databaseConnectionParameters = undefined,
+    databaseConnectionParameters: PostgresConnectionParams | undefined = undefined,
     private readonly config: Config = defaultConfig,
   ) {
     this.DEFAULT_HASURA_ROLE = 'append';

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -90,7 +90,6 @@ export default class Indexer {
 
       try {
         if (!await this.deps.provisioner.fetchUserApiProvisioningStatus(this.indexerConfig)) {
-          // TODO: Remove call as setting PROVISIONING status is impossible with new table
           await this.setStatus(blockHeight, IndexerStatus.PROVISIONING);
           simultaneousPromises.push(this.writeLogOld(LogLevel.INFO, blockHeight, 'Provisioning endpoint: starting'));
           const provisionStartLogEntry = LogEntry.systemInfo('Provisioning endpoint: starting', blockHeight);

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -7,10 +7,10 @@ import Provisioner from '../provisioner';
 import DmlHandler from '../dml-handler/dml-handler';
 import LogEntry, { LogLevel } from '../indexer-meta/log-entry';
 
-import IndexerMeta, { IndexerStatus } from '../indexer-meta/indexer-meta';
 import { trace, type Span } from '@opentelemetry/api';
 import type IndexerConfig from '../indexer-config';
 import { type PostgresConnectionParams } from '../pg-client';
+import IndexerMeta, { IndexerStatus } from '../indexer-meta';
 
 interface Dependencies {
   fetch: typeof fetch
@@ -422,6 +422,8 @@ export default class Indexer {
     } finally {
       setStatusSpan.end();
     }
+
+    await (this.deps.indexerMeta as IndexerMeta).setStatus(status);
   }
 
   async writeLog (logEntry: LogEntry, logEntries: LogEntry[]): Promise<any> {
@@ -463,6 +465,8 @@ export default class Indexer {
     } finally {
       setBlockHeightSpan.end();
     }
+
+    await (this.deps.indexerMeta as IndexerMeta).updateBlockHeight(blockHeight);
   }
 
   // todo rename to writeLogOld

--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -3,8 +3,6 @@ import pgFormat from 'pg-format';
 import Provisioner from './provisioner';
 import IndexerConfig from '../indexer-config/indexer-config';
 import { LogLevel } from '../indexer-meta/log-entry';
-// import { logsTableDDL } from './schemas/logs-table';
-// import { metadataTableDDL } from './schemas/metadata-table';
 
 describe('Provisioner', () => {
   let adminPgClient: any;
@@ -117,10 +115,9 @@ describe('Provisioner', () => {
       ]);
       expect(hasuraClient.addDatasource).toBeCalledWith(indexerConfig.userName(), password, indexerConfig.databaseName());
       expect(hasuraClient.createSchema).toBeCalledWith(indexerConfig.userName(), indexerConfig.schemaName());
-      // expect(hasuraClient.executeSqlOnSchema).toBeCalledWith(sanitizedAccountId, schemaName, metadataTableDDL());
-      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(1, indexerConfig.userName(), indexerConfig.schemaName(), databaseSchema);
-      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(2, indexerConfig.userName(), indexerConfig.schemaName(), logsDDL);
-      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(3, indexerConfig.userName(), indexerConfig.schemaName(), metadataDDL);
+      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(1, indexerConfig.userName(), indexerConfig.schemaName(), logsDDL);
+      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(2, indexerConfig.userName(), indexerConfig.schemaName(), metadataDDL);
+      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(3, indexerConfig.userName(), indexerConfig.schemaName(), databaseSchema);
       expect(hasuraClient.getTableNames).toBeCalledWith(indexerConfig.schemaName(), indexerConfig.databaseName());
       expect(hasuraClient.trackTables).toBeCalledWith(indexerConfig.schemaName(), tableNames, indexerConfig.databaseName());
       expect(hasuraClient.addPermissionsToTables).toBeCalledWith(
@@ -147,9 +144,9 @@ describe('Provisioner', () => {
       expect(hasuraClient.addDatasource).not.toBeCalled();
 
       expect(hasuraClient.createSchema).toBeCalledWith(indexerConfig.userName(), indexerConfig.schemaName());
-      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(1, indexerConfig.databaseName(), indexerConfig.schemaName(), databaseSchema);
-      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(2, indexerConfig.userName(), indexerConfig.schemaName(), logsDDL);
-      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(3, indexerConfig.userName(), indexerConfig.schemaName(), metadataDDL);
+      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(1, indexerConfig.userName(), indexerConfig.schemaName(), logsDDL);
+      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(2, indexerConfig.userName(), indexerConfig.schemaName(), metadataDDL);
+      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(3, indexerConfig.databaseName(), indexerConfig.schemaName(), databaseSchema);
       expect(hasuraClient.getTableNames).toBeCalledWith(indexerConfig.schemaName(), indexerConfig.databaseName());
       expect(hasuraClient.trackTables).toBeCalledWith(indexerConfig.schemaName(), tableNames, indexerConfig.databaseName());
       expect(hasuraClient.addPermissionsToTables).toBeCalledWith(

--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -3,7 +3,6 @@ import pgFormat from 'pg-format';
 import Provisioner from './provisioner';
 import IndexerConfig from '../indexer-config/indexer-config';
 import { LogLevel } from '../indexer-meta/log-entry';
-import IndexerMeta, { IndexerStatus } from '../indexer-meta';
 
 describe('Provisioner', () => {
   let adminPgClient: any;
@@ -11,14 +10,14 @@ describe('Provisioner', () => {
   let hasuraClient: any;
   let provisioner: Provisioner;
   let userPgClientQuery: any;
-  let indexerConfig: any;
+  let indexerConfig: IndexerConfig;
 
   const tableNames = ['blocks'];
   const accountId = 'morgs.near';
   const functionName = 'test-function';
   const databaseSchema = 'CREATE TABLE blocks (height numeric)';
   indexerConfig = new IndexerConfig('', accountId, functionName, 0, '', databaseSchema, LogLevel.INFO);
-  const setProvisioningStatusQuery = IndexerMeta.createSetStatusQuery(IndexerStatus.PROVISIONING, indexerConfig.schemaName());
+  const setProvisioningStatusQuery = `INSERT INTO ${indexerConfig.schemaName()}.__metadata (attribute, value) VALUES ('STATUS', 'PROVISIONING') ON CONFLICT (attribute) DO UPDATE SET value = EXCLUDED.value RETURNING *`;
   const logsDDL = expect.any(String);
   const metadataDDL = expect.any(String);
   const error = new Error('some error');
@@ -43,13 +42,10 @@ describe('Provisioner', () => {
       addDatasource: jest.fn().mockReturnValueOnce(null),
       executeSqlOnSchema: jest.fn().mockReturnValueOnce(null),
       createSchema: jest.fn().mockReturnValueOnce(null),
-      setupPartitionedLogsTable: jest.fn().mockReturnValueOnce(null),
       doesSourceExist: jest.fn().mockReturnValueOnce(false),
       doesSchemaExist: jest.fn().mockReturnValueOnce(false),
       untrackTables: jest.fn().mockReturnValueOnce(null),
-      grantCronAccess: jest.fn().mockResolvedValueOnce(null),
-      scheduleLogPartitionJobs: jest.fn().mockResolvedValueOnce(null),
-      getDbConnectionParameters: jest.fn().mockReturnValueOnce({}),
+      getDbConnectionParameters: jest.fn().mockReturnValue({}),
     };
 
     adminPgClient = {
@@ -113,15 +109,15 @@ describe('Provisioner', () => {
         ['GRANT EXECUTE ON FUNCTION cron.schedule_in_database TO morgs_near;'],
       ]);
       expect(userPgClientQuery.mock.calls).toEqual([
+        [setProvisioningStatusQuery],
         ["SELECT cron.schedule_in_database('morgs_near_test_function_logs_create_partition', '0 1 * * *', $$SELECT morgs_near_test_function.fn_create_partition('morgs_near_test_function.__logs', CURRENT_DATE, '1 day', '2 day')$$, 'morgs_near');"],
         ["SELECT cron.schedule_in_database('morgs_near_test_function_logs_delete_partition', '0 2 * * *', $$SELECT morgs_near_test_function.fn_delete_partition('morgs_near_test_function.__logs', CURRENT_DATE, '-15 day', '-14 day')$$, 'morgs_near');"]
       ]);
       expect(hasuraClient.addDatasource).toBeCalledWith(indexerConfig.userName(), password, indexerConfig.databaseName());
       expect(hasuraClient.createSchema).toBeCalledWith(indexerConfig.userName(), indexerConfig.schemaName());
       expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(1, indexerConfig.userName(), indexerConfig.schemaName(), metadataDDL);
-      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(2, indexerConfig.userName(), indexerConfig.schemaName(), setProvisioningStatusQuery);
-      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(3, indexerConfig.userName(), indexerConfig.schemaName(), logsDDL);
-      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(4, indexerConfig.userName(), indexerConfig.schemaName(), databaseSchema);
+      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(2, indexerConfig.userName(), indexerConfig.schemaName(), logsDDL);
+      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(3, indexerConfig.userName(), indexerConfig.schemaName(), databaseSchema);
       expect(hasuraClient.getTableNames).toBeCalledWith(indexerConfig.schemaName(), indexerConfig.databaseName());
       expect(hasuraClient.trackTables).toBeCalledWith(indexerConfig.schemaName(), tableNames, indexerConfig.databaseName());
       expect(hasuraClient.addPermissionsToTables).toBeCalledWith(
@@ -149,9 +145,8 @@ describe('Provisioner', () => {
 
       expect(hasuraClient.createSchema).toBeCalledWith(indexerConfig.userName(), indexerConfig.schemaName());
       expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(1, indexerConfig.userName(), indexerConfig.schemaName(), metadataDDL);
-      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(2, indexerConfig.userName(), indexerConfig.schemaName(), setProvisioningStatusQuery);
-      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(3, indexerConfig.userName(), indexerConfig.schemaName(), logsDDL);
-      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(4, indexerConfig.databaseName(), indexerConfig.schemaName(), databaseSchema);
+      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(2, indexerConfig.userName(), indexerConfig.schemaName(), logsDDL);
+      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(3, indexerConfig.databaseName(), indexerConfig.schemaName(), databaseSchema);
       expect(hasuraClient.getTableNames).toBeCalledWith(indexerConfig.schemaName(), indexerConfig.databaseName());
       expect(hasuraClient.trackTables).toBeCalledWith(indexerConfig.schemaName(), tableNames, indexerConfig.databaseName());
       expect(hasuraClient.addPermissionsToTables).toBeCalledWith(
@@ -241,19 +236,7 @@ describe('Provisioner', () => {
     });
 
     it('throws when scheduling cron jobs fails', async () => {
-      userPgClientQuery = jest.fn().mockRejectedValueOnce(error);
-
-      await expect(provisioner.provisionUserApi(indexerConfig)).rejects.toThrow('Failed to provision endpoint: Failed to setup partitioned logs table: Failed to schedule log partition jobs: some error');
-    });
-
-    it('throws when scheduling cron jobs fails', async () => {
-      userPgClientQuery = jest.fn().mockRejectedValueOnce(error);
-
-      await expect(provisioner.provisionUserApi(indexerConfig)).rejects.toThrow('Failed to provision endpoint: Failed to setup partitioned logs table: Failed to schedule log partition jobs: some error');
-    });
-
-    it('throws when scheduling cron jobs fails', async () => {
-      userPgClientQuery = jest.fn().mockRejectedValueOnce(error);
+      userPgClientQuery = jest.fn().mockReturnValueOnce({}).mockRejectedValueOnce(error); // Succeed setting provisioning status first
 
       await expect(provisioner.provisionUserApi(indexerConfig)).rejects.toThrow('Failed to provision endpoint: Failed to setup partitioned logs table: Failed to schedule log partition jobs: some error');
     });
@@ -270,7 +253,10 @@ describe('Provisioner', () => {
       await provisioner.provisionMetadataIfNeeded(indexerConfig);
       await provisioner.provisionMetadataIfNeeded(indexerConfig);
 
-      expect(hasuraClient.executeSqlOnSchema).toBeCalledTimes(2); // Create table and set provisioning status
+      expect(hasuraClient.executeSqlOnSchema).toBeCalledTimes(1);
+      expect(userPgClientQuery.mock.calls).toEqual([
+        [setProvisioningStatusQuery],
+      ]);
     });
 
     it('get credentials for postgres', async () => {
@@ -291,7 +277,7 @@ describe('Provisioner', () => {
         pgBouncerPort: 2,
       });
 
-      const params = await mockProvisioner.getPostgresConnectionParameters(indexerConfig);
+      const params = await mockProvisioner.getPostgresConnectionParameters(indexerConfig.userName());
       expect(params).toEqual({
         user: 'username',
         password: 'password',
@@ -319,7 +305,7 @@ describe('Provisioner', () => {
         pgBouncerPort: 2,
       });
 
-      const params = await mockProvisioner.getPgBouncerConnectionParameters(indexerConfig);
+      const params = await mockProvisioner.getPgBouncerConnectionParameters(indexerConfig.userName());
       expect(params).toEqual({
         user: 'username',
         password: 'password',

--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -118,9 +118,9 @@ describe('Provisioner', () => {
       ]);
       expect(hasuraClient.addDatasource).toBeCalledWith(indexerConfig.userName(), password, indexerConfig.databaseName());
       expect(hasuraClient.createSchema).toBeCalledWith(indexerConfig.userName(), indexerConfig.schemaName());
-      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(1, indexerConfig.userName(), indexerConfig.schemaName(), logsDDL);
-      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(2, indexerConfig.userName(), indexerConfig.schemaName(), metadataDDL);
-      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(3, indexerConfig.userName(), indexerConfig.schemaName(), setProvisioningStatusQuery);
+      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(1, indexerConfig.userName(), indexerConfig.schemaName(), metadataDDL);
+      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(2, indexerConfig.userName(), indexerConfig.schemaName(), setProvisioningStatusQuery);
+      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(3, indexerConfig.userName(), indexerConfig.schemaName(), logsDDL);
       expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(4, indexerConfig.userName(), indexerConfig.schemaName(), databaseSchema);
       expect(hasuraClient.getTableNames).toBeCalledWith(indexerConfig.schemaName(), indexerConfig.databaseName());
       expect(hasuraClient.trackTables).toBeCalledWith(indexerConfig.schemaName(), tableNames, indexerConfig.databaseName());
@@ -148,9 +148,9 @@ describe('Provisioner', () => {
       expect(hasuraClient.addDatasource).not.toBeCalled();
 
       expect(hasuraClient.createSchema).toBeCalledWith(indexerConfig.userName(), indexerConfig.schemaName());
-      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(1, indexerConfig.userName(), indexerConfig.schemaName(), logsDDL);
-      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(2, indexerConfig.userName(), indexerConfig.schemaName(), metadataDDL);
-      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(3, indexerConfig.userName(), indexerConfig.schemaName(), setProvisioningStatusQuery);
+      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(1, indexerConfig.userName(), indexerConfig.schemaName(), metadataDDL);
+      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(2, indexerConfig.userName(), indexerConfig.schemaName(), setProvisioningStatusQuery);
+      expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(3, indexerConfig.userName(), indexerConfig.schemaName(), logsDDL);
       expect(hasuraClient.executeSqlOnSchema).toHaveBeenNthCalledWith(4, indexerConfig.databaseName(), indexerConfig.schemaName(), databaseSchema);
       expect(hasuraClient.getTableNames).toBeCalledWith(indexerConfig.schemaName(), indexerConfig.databaseName());
       expect(hasuraClient.trackTables).toBeCalledWith(indexerConfig.schemaName(), tableNames, indexerConfig.databaseName());

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -301,8 +301,8 @@ export default class Provisioner {
 
           await this.createSchema(databaseName, schemaName);
 
-          await this.setupPartitionedLogsTable(userName, databaseName, schemaName);
           await this.createMetadataTable(databaseName, schemaName);
+          await this.setupPartitionedLogsTable(userName, databaseName, schemaName);
           await this.runIndexerSql(databaseName, schemaName, indexerConfig.schema);
 
           const updatedTableNames = await this.getTableNames(schemaName, databaseName);

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -296,9 +296,9 @@ export default class Provisioner {
 
           await this.createSchema(databaseName, schemaName);
 
-          await this.runIndexerSql(databaseName, schemaName, indexerConfig.schema);
           await this.setupPartitionedLogsTable(userName, databaseName, schemaName);
           await this.createMetadataTable(databaseName, schemaName);
+          await this.runIndexerSql(databaseName, schemaName, indexerConfig.schema);
 
           const updatedTableNames = await this.getTableNames(schemaName, databaseName);
 

--- a/runner/src/stream-handler/stream-handler.ts
+++ b/runner/src/stream-handler/stream-handler.ts
@@ -73,7 +73,7 @@ export default class StreamHandler {
       indexer.writeLogOld(LogLevel.ERROR, this.executorContext.block_height, `Encountered error processing stream: ${this.indexerConfig.fullName()}, terminating thread\n${error.toString()}`),
       indexer.callWriteLog(streamErrorLogEntry),
     ]).catch((e) => {
-      console.error(`Failed to set status or write failure log for stream: ${this.indexerConfig.redisStreamKey}`, e);
+      console.error(`Failed to write failure log for stream: ${this.indexerConfig.redisStreamKey}`, e);
     });
 
     this.worker.terminate().catch(() => {
@@ -87,7 +87,7 @@ export default class StreamHandler {
         this.executorContext.status = message.data;
         break;
       case WorkerMessageType.BLOCK_HEIGHT:
-        this.executorContext.block_height = Number(message.data);
+        this.executorContext.block_height = message.data;
         break;
       case WorkerMessageType.METRICS:
         registerWorkerMetrics(this.worker.threadId, message.data);

--- a/runner/src/stream-handler/stream-handler.ts
+++ b/runner/src/stream-handler/stream-handler.ts
@@ -58,10 +58,13 @@ export default class StreamHandler {
   private handleError (error: Error): void {
     console.error(`Encountered error processing stream: ${this.indexerConfig.fullName()}, terminating thread`, error);
     this.executorContext.status = IndexerStatus.STOPPED;
-    const indexer = new Indexer(this.indexerConfig);
 
+    const indexer = new Indexer(this.indexerConfig);
     indexer.setStatus(0, IndexerStatus.STOPPED).catch((e) => {
       console.error(`Failed to set status STOPPED for stream: ${this.indexerConfig.redisStreamKey}`, e);
+    });
+    indexer.setStoppedStatus().catch((e) => {
+      console.error(`Failed to set stopped status for stream in Metadata table: ${this.indexerConfig.redisStreamKey}`, e);
     });
 
     const streamErrorLogEntry = LogEntry.systemError(`Encountered error processing stream: ${this.indexerConfig.redisStreamKey}, terminating thread\n${error.toString()}`, this.executorContext.block_height);
@@ -70,7 +73,7 @@ export default class StreamHandler {
       indexer.writeLogOld(LogLevel.ERROR, this.executorContext.block_height, `Encountered error processing stream: ${this.indexerConfig.fullName()}, terminating thread\n${error.toString()}`),
       indexer.callWriteLog(streamErrorLogEntry),
     ]).catch((e) => {
-      console.error(`Failed to write log for stream: ${this.indexerConfig.redisStreamKey}`, e);
+      console.error(`Failed to set status or write failure log for stream: ${this.indexerConfig.redisStreamKey}`, e);
     });
 
     this.worker.terminate().catch(() => {
@@ -84,7 +87,7 @@ export default class StreamHandler {
         this.executorContext.status = message.data;
         break;
       case WorkerMessageType.BLOCK_HEIGHT:
-        this.executorContext.block_height = message.data;
+        this.executorContext.block_height = Number(message.data);
         break;
       case WorkerMessageType.METRICS:
         registerWorkerMetrics(this.worker.threadId, message.data);


### PR DESCRIPTION
Enable writes of Status and Last Processed Block Height to Metadata table. Reorganizes provisioning to ensure writing of PROVISIONING status. Ensures IndexerMeta is available for writing error logs.