### PR TITLE
fix: Reduce requests made to Near Lake S3

### DIFF
--- a/block-streamer/Cargo.lock
+++ b/block-streamer/Cargo.lock
@@ -958,6 +958,7 @@ dependencies = [
  "aws-smithy-runtime",
  "aws-smithy-types",
  "borsh 0.10.3",
+ "cached",
  "chrono",
  "futures",
  "http 0.2.12",
@@ -1132,6 +1133,39 @@ dependencies = [
  "cipher",
  "ppv-lite86",
 ]
+
+[[package]]
+name = "cached"
+version = "0.49.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8e463fceca5674287f32d252fb1d94083758b8709c160efae66d263e5f4eba"
+dependencies = [
+ "ahash",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
+ "hashbrown 0.14.3",
+ "instant",
+ "once_cell",
+ "thiserror",
+]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9f16c0d84de31a2ab7fdf5f7783c14631f7075cf464eb3bb43119f61c9cb2a"
+dependencies = [
+ "darling 0.14.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "cached_proc_macro_types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cc"
@@ -2205,6 +2239,15 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
  "serde",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]

--- a/block-streamer/Cargo.toml
+++ b/block-streamer/Cargo.toml
@@ -10,6 +10,7 @@ async-trait = "0.1.74"
 aws-config = { version = "1.1.3", features = ["behavior-version-latest"] }
 aws-sdk-s3 = "1.13.0"
 borsh = "0.10.2"
+cached = "0.49.3"
 chrono = "0.4.25"
 futures = "0.3.5"
 lazy_static = "1.4.0"

--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -47,7 +47,7 @@ impl BlockStream {
         start_block_height: near_indexer_primitives::types::BlockHeight,
         redis_client: std::sync::Arc<crate::redis::RedisClient>,
         delta_lake_client: std::sync::Arc<crate::delta_lake_client::DeltaLakeClient>,
-        lake_s3_client: crate::lake_s3_client::LakeS3Client,
+        lake_s3_client: crate::lake_s3_client::SharedLakeS3Client,
     ) -> anyhow::Result<()> {
         if self.task.is_some() {
             return Err(anyhow::anyhow!("BlockStreamer has already been started",));
@@ -131,7 +131,7 @@ pub(crate) async fn start_block_stream(
     indexer: &IndexerConfig,
     redis_client: std::sync::Arc<crate::redis::RedisClient>,
     delta_lake_client: std::sync::Arc<crate::delta_lake_client::DeltaLakeClient>,
-    lake_s3_client: crate::lake_s3_client::LakeS3Client,
+    lake_s3_client: crate::lake_s3_client::SharedLakeS3Client,
     chain_id: &ChainId,
     lake_prefetch_size: usize,
     redis_stream: String,
@@ -251,7 +251,7 @@ async fn process_delta_lake_blocks(
 
 async fn process_near_lake_blocks(
     start_block_height: near_indexer_primitives::types::BlockHeight,
-    lake_s3_client: crate::lake_s3_client::LakeS3Client,
+    lake_s3_client: crate::lake_s3_client::SharedLakeS3Client,
     lake_prefetch_size: usize,
     redis_client: std::sync::Arc<crate::redis::RedisClient>,
     indexer: &IndexerConfig,
@@ -324,7 +324,7 @@ mod tests {
     #[ignore]
     #[tokio::test]
     async fn adds_matching_blocks_from_index_and_lake() {
-        let mut mock_lake_s3_client = crate::lake_s3_client::LakeS3Client::default();
+        let mut mock_lake_s3_client = crate::lake_s3_client::SharedLakeS3Client::default();
 
         mock_lake_s3_client
             .expect_get_object_bytes()
@@ -413,7 +413,7 @@ mod tests {
     #[ignore]
     #[tokio::test]
     async fn skips_caching_of_lake_block_over_stream_size_limit() {
-        let mock_lake_s3_client = crate::lake_s3_client::LakeS3Client::default();
+        let mock_lake_s3_client = crate::lake_s3_client::SharedLakeS3Client::default();
 
         let mut mock_delta_lake_client = crate::delta_lake_client::DeltaLakeClient::default();
         mock_delta_lake_client

--- a/block-streamer/src/lake_s3_client.rs
+++ b/block-streamer/src/lake_s3_client.rs
@@ -168,7 +168,7 @@ impl LakeS3Client {
     ) -> ListCommonPrefixesResult {
         let response = self
             .s3_client
-            .list_objects(bucket, start_after_prefix, None)
+            .list_objects_after(bucket, start_after_prefix)
             .await?;
 
         let prefixes = match response.common_prefixes {

--- a/block-streamer/src/lake_s3_client.rs
+++ b/block-streamer/src/lake_s3_client.rs
@@ -34,6 +34,7 @@ pub struct SharedLakeS3ClientImpl {
 }
 
 impl SharedLakeS3ClientImpl {
+    #[cfg(test)]
     pub fn new(inner: LakeS3Client) -> Self {
         Self {
             inner: Arc::new(inner),
@@ -249,8 +250,8 @@ mod tests {
 
         let shared_lake_s3_client = SharedLakeS3ClientImpl::new(LakeS3Client::new(mock_s3_client));
 
-        let barrier = Arc::new(Barrier::new(10));
-        let handles: Vec<_> = (0..10)
+        let barrier = Arc::new(Barrier::new(50));
+        let handles: Vec<_> = (0..50)
             .map(|_| {
                 let client = shared_lake_s3_client.clone();
                 let barrier_clone = barrier.clone();

--- a/block-streamer/src/main.rs
+++ b/block-streamer/src/main.rs
@@ -51,7 +51,7 @@ async fn main() -> anyhow::Result<()> {
     let delta_lake_client =
         std::sync::Arc::new(crate::delta_lake_client::DeltaLakeClient::new(s3_client));
 
-    let lake_s3_client = crate::lake_s3_client::LakeS3Client::from_conf(s3_config);
+    let lake_s3_client = crate::lake_s3_client::SharedLakeS3Client::from_conf(s3_config);
 
     tokio::spawn(metrics::init_server(metrics_port).expect("Failed to start metrics server"));
 

--- a/block-streamer/src/metrics.rs
+++ b/block-streamer/src/metrics.rs
@@ -1,13 +1,18 @@
 use actix_web::{get, App, HttpServer, Responder};
 use lazy_static::lazy_static;
 use prometheus::{
-    register_int_counter, register_int_counter_vec, register_int_gauge_vec, Encoder, IntCounter,
-    IntCounterVec, IntGaugeVec,
+    register_histogram, register_int_counter, register_int_counter_vec, register_int_gauge_vec,
+    Encoder, Histogram, IntCounter, IntCounterVec, IntGaugeVec,
 };
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::Layer;
 
 lazy_static! {
+    pub static ref LAKE_CACHE_LOCK_WAIT_SECONDS: Histogram = register_histogram!(
+        "queryapi_block_streamer_lake_cache_lock_wait_seconds",
+        "Time spent waiting for lock acquisition in LakeS3Client cache",
+    )
+    .unwrap();
     pub static ref LAKE_S3_GET_REQUEST_COUNT: IntCounter = register_int_counter!(
         "queryapi_block_streamer_lake_s3_get_request_count",
         "Number of requests made to S3 from near lake framework",

--- a/block-streamer/src/s3_client.rs
+++ b/block-streamer/src/s3_client.rs
@@ -14,7 +14,6 @@ pub struct S3ClientImpl {
     client: aws_sdk_s3::Client,
 }
 
-#[cfg_attr(test, mockall::automock)]
 impl S3ClientImpl {
     pub fn new(s3_config: aws_sdk_s3::Config) -> Self {
         Self {
@@ -118,5 +117,44 @@ impl S3ClientImpl {
         }
 
         Ok(results)
+    }
+}
+
+#[cfg(test)]
+mockall::mock! {
+    #[derive(Debug)]
+    pub S3ClientImpl {
+        pub fn new(s3_config: aws_sdk_s3::Config) -> Self;
+
+        pub async fn get_object(
+            &self,
+            bucket: &str,
+            prefix: &str,
+        ) -> Result<
+            aws_sdk_s3::operation::get_object::GetObjectOutput,
+            aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::get_object::GetObjectError>,
+        >;
+
+        pub async fn list_objects(
+            &self,
+            bucket: &str,
+            prefix: &str,
+            continuation_token: Option<String>,
+        ) -> Result<
+            aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Output,
+            aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Error>,
+        >;
+
+        pub async fn get_text_file(&self, bucket: &str, prefix: &str) -> anyhow::Result<String>;
+
+        pub async fn list_all_objects(
+            &self,
+            bucket: &str,
+            prefix: &str,
+        ) -> anyhow::Result<Vec<String>>;
+    }
+
+    impl Clone for S3ClientImpl {
+        fn clone(&self) -> Self;
     }
 }

--- a/block-streamer/src/s3_client.rs
+++ b/block-streamer/src/s3_client.rs
@@ -40,7 +40,7 @@ impl S3ClientImpl {
     pub async fn list_objects(
         &self,
         bucket: &str,
-        prefix: &str,
+        start_after: &str,
         continuation_token: Option<String>,
     ) -> Result<
         aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Output,
@@ -51,7 +51,7 @@ impl S3ClientImpl {
             .list_objects_v2()
             .delimiter("/")
             .bucket(bucket)
-            .prefix(prefix);
+            .start_after(start_after);
 
         if let Some(token) = continuation_token {
             builder = builder.continuation_token(token);

--- a/block-streamer/src/server/block_streamer_service.rs
+++ b/block-streamer/src/server/block_streamer_service.rs
@@ -15,7 +15,7 @@ use blockstreamer::*;
 pub struct BlockStreamerService {
     redis_client: std::sync::Arc<crate::redis::RedisClient>,
     delta_lake_client: std::sync::Arc<crate::delta_lake_client::DeltaLakeClient>,
-    lake_s3_client: crate::lake_s3_client::LakeS3Client,
+    lake_s3_client: crate::lake_s3_client::SharedLakeS3Client,
     chain_id: ChainId,
     block_streams: Mutex<HashMap<String, block_stream::BlockStream>>,
 }
@@ -24,7 +24,7 @@ impl BlockStreamerService {
     pub fn new(
         redis_client: std::sync::Arc<crate::redis::RedisClient>,
         delta_lake_client: std::sync::Arc<crate::delta_lake_client::DeltaLakeClient>,
-        lake_s3_client: crate::lake_s3_client::LakeS3Client,
+        lake_s3_client: crate::lake_s3_client::SharedLakeS3Client,
     ) -> Self {
         Self {
             redis_client,
@@ -211,10 +211,10 @@ mod tests {
             .expect_xadd::<String, u64>()
             .returning(|_, _| Ok(()));
 
-        let mut mock_lake_s3_client = crate::lake_s3_client::LakeS3Client::default();
+        let mut mock_lake_s3_client = crate::lake_s3_client::SharedLakeS3Client::default();
         mock_lake_s3_client
             .expect_clone()
-            .returning(crate::lake_s3_client::LakeS3Client::default);
+            .returning(crate::lake_s3_client::SharedLakeS3Client::default);
 
         BlockStreamerService::new(
             std::sync::Arc::new(mock_redis_client),

--- a/block-streamer/src/server/mod.rs
+++ b/block-streamer/src/server/mod.rs
@@ -8,7 +8,7 @@ pub async fn init(
     port: &str,
     redis_client: std::sync::Arc<crate::redis::RedisClient>,
     delta_lake_client: std::sync::Arc<crate::delta_lake_client::DeltaLakeClient>,
-    lake_s3_client: crate::lake_s3_client::LakeS3Client,
+    lake_s3_client: crate::lake_s3_client::SharedLakeS3Client,
 ) -> anyhow::Result<()> {
     let addr = format!("0.0.0.0:{}", port).parse()?;
 


### PR DESCRIPTION
Each `BlockStream` uses its own dedicated `near-lake-framework` instance, and hence manages its own connection with S3. This leads to many duplicate S3 requests, particularly across the large majority of Indexers which follow the network tip, which request the same block data at the same time. 

This PR introduces a shared S3 client to be used across all `near-lake-framework` instances. `SharedLakeS3Client` ensures that duplicate requests made within a short time-frame, including those made in parallel, result in only a single request to S3.

## Cache Strategy

This implementation will mostly impact `BlockStream`s following the network tip, i.e. `From Latest`. These streams will wait for new data in Near Lake S3, and request it as soon as it is available, at the same time. Therefore, it would be enough to cache the result alone, by the time we actually prime the cache, all other requests would have missed it and fired a request of their own. Locking while the request is in-flight also is not feasible, as this would force _every_ request to execute in sequence.

Instead of caching the result of the request, we cache its computation. The first request initiates the request and stores its `Future`, then all subsequent requests retrieve that `Future` from cache and `await` its result, ensuring only one underlying request at most.

## Performance Impact

My main concern with this implementation is the impact it will have on performance. Each request made must block to check the cache, introducing contention/delays. The lock is only held while checking the cache, and not while the request is being made, so my hope is that it does not impact too much. This may be something that needs to be iterated over time.

From local testing the impact seemed to be negligible, but that was with 5 Indexers, it may be worse with many. I've added a metric to measure lock wait time, to determine whether this contention is becoming a problem.

