### PR TITLE
fix: Pass startblock regardless of DDL Validation Error

### DIFF
--- a/frontend/src/components/Editor/Editor.jsx
+++ b/frontend/src/components/Editor/Editor.jsx
@@ -235,6 +235,13 @@ const Editor = ({ actionButtonText }) => {
     )[1];
     indexerName = indexerName.replaceAll(" ", "_");
 
+    const startBlock =
+    indexerConfig.startBlock === "startBlockHeight"
+      ? { HEIGHT: indexerConfig.height }
+      : indexerConfig.startBlock === "startBlockLatest"
+      ? "LATEST"
+      : "CONTINUE";  
+
     if (schemaValidationError?.type === FORMATTING_ERROR_TYPE) {
       setError(SCHEMA_FORMATTING_ERROR_MESSAGE);
       return;
@@ -243,21 +250,10 @@ const Editor = ({ actionButtonText }) => {
         indexerName,
         code: innerCode,
         schema: validatedSchema,
-        blockHeight: indexerConfig.startBlockHeight,
+        startBlock,
         contractFilter: indexerConfig.filter,
       });
       return;
-    }
-
-    let startBlock = null;
-    if (indexerConfig.startBlock === "startBlockHeight") {
-      startBlock = {
-        HEIGHT: indexerConfig.height
-      };
-    } else if (indexerConfig.startBlock === "startBlockLatest") {
-      startBlock = "LATEST";
-    } else {
-      startBlock = "CONTINUE"
     }
 
     request("register-function", {


### PR DESCRIPTION
Passes startblock regardless if DDL Validation Error or not.

The culprit seems to be when we bypass the ddl Validation Error.
` There was an error while generating types for your SQL schema. Please ensure your schema is valid SQL DDL.`

If the SQL schema is valid we generate the start_block. If its not, we use a modal with obj and did not pass in the startblock k/v pair. The modal never had the start_block param. 