### PR TITLE
fix: Remove custom lake s3 client entirely

### DIFF
--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -264,7 +264,6 @@ async fn process_near_lake_blocks(
         ChainId::Mainnet => near_lake_framework::LakeConfigBuilder::default().mainnet(),
         ChainId::Testnet => near_lake_framework::LakeConfigBuilder::default().testnet(),
     }
-    .s3_client(lake_s3_client)
     .start_block_height(start_block_height)
     .blocks_preload_pool_size(lake_prefetch_size)
     .build()

--- a/block-streamer/src/lake_s3_client.rs
+++ b/block-streamer/src/lake_s3_client.rs
@@ -51,8 +51,7 @@ impl SharedLakeS3ClientImpl {
 #[async_trait]
 impl near_lake_framework::s3_client::S3Client for SharedLakeS3ClientImpl {
     async fn get_object_bytes(&self, bucket: &str, prefix: &str) -> GetObjectBytesResult {
-        // TODO: Re-enable cache implementation once better locking strategy is implemented
-        self.inner.get_object_bytes_shared(bucket, prefix).await
+        self.inner.get_object_bytes_cached(bucket, prefix).await
     }
 
     async fn list_common_prefixes(
@@ -233,7 +232,6 @@ mod tests {
     use aws_sdk_s3::types::error::NoSuchKey;
     use near_lake_framework::s3_client::S3Client;
 
-    #[ignore]
     #[tokio::test]
     async fn deduplicates_parallel_requests() {
         let s3_get_call_count = Arc::new(AtomicUsize::new(0));
@@ -280,7 +278,6 @@ mod tests {
         assert_eq!(s3_get_call_count.load(Ordering::SeqCst), 1);
     }
 
-    #[ignore]
     #[tokio::test]
     async fn caches_requests() {
         let mut mock_s3_client = crate::s3_client::S3Client::default();


### PR DESCRIPTION
My previous PR still maintained the shared client, which used shared
futures under the hood, but this created a lot of overhead, so I'm
removing the shared client entirely.
