### PR TITLE
fix: Add rollout provisioning through redis whitelist

### DIFF
--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -78,7 +78,8 @@ export default class Indexer {
   }
 
   async execute (
-    block: lakePrimitives.Block
+    block: lakePrimitives.Block,
+    whiteList: string[] = [],
   ): Promise<string[]> {
     const blockHeight: number = block.blockHeight;
 
@@ -103,8 +104,10 @@ export default class Indexer {
           const provisionSuccessLogEntry = LogEntry.systemInfo('Provisioning endpoint: successful', blockHeight);
           logEntries.push(provisionSuccessLogEntry);
         }
-        await this.deps.provisioner.provisionLogsAndMetadataIfNeeded(this.indexerConfig);
-        await this.deps.provisioner.ensureConsistentHasuraState(this.indexerConfig);
+        if (whiteList.length === 0 || whiteList.includes(this.indexerConfig.accountId)) {
+          await this.deps.provisioner.provisionLogsAndMetadataIfNeeded(this.indexerConfig);
+          await this.deps.provisioner.ensureConsistentHasuraState(this.indexerConfig);
+        }
       } catch (e) {
         const error = e as Error;
         if (this.IS_FIRST_EXECUTION) {

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -367,9 +367,9 @@ export default class Provisioner {
 
           await this.createSchema(databaseName, schemaName);
 
-          // await this.createMetadataTable(databaseName, schemaName);
-          // await this.setProvisioningStatus(userName, schemaName);
-          // await this.setupPartitionedLogsTable(userName, databaseName, schemaName);
+          await this.createMetadataTable(databaseName, schemaName);
+          await this.setProvisioningStatus(userName, schemaName);
+          await this.setupPartitionedLogsTable(userName, databaseName, schemaName);
           await this.runIndexerSql(databaseName, schemaName, indexerConfig.schema);
 
           const updatedTableNames = await this.getTableNames(schemaName, databaseName);

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -367,9 +367,9 @@ export default class Provisioner {
 
           await this.createSchema(databaseName, schemaName);
 
-          await this.createMetadataTable(databaseName, schemaName);
-          await this.setProvisioningStatus(userName, schemaName);
-          await this.setupPartitionedLogsTable(userName, databaseName, schemaName);
+          // await this.createMetadataTable(databaseName, schemaName);
+          // await this.setProvisioningStatus(userName, schemaName);
+          // await this.setupPartitionedLogsTable(userName, databaseName, schemaName);
           await this.runIndexerSql(databaseName, schemaName, indexerConfig.schema);
 
           const updatedTableNames = await this.getTableNames(schemaName, databaseName);

--- a/runner/src/redis-client/redis-client.ts
+++ b/runner/src/redis-client/redis-client.ts
@@ -30,6 +30,10 @@ export default class RedisClient {
     await this.client.disconnect();
   }
 
+  async getWhiteList (): Promise<string[]> {
+    return await this.client.sMembers('whitelist_accounts');
+  }
+
   async getStreamMessages (
     streamKey: string,
     streamId = this.SMALLEST_STREAM_ID,

--- a/runner/src/stream-handler/worker.ts
+++ b/runner/src/stream-handler/worker.ts
@@ -138,7 +138,8 @@ async function blockQueueConsumer (workerContext: WorkerContext): Promise<void> 
 
         await tracer.startActiveSpan(`Process Block ${currBlockHeight}`, async (executeSpan: Span) => {
           try {
-            await indexer.execute(block);
+            const whitelist = await workerContext.redisClient.getWhiteList();
+            await indexer.execute(block, whitelist);
           } finally {
             executeSpan.end();
           }
@@ -191,4 +192,3 @@ async function generateQueuePromise (workerContext: WorkerContext, blockHeight: 
     streamMessageId
   };
 }
-


### PR DESCRIPTION
Adding a rollout for provisioning of logs and metadata table for existing users to soften prod release impact. Provisioning has been observed to use many DB connections on startup. 