### PR TITLE
feat: Retry Tracking and Permissions for Tables in Hasura

### DIFF
--- a/runner/src/hasura-client/__snapshots__/hasura-client.test.ts.snap
+++ b/runner/src/hasura-client/__snapshots__/hasura-client.test.ts.snap
@@ -215,7 +215,7 @@ exports[`HasuraClient gets table names within a schema 1`] = `
 }
 `;
 
-exports[`HasuraClient gets tracked tables and their permissions in a schema 1`] = `
+exports[`HasuraClient gets tracked tables and their permissions for a schema 1`] = `
 [
   {
     "delete_permissions": [

--- a/runner/src/hasura-client/__snapshots__/hasura-client.test.ts.snap
+++ b/runner/src/hasura-client/__snapshots__/hasura-client.test.ts.snap
@@ -215,6 +215,63 @@ exports[`HasuraClient gets table names within a schema 1`] = `
 }
 `;
 
+exports[`HasuraClient gets tracked tables and their permissions in a schema 1`] = `
+[
+  {
+    "delete_permissions": [
+      {
+        "role": "role",
+      },
+    ],
+    "insert_permissions": [
+      {
+        "role": "role",
+      },
+    ],
+    "select_permissions": [
+      {
+        "role": "role",
+      },
+    ],
+    "table": {
+      "name": "tableA",
+      "schema": "schemaB",
+    },
+    "update_permissions": [
+      {
+        "role": "role",
+      },
+    ],
+  },
+  {
+    "delete_permissions": [
+      {
+        "role": "role",
+      },
+    ],
+    "insert_permissions": [
+      {
+        "role": "role",
+      },
+    ],
+    "select_permissions": [
+      {
+        "role": "role",
+      },
+    ],
+    "table": {
+      "name": "tableB",
+      "schema": "schemaB",
+    },
+    "update_permissions": [
+      {
+        "role": "role",
+      },
+    ],
+  },
+]
+`;
+
 exports[`HasuraClient runs migrations for the specified schema 1`] = `
 [
   [

--- a/runner/src/hasura-client/__snapshots__/hasura-client.test.ts.snap
+++ b/runner/src/hasura-client/__snapshots__/hasura-client.test.ts.snap
@@ -220,16 +220,19 @@ exports[`HasuraClient gets tracked tables and their permissions for a schema 1`]
   {
     "delete_permissions": [
       {
+        "permission": {},
         "role": "role",
       },
     ],
     "insert_permissions": [
       {
+        "permission": {},
         "role": "role",
       },
     ],
     "select_permissions": [
       {
+        "permission": {},
         "role": "role",
       },
     ],
@@ -239,6 +242,7 @@ exports[`HasuraClient gets tracked tables and their permissions for a schema 1`]
     },
     "update_permissions": [
       {
+        "permission": {},
         "role": "role",
       },
     ],
@@ -246,16 +250,19 @@ exports[`HasuraClient gets tracked tables and their permissions for a schema 1`]
   {
     "delete_permissions": [
       {
+        "permission": {},
         "role": "role",
       },
     ],
     "insert_permissions": [
       {
+        "permission": {},
         "role": "role",
       },
     ],
     "select_permissions": [
       {
+        "permission": {},
         "role": "role",
       },
     ],
@@ -265,6 +272,7 @@ exports[`HasuraClient gets tracked tables and their permissions for a schema 1`]
     },
     "update_permissions": [
       {
+        "permission": {},
         "role": "role",
       },
     ],

--- a/runner/src/hasura-client/hasura-client.test.ts
+++ b/runner/src/hasura-client/hasura-client.test.ts
@@ -97,7 +97,7 @@ describe('HasuraClient', () => {
     expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toMatchSnapshot();
   });
 
-  it('gets tracked tables and their permissions in a schema', async () => {
+  it('gets tracked tables and their permissions for a schema', async () => {
     const TEST_METADATA = generateTableMetadata(['schemaA', 'schemaB'], ['tableA', 'tableB'], 'role');
     const mockFetch = jest
       .fn()

--- a/runner/src/hasura-client/hasura-client.ts
+++ b/runner/src/hasura-client/hasura-client.ts
@@ -181,10 +181,7 @@ export default class HasuraClient {
     source: string,
     schemaName: string,
   ): Promise<any> {
-    const metadata = await this.executeMetadataRequest(
-      'export_metadata',
-      {},
-    );
+    const metadata = await this.exportMetadata();
     const tablesForSchema = metadata.sources
       .find((database: { name: string }) => database.name === source)
       .tables

--- a/runner/src/hasura-client/hasura-client.ts
+++ b/runner/src/hasura-client/hasura-client.ts
@@ -172,6 +172,7 @@ export default class HasuraClient {
         source,
       }
     );
+    console.log(tablesInSource);
     return tablesInSource
       .filter(({ schema }: { schema: string }) => schema === schemaName)
       .map(({ name }: { name: string }) => name);

--- a/runner/src/hasura-client/hasura-client.ts
+++ b/runner/src/hasura-client/hasura-client.ts
@@ -241,12 +241,12 @@ export default class HasuraClient {
   async getTrackedTablePermissions (
     databaseName: string,
     schemaName: string,
-  ): Promise<any> {
+  ): Promise<HasuraTableMetadata[]> {
     const metadata: HasuraMetadata = await this.exportMetadata();
     const hasuraSource = metadata.sources.find((source: HasuraSource) => source.name === databaseName);
     const tablesForSchema = hasuraSource?.tables.filter((tableMetadata: HasuraTableMetadata) => tableMetadata.table.schema === schemaName);
 
-    return tablesForSchema;
+    return tablesForSchema ?? [];
   }
 
   async trackTables (

--- a/runner/src/hasura-client/hasura-client.ts
+++ b/runner/src/hasura-client/hasura-client.ts
@@ -16,7 +16,7 @@ interface TableDefinition {
   name: string
   schema: string
 }
-interface HasuraRolePermission {
+export interface HasuraRolePermission {
   role: string
   permission: {
     check?: Record<string, any>
@@ -26,13 +26,12 @@ interface HasuraRolePermission {
     allow_aggregations?: boolean
   }
 }
-type HasuraPermissions = HasuraRolePermission[];
 export interface HasuraTableMetadata {
   table: TableDefinition
-  insert_permissions?: HasuraPermissions
-  select_permissions?: HasuraPermissions
-  update_permissions?: HasuraPermissions
-  delete_permissions?: HasuraPermissions
+  insert_permissions?: HasuraRolePermission[]
+  select_permissions?: HasuraRolePermission[]
+  update_permissions?: HasuraRolePermission[]
+  delete_permissions?: HasuraRolePermission[]
 }
 
 export interface HasuraDatabaseConnectionParameters {

--- a/runner/src/hasura-client/hasura-client.ts
+++ b/runner/src/hasura-client/hasura-client.ts
@@ -177,26 +177,20 @@ export default class HasuraClient {
       .map(({ name }: { name: string }) => name);
   }
 
-  async getTableMetadata (
+  async getTrackedTablesWithPermissions (
     source: string,
     schemaName: string,
   ): Promise<any> {
-    console.log(schemaName);
     const metadata = await this.executeMetadataRequest(
       'export_metadata',
       {},
     );
-    const filteredTables = metadata.sources
+    const tablesForSchema = metadata.sources
       .find((database: { name: string }) => database.name === source)
       .tables
       .filter((table: { table: { schema: string } }) => table.table.schema === schemaName);
 
-    const tableMetadata = new Map<string, any>();
-    for (const table of filteredTables) {
-      tableMetadata.set(table.table.name, table);
-    }
-
-    return tableMetadata;
+    return tablesForSchema;
   }
 
   async trackTables (

--- a/runner/src/hasura-client/hasura-client.ts
+++ b/runner/src/hasura-client/hasura-client.ts
@@ -172,10 +172,31 @@ export default class HasuraClient {
         source,
       }
     );
-    console.log(tablesInSource);
     return tablesInSource
       .filter(({ schema }: { schema: string }) => schema === schemaName)
       .map(({ name }: { name: string }) => name);
+  }
+
+  async getTableMetadata (
+    source: string,
+    schemaName: string,
+  ): Promise<any> {
+    console.log(schemaName);
+    const metadata = await this.executeMetadataRequest(
+      'export_metadata',
+      {},
+    );
+    const filteredTables = metadata.sources
+      .find((database: { name: string }) => database.name === source)
+      .tables
+      .filter((table: { table: { schema: string } }) => table.table.schema === schemaName);
+
+    const tableMetadata = new Map<string, any>();
+    for (const table of filteredTables) {
+      tableMetadata.set(table.table.name, table);
+    }
+
+    return tableMetadata;
   }
 
   async trackTables (

--- a/runner/src/hasura-client/index.ts
+++ b/runner/src/hasura-client/index.ts
@@ -1,2 +1,2 @@
 export { default } from './hasura-client';
-export type { HasuraDatabaseConnectionParameters } from './hasura-client';
+export type { HasuraMetadata, HasuraSource, HasuraConfiguration, HasuraDatabaseConnectionParameters, HasuraTableMetadata, HasuraPermission } from './hasura-client';

--- a/runner/src/hasura-client/index.ts
+++ b/runner/src/hasura-client/index.ts
@@ -1,2 +1,2 @@
 export { default } from './hasura-client';
-export type { HasuraMetadata, HasuraSource, HasuraConfiguration, HasuraDatabaseConnectionParameters, HasuraTableMetadata, HasuraPermission } from './hasura-client';
+export type { HasuraMetadata, HasuraSource, HasuraConfiguration, HasuraDatabaseConnectionParameters, HasuraTableMetadata, HasuraRolePermission, HasuraPermission } from './hasura-client';

--- a/runner/src/indexer-meta/indexer-meta.ts
+++ b/runner/src/indexer-meta/indexer-meta.ts
@@ -47,7 +47,7 @@ export default class IndexerMeta {
     const entriesArray = logEntries.filter(entry => this.shouldLog(entry.level));
     if (entriesArray.length === 0) return;
 
-    const spanMessage = `write log for ${entriesArray.length === 1 ? 'single entry' : `batch of ${entriesArray.length}`} through postgres `;
+    const spanMessage = `write batch of ${entriesArray.length} logs through postgres`;
     const writeLogSpan = this.tracer.startSpan(spanMessage);
 
     await wrapError(async () => {
@@ -69,7 +69,7 @@ export default class IndexerMeta {
   }
 
   async setStatus (status: IndexerStatus): Promise<void> {
-    const setStatusSpan = this.tracer.startSpan(`set status of indexer to ${status} through postgres`);
+    const setStatusSpan = this.tracer.startSpan(`set status to ${status} through postgres`);
     const values = [[MetadataFields.STATUS, status]];
     const setStatusQuery = format(METADATA_TABLE_UPSERT, this.indexerConfig.schemaName(), values);
 
@@ -81,7 +81,7 @@ export default class IndexerMeta {
   }
 
   async updateBlockHeight (blockHeight: number): Promise<void> {
-    const setLastProcessedBlockSpan = this.tracer.startSpan(`set last processed block to ${blockHeight} through postgres`);
+    const setLastProcessedBlockSpan = this.tracer.startSpan('set last processed block through postgres');
     const values = [[MetadataFields.LAST_PROCESSED_BLOCK_HEIGHT, blockHeight.toString()]];
     const updateBlockHeightQuery = format(METADATA_TABLE_UPSERT, this.indexerConfig.schemaName(), values);
 

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -951,7 +951,8 @@ describe('Indexer unit tests', () => {
     expect(indexerMeta.setStatus).toHaveBeenNthCalledWith(2, IndexerStatus.RUNNING);
     expect(provisioner.provisionUserApi).toHaveBeenCalledTimes(1);
     expect(provisioner.provisionUserApi).toHaveBeenCalledWith(simpleSchemaConfig);
-    expect(provisioner.provisionLogsAndMetadataIfNeeded).toHaveBeenCalled();
+    expect(provisioner.provisionLogsAndMetadataIfNeeded).toHaveBeenCalledTimes(1);
+    expect(provisioner.ensureConsistentHasuraState).toHaveBeenCalledTimes(1);
     expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
   });
 
@@ -990,7 +991,8 @@ describe('Indexer unit tests', () => {
 
     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
     expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
-    expect(provisioner.provisionLogsAndMetadataIfNeeded).toHaveBeenCalled();
+    expect(provisioner.provisionLogsAndMetadataIfNeeded).toHaveBeenCalledTimes(1);
+    expect(provisioner.ensureConsistentHasuraState).toHaveBeenCalledTimes(1);
   });
 
   test('Indexer.execute() skips database credentials fetch second time onward', async () => {
@@ -1036,6 +1038,7 @@ describe('Indexer unit tests', () => {
     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
     expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
     expect(provisioner.provisionLogsAndMetadataIfNeeded).toHaveBeenCalled();
+    expect(provisioner.ensureConsistentHasuraState).toHaveBeenCalled();
     expect(indexerMeta.setStatus).toHaveBeenCalledTimes(1); // Status is cached, so only called once
     expect(indexerMeta.setStatus).toHaveBeenCalledWith(IndexerStatus.RUNNING);
     expect(indexerMeta.updateBlockHeight).toHaveBeenCalledTimes(3);
@@ -1088,7 +1091,8 @@ describe('Indexer unit tests', () => {
     expect(indexerMeta.setStatus).toHaveBeenNthCalledWith(1, IndexerStatus.RUNNING);
     expect(mockFetch.mock.calls).toMatchSnapshot();
     expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
-    expect(provisioner.provisionLogsAndMetadataIfNeeded).toHaveBeenCalled();
+    expect(provisioner.provisionLogsAndMetadataIfNeeded).toHaveBeenCalledTimes(1);
+    expect(provisioner.ensureConsistentHasuraState).toHaveBeenCalledTimes(1);
     expect(indexerMeta.updateBlockHeight).toHaveBeenCalledWith(blockHeight);
   });
 

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -220,6 +220,7 @@ describe('Indexer unit tests', () => {
     getPgBouncerConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
     fetchUserApiProvisioningStatus: jest.fn().mockResolvedValue(true),
     provisionLogsAndMetadataIfNeeded: jest.fn(),
+    ensureConsistentHasuraState: jest.fn(),
   } as unknown as Provisioner;
 
   const config = {
@@ -930,6 +931,7 @@ describe('Indexer unit tests', () => {
       fetchUserApiProvisioningStatus: jest.fn().mockReturnValue(false),
       provisionUserApi: jest.fn(),
       provisionLogsAndMetadataIfNeeded: jest.fn(),
+      ensureConsistentHasuraState: jest.fn(),
     };
     const indexerMeta = {
       writeLogs: jest.fn(),
@@ -975,6 +977,7 @@ describe('Indexer unit tests', () => {
       fetchUserApiProvisioningStatus: jest.fn().mockReturnValue(true),
       provisionUserApi: jest.fn(),
       provisionLogsAndMetadataIfNeeded: jest.fn(),
+      ensureConsistentHasuraState: jest.fn(),
     };
     const indexer = new Indexer(simpleSchemaConfig, {
       fetch: mockFetch as unknown as typeof fetch,
@@ -1012,6 +1015,7 @@ describe('Indexer unit tests', () => {
       fetchUserApiProvisioningStatus: jest.fn().mockReturnValue(true),
       provisionUserApi: jest.fn(),
       provisionLogsAndMetadataIfNeeded: jest.fn(),
+      ensureConsistentHasuraState: jest.fn(),
     };
     const indexerMeta = {
       writeLogs: jest.fn(),
@@ -1060,6 +1064,7 @@ describe('Indexer unit tests', () => {
       fetchUserApiProvisioningStatus: jest.fn().mockReturnValue(true),
       provisionUserApi: jest.fn(),
       provisionLogsAndMetadataIfNeeded: jest.fn(),
+      ensureConsistentHasuraState: jest.fn(),
     };
     const indexerMeta = {
       writeLogs: jest.fn(),
@@ -1111,6 +1116,7 @@ describe('Indexer unit tests', () => {
       provisionUserApi: jest.fn().mockRejectedValue(error),
       provisionLogsIfNeeded: jest.fn(),
       provisionMetadataIfNeeded: jest.fn(),
+      ensureConsistentHasuraState: jest.fn(),
     };
     const indexerMeta = {
       writeLogs: jest.fn(),

--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -219,8 +219,7 @@ describe('Indexer unit tests', () => {
   const genericProvisioner = {
     getPgBouncerConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
     fetchUserApiProvisioningStatus: jest.fn().mockResolvedValue(true),
-    provisionLogsIfNeeded: jest.fn(),
-    provisionMetadataIfNeeded: jest.fn(),
+    provisionLogsAndMetadataIfNeeded: jest.fn(),
   } as unknown as Provisioner;
 
   const config = {
@@ -930,8 +929,7 @@ describe('Indexer unit tests', () => {
       getPgBouncerConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
       fetchUserApiProvisioningStatus: jest.fn().mockReturnValue(false),
       provisionUserApi: jest.fn(),
-      provisionLogsIfNeeded: jest.fn(),
-      provisionMetadataIfNeeded: jest.fn(),
+      provisionLogsAndMetadataIfNeeded: jest.fn(),
     };
     const indexerMeta = {
       writeLogs: jest.fn(),
@@ -951,8 +949,7 @@ describe('Indexer unit tests', () => {
     expect(indexerMeta.setStatus).toHaveBeenNthCalledWith(2, IndexerStatus.RUNNING);
     expect(provisioner.provisionUserApi).toHaveBeenCalledTimes(1);
     expect(provisioner.provisionUserApi).toHaveBeenCalledWith(simpleSchemaConfig);
-    expect(provisioner.provisionLogsIfNeeded).toHaveBeenCalled();
-    expect(provisioner.provisionMetadataIfNeeded).toHaveBeenCalled();
+    expect(provisioner.provisionLogsAndMetadataIfNeeded).toHaveBeenCalled();
     expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
   });
 
@@ -977,8 +974,7 @@ describe('Indexer unit tests', () => {
       getPgBouncerConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
       fetchUserApiProvisioningStatus: jest.fn().mockReturnValue(true),
       provisionUserApi: jest.fn(),
-      provisionLogsIfNeeded: jest.fn(),
-      provisionMetadataIfNeeded: jest.fn(),
+      provisionLogsAndMetadataIfNeeded: jest.fn(),
     };
     const indexer = new Indexer(simpleSchemaConfig, {
       fetch: mockFetch as unknown as typeof fetch,
@@ -991,8 +987,7 @@ describe('Indexer unit tests', () => {
 
     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
     expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
-    expect(provisioner.provisionLogsIfNeeded).toHaveBeenCalled();
-    expect(provisioner.provisionMetadataIfNeeded).toHaveBeenCalled();
+    expect(provisioner.provisionLogsAndMetadataIfNeeded).toHaveBeenCalled();
   });
 
   test('Indexer.execute() skips database credentials fetch second time onward', async () => {
@@ -1016,8 +1011,7 @@ describe('Indexer unit tests', () => {
       getPgBouncerConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
       fetchUserApiProvisioningStatus: jest.fn().mockReturnValue(true),
       provisionUserApi: jest.fn(),
-      provisionLogsIfNeeded: jest.fn(),
-      provisionMetadataIfNeeded: jest.fn(),
+      provisionLogsAndMetadataIfNeeded: jest.fn(),
     };
     const indexerMeta = {
       writeLogs: jest.fn(),
@@ -1037,8 +1031,7 @@ describe('Indexer unit tests', () => {
 
     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
     expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
-    expect(provisioner.provisionLogsIfNeeded).toHaveBeenCalled();
-    expect(provisioner.provisionMetadataIfNeeded).toHaveBeenCalled();
+    expect(provisioner.provisionLogsAndMetadataIfNeeded).toHaveBeenCalled();
     expect(indexerMeta.setStatus).toHaveBeenCalledTimes(1); // Status is cached, so only called once
     expect(indexerMeta.setStatus).toHaveBeenCalledWith(IndexerStatus.RUNNING);
     expect(indexerMeta.updateBlockHeight).toHaveBeenCalledTimes(3);
@@ -1066,8 +1059,7 @@ describe('Indexer unit tests', () => {
       getPgBouncerConnectionParameters: jest.fn().mockReturnValue(genericDbCredentials),
       fetchUserApiProvisioningStatus: jest.fn().mockReturnValue(true),
       provisionUserApi: jest.fn(),
-      provisionLogsIfNeeded: jest.fn(),
-      provisionMetadataIfNeeded: jest.fn(),
+      provisionLogsAndMetadataIfNeeded: jest.fn(),
     };
     const indexerMeta = {
       writeLogs: jest.fn(),
@@ -1091,8 +1083,7 @@ describe('Indexer unit tests', () => {
     expect(indexerMeta.setStatus).toHaveBeenNthCalledWith(1, IndexerStatus.RUNNING);
     expect(mockFetch.mock.calls).toMatchSnapshot();
     expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
-    expect(provisioner.provisionLogsIfNeeded).toHaveBeenCalled();
-    expect(provisioner.provisionMetadataIfNeeded).toHaveBeenCalled();
+    expect(provisioner.provisionLogsAndMetadataIfNeeded).toHaveBeenCalled();
     expect(indexerMeta.updateBlockHeight).toHaveBeenCalledWith(blockHeight);
   });
 

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -490,7 +490,6 @@ export default class Indexer {
     await (this.deps.indexerMeta as IndexerMeta).updateBlockHeight(blockHeight);
   }
 
-  // todo rename to writeLogOld
   async writeLogOld (logLevel: LogLevel, blockHeight: number, ...message: any[]): Promise<any> {
     if (logLevel < this.indexerConfig.logLevel) {
       return;

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -99,8 +99,7 @@ export default class Indexer {
           const provisionSuccessLogEntry = LogEntry.systemInfo('Provisioning endpoint: successful', blockHeight);
           logEntries.push(provisionSuccessLogEntry);
         }
-        await this.deps.provisioner.provisionLogsIfNeeded(this.indexerConfig);
-        await this.deps.provisioner.provisionMetadataIfNeeded(this.indexerConfig);
+        await this.deps.provisioner.provisionLogsAndMetadataIfNeeded(this.indexerConfig);
       } catch (e) {
         const error = e as Error;
         simultaneousPromises.push(this.writeLogOld(LogLevel.ERROR, blockHeight, `Provisioning endpoint: failure:${error.message}`));

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -100,6 +100,7 @@ export default class Indexer {
           logEntries.push(provisionSuccessLogEntry);
         }
         await this.deps.provisioner.provisionLogsAndMetadataIfNeeded(this.indexerConfig);
+        await this.deps.provisioner.ensureConsistentHasuraState(this.indexerConfig);
       } catch (e) {
         const error = e as Error;
         simultaneousPromises.push(this.writeLogOld(LogLevel.ERROR, blockHeight, `Provisioning endpoint: failure:${error.message}`));

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -407,7 +407,7 @@ export default class Indexer {
           status
         }
       }`;
-    const setStatusSpan = this.tracer.startSpan(`set status of indexer to ${status} through hasura`);
+    const setStatusSpan = this.tracer.startSpan(`set status to ${status} through hasura`);
     try {
       await this.runGraphQLQuery(
         setStatusMutation,
@@ -477,7 +477,7 @@ export default class Indexer {
       function_name: this.indexerConfig.fullName(),
       block_height: blockHeight,
     };
-    const setBlockHeightSpan = this.tracer.startSpan('set last processed block height through Hasura');
+    const setBlockHeightSpan = this.tracer.startSpan('set last processed block through Hasura');
     try {
       await this.runGraphQLQuery(realTimeMutation, variables, blockHeight, this.DEFAULT_HASURA_ROLE)
         .catch((e: any) => {
@@ -500,7 +500,7 @@ export default class Indexer {
           insert_indexer_log_entries_one(object: {function_name: $function_name, block_height: $block_height, message: $message}) {id}
       }`;
 
-    const writeLogSpan = this.tracer.startSpan('Write log to log table through Hasura');
+    const writeLogSpan = this.tracer.startSpan('Write log through Hasura');
     const parsedMessage: string = message
       .map(m => typeof m === 'object' ? JSON.stringify(m) : m)
       .join(':');

--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -254,7 +254,7 @@ describe('Provisioner', () => {
     });
 
     it('provisions and tracks logs and metadata table once, adds permissions twice', async () => {
-      hasuraClient.getTrackedTablesWithPermissions = jest.fn().mockReturnValueOnce([]).mockReturnValueOnce([
+      hasuraClient.getTrackedTablePermissions = jest.fn().mockReturnValueOnce([]).mockReturnValueOnce([
         {
           table: {
             name: 'blocks',
@@ -285,7 +285,7 @@ describe('Provisioner', () => {
     });
 
     it('provision logs and metadata table function caches result', async () => {
-      hasuraClient.getTrackedTablesWithPermissions = jest.fn().mockReturnValue([
+      hasuraClient.getTrackedTablePermissions = jest.fn().mockReturnValue([
         generateTableConfig('morgs_near_test_function', 'blocks', 'morgs_near'),
         generateTableConfig('morgs_near_test_function', '__logs', 'morgs_near'),
         generateTableConfig('morgs_near_test_function', '__metadata', 'morgs_near'),

--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -352,7 +352,7 @@ function generateTableConfig (schemaName: string, tableName: string, role: strin
   };
 
   permissionsToAdd.forEach((permission) => {
-    const permissionKey: keyof Omit<HasuraTableMetadata, 'table'> = `${permission}_permissions`;
+    const permissionKey = `${permission as string}_permissions` as keyof Omit<HasuraTableMetadata, 'table'>;
     config[permissionKey] = [{ role, permission: {} }];
   });
 

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -264,12 +264,10 @@ export default class Provisioner {
 
         if (!tableNames.includes(logsTable)) {
           await this.setupPartitionedLogsTable(indexerConfig.userName(), indexerConfig.databaseName(), indexerConfig.schemaName());
-          tableNames.push(logsTable);
         }
         if (!tableNames.includes(metadataTable)) {
           await this.createMetadataTable(indexerConfig.databaseName(), indexerConfig.schemaName());
           await this.setProvisioningStatus(indexerConfig.userName(), indexerConfig.schemaName());
-          tableNames.push(metadataTable);
         }
       },
       'Failed logs and metadata provisioning'

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -8,7 +8,6 @@ import { logsTableDDL } from './schemas/logs-table';
 import { metadataTableDDL } from './schemas/metadata-table';
 import PgClientClass, { type PostgresConnectionParams } from '../pg-client';
 import type IndexerConfig from '../indexer-config/indexer-config';
-import { IndexerStatus, METADATA_TABLE_UPSERT, MetadataFields } from '../indexer-meta/indexer-meta';
 
 const DEFAULT_PASSWORD_LENGTH = 16;
 
@@ -335,8 +334,8 @@ export default class Provisioner {
           const permisionAttribute = `${permission}_permissions` as keyof HasuraTableMetadata;
           const usersWithPermission = tablePermissions[permisionAttribute] as (HasuraPermissions | undefined);
           // Returns true if the table does not have the permission or the user doesn't have the permission
-          const userLackingPermission = !usersWithPermission?.some((role: { role: string }) => role.role === userName);
-          return userLackingPermission;
+          const userIsLackingPermission = !usersWithPermission?.some((role: { role: string }) => role.role === userName);
+          return userIsLackingPermission;
         });
       }
       return true;

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -250,9 +250,9 @@ export default class Provisioner {
 
         if (!tableNames.includes(logsTable)) {
           await this.setupPartitionedLogsTable(indexerConfig.userName(), indexerConfig.databaseName(), indexerConfig.schemaName());
-          await this.trackTables(indexerConfig.schemaName(), [logsTable], indexerConfig.databaseName());
-          await this.addPermissionsToTables(indexerConfig.schemaName(), indexerConfig.databaseName(), [logsTable], indexerConfig.userName(), ['select', 'insert', 'update', 'delete']);
         }
+        await this.trackTables(indexerConfig.schemaName(), [logsTable], indexerConfig.databaseName());
+        await this.addPermissionsToTables(indexerConfig.schemaName(), indexerConfig.databaseName(), [logsTable], indexerConfig.userName(), ['select', 'insert', 'update', 'delete']);
       },
       'Failed standalone logs provisioning'
     );
@@ -282,6 +282,8 @@ export default class Provisioner {
           await this.trackTables(indexerConfig.schemaName(), [metadataTable], indexerConfig.databaseName());
           await this.addPermissionsToTables(indexerConfig.schemaName(), indexerConfig.databaseName(), [metadataTable], indexerConfig.userName(), ['select', 'insert', 'update', 'delete']);
         }
+        await this.trackTables(indexerConfig.schemaName(), [metadataTable], indexerConfig.databaseName());
+        await this.addPermissionsToTables(indexerConfig.schemaName(), indexerConfig.databaseName(), [metadataTable], indexerConfig.userName(), ['select', 'insert', 'update', 'delete']);
       },
       'Failed standalone metadata provisioning'
     );

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -290,8 +290,12 @@ export default class Provisioner {
         if (needsTrackingTables.length === 0 && needsPermissionsTables.length === 0) {
           provisioningComplete = true;
         } else {
-          await this.trackTables(indexerConfig.schemaName(), needsTrackingTables, indexerConfig.databaseName());
-          await this.addPermissionsToTables(indexerConfig, needsPermissionsTables, permissionsToAdd);
+          if (needsTrackingTables.length > 0) {
+            await this.trackTables(indexerConfig.schemaName(), needsTrackingTables, indexerConfig.databaseName());
+          }
+          if (needsPermissionsTables.length > 0) {
+            await this.addPermissionsToTables(indexerConfig, needsPermissionsTables, permissionsToAdd);
+          }
         }
       },
       'Failed logs and metadata provisioning'

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -317,9 +317,9 @@ export default class Provisioner {
       if (tablePermissions) {
         return permissionsToCheck.some((permission: string) => {
           const permissionAttribute = `${permission}_permissions` as keyof Omit<HasuraTableMetadata, 'table'>;
-          // Returns true if the table does not have the permission or the user doesn't have the permission
-          const userIsLackingPermission = !tablePermissions[permissionAttribute]?.some((role: { role: string }) => role.role === userName);
-          return userIsLackingPermission;
+          // Returns true if the table does not have the permission or the role doesn't have the permission
+          const roleIsLackingPermission = !tablePermissions[permissionAttribute]?.some((role: { role: string }) => role.role === userName);
+          return roleIsLackingPermission;
         });
       }
       return true;

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -8,6 +8,7 @@ import { logsTableDDL } from './schemas/logs-table';
 import { metadataTableDDL } from './schemas/metadata-table';
 import PgClientClass, { type PostgresConnectionParams } from '../pg-client';
 import type IndexerConfig from '../indexer-config/indexer-config';
+import { METADATA_TABLE_UPSERT, MetadataFields, IndexerStatus } from '../indexer-meta';
 
 const DEFAULT_PASSWORD_LENGTH = 16;
 

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -286,8 +286,6 @@ export default class Provisioner {
           hasuraTablesMetadata,
           permissionsToAdd
         );
-        console.log('needsTrackingTables', needsTrackingTables);
-        console.log('needsPermissionsTables', needsPermissionsTables);
 
         if (needsTrackingTables.length === 0 && needsPermissionsTables.length === 0) {
           provisioningComplete = true;
@@ -332,8 +330,9 @@ export default class Provisioner {
         return permissionsToCheck.some((permission: string) => {
           const permisionAttribute = `${permission}_permissions` as keyof HasuraTableMetadata;
           const usersWithPermission = tablePermissions[permisionAttribute] as (HasuraPermissions | undefined);
-          // Returns true if the table does not have the permission or the user is not in the role
-          return !usersWithPermission?.some((role: { role: string }) => role.role === userName);
+          // Returns true if the table does not have the permission or the user doesn't have the permission
+          const userLackingPermission = !usersWithPermission?.some((role: { role: string }) => role.role === userName);
+          return userLackingPermission;
         });
       }
       return true;

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -263,22 +263,22 @@ export default class Provisioner {
         }
 
         const hasuraTablesMetadata = await this.getTrackedTablesWithPermissions(indexerConfig);
-        const needsTrackingTables = this.getTablesMissingTracking(tableNames, hasuraTablesMetadata);
-        const needsPermissionsTables = this.getTablesMissingPermissions(
+        const untrackedTables = this.getUntrackedTables(tableNames, hasuraTablesMetadata);
+        const tablesWithoutPermissions = this.getTablesWithoutPermissions(
           indexerConfig.hasuraRoleName(),
           tableNames,
           hasuraTablesMetadata,
           permissionsToAdd
         );
 
-        if (needsTrackingTables.length === 0 && needsPermissionsTables.length === 0) {
+        if (untrackedTables.length === 0 && tablesWithoutPermissions.length === 0) {
           provisioningComplete = true;
         } else {
-          if (needsTrackingTables.length > 0) {
-            await this.trackTables(indexerConfig.schemaName(), needsTrackingTables, indexerConfig.databaseName());
+          if (untrackedTables.length > 0) {
+            await this.trackTables(indexerConfig.schemaName(), untrackedTables, indexerConfig.databaseName());
           }
-          if (needsPermissionsTables.length > 0) {
-            await this.addPermissionsToTables(indexerConfig, needsPermissionsTables, permissionsToAdd);
+          if (tablesWithoutPermissions.length > 0) {
+            await this.addPermissionsToTables(indexerConfig, tablesWithoutPermissions, permissionsToAdd);
           }
         }
       },
@@ -302,11 +302,11 @@ export default class Provisioner {
     return trackedTablePermissions;
   }
 
-  private getTablesMissingTracking (shouldBeTrackedTables: string[], tableMetadata: Map<string, any>): string[] {
+  private getUntrackedTables (shouldBeTrackedTables: string[], tableMetadata: Map<string, any>): string[] {
     return shouldBeTrackedTables.filter((tableName: string) => !tableMetadata.has(tableName));
   }
 
-  private getTablesMissingPermissions (
+  private getTablesWithoutPermissions (
     userName: string,
     shouldHavePermissionsTables: string[],
     tableMetadata: Map<string, HasuraTableMetadata>,

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -341,18 +341,18 @@ export default class Provisioner {
         return true;
       }
 
-      return this.roleLacksPermissionsForTable(roleName, tablePermissionsMetadata, permissionsToCheck);
+      return this.tablePermissionsLackRole(roleName, tablePermissionsMetadata, permissionsToCheck);
     });
   }
 
-  private roleLacksPermissionsForTable (roleName: string, tablePermissionsMetadata: HasuraTableMetadata, permissionsToCheck: HasuraPermission[]): boolean {
+  private tablePermissionsLackRole (roleName: string, tablePermissionsMetadata: HasuraTableMetadata, permissionsToCheck: HasuraPermission[]): boolean {
     return permissionsToCheck.some((permission: string) => {
       const permissionAttribute = `${permission}_permissions` as keyof Omit<HasuraTableMetadata, 'table'>;
-      return this.roleLacksPermission(roleName, tablePermissionsMetadata[permissionAttribute]);
+      return this.permissionLacksRole(roleName, tablePermissionsMetadata[permissionAttribute]);
     });
   }
 
-  private roleLacksPermission (roleName: string, tablePermission: HasuraRolePermission[] | undefined): boolean {
+  private permissionLacksRole (roleName: string, tablePermission: HasuraRolePermission[] | undefined): boolean {
     return !tablePermission?.some((roleWithPermission: { role: string }) => roleWithPermission.role === roleName);
   }
 

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -300,11 +300,8 @@ export default class Provisioner {
           hasuraTablesMetadata,
           permissionsToAdd
         );
-        console.log('untrackedTables', untrackedTables);
-        console.log('tablesWithoutPermissions', tablesWithoutPermissions);
 
         if (untrackedTables.length === 0 && tablesWithoutPermissions.length === 0) {
-          console.log('Consistent state achieved');
           this.setConsistentState(indexerConfig.accountId, indexerConfig.functionName);
           return;
         }

--- a/runner/src/stream-handler/stream-handler.ts
+++ b/runner/src/stream-handler/stream-handler.ts
@@ -61,10 +61,10 @@ export default class StreamHandler {
 
     const indexer = new Indexer(this.indexerConfig);
     indexer.setStatus(0, IndexerStatus.STOPPED).catch((e) => {
-      console.error(`Failed to set status STOPPED for stream: ${this.indexerConfig.redisStreamKey}`, e);
+      console.error(`Failed to set status STOPPED for indexer through hasura: ${this.indexerConfig.redisStreamKey}`, e);
     });
     indexer.setStoppedStatus().catch((e) => {
-      console.error(`Failed to set stopped status for stream in Metadata table: ${this.indexerConfig.redisStreamKey}`, e);
+      console.error(`Failed to set stopped status for indexer: ${this.indexerConfig.redisStreamKey}`, e);
     });
 
     const streamErrorLogEntry = LogEntry.systemError(`Encountered error processing stream: ${this.indexerConfig.redisStreamKey}, terminating thread\n${error.toString()}`, this.executorContext.block_height);


### PR DESCRIPTION
Logs Table and Metadata Table are necessary for important functions of QueryApi. Hasura often invisibly fails to track tables and add permissions. These operations need to be successful, so I added a check which verifies tracking and permissions are correct, and reattempts them if not. When successful, the result is cached. In a successful case, the expensive hasura calls (getTableNames and getTrackedTablesWithPermissions) are done at most twice. 

I also combined the conditional provisioning functions since they are verified to work already. 