### PR TITLE
fix: Close pg pools when finished provisioning

### DIFF
--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -948,7 +948,7 @@ describe('Indexer unit tests', () => {
     await indexer.execute(mockBlock);
 
     expect(provisioner.fetchUserApiProvisioningStatus).toHaveBeenCalledWith(simpleSchemaConfig);
-    expect(indexerMeta.setStatus).toHaveBeenNthCalledWith(2, IndexerStatus.RUNNING);
+    expect(indexerMeta.setStatus).toHaveBeenNthCalledWith(1, IndexerStatus.RUNNING);
     expect(provisioner.provisionUserApi).toHaveBeenCalledTimes(1);
     expect(provisioner.provisionUserApi).toHaveBeenCalledWith(simpleSchemaConfig);
     expect(provisioner.provisionLogsAndMetadataIfNeeded).toHaveBeenCalledTimes(1);

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -94,7 +94,6 @@ export default class Indexer {
 
       try {
         if (!await this.deps.provisioner.fetchUserApiProvisioningStatus(this.indexerConfig)) {
-          await this.setStatus(IndexerStatus.PROVISIONING);
           logEntries.push(LogEntry.systemInfo('Provisioning endpoint: starting', blockHeight));
           await this.deps.provisioner.provisionUserApi(this.indexerConfig);
           logEntries.push(LogEntry.systemInfo('Provisioning endpoint: successful', blockHeight));

--- a/runner/src/pg-client.ts
+++ b/runner/src/pg-client.ts
@@ -37,6 +37,10 @@ export default class PgClient {
     this.format = pgFormat;
   }
 
+  async end (): Promise<void> {
+    await this.pgPool.end();
+  }
+
   async query<R extends QueryResultRow = any>(query: string, params: any[] = []): Promise<QueryResult<R>> {
     // Automatically manages client connections to pool
     return await this.pgPool.query<R>(query, params);

--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -51,16 +51,19 @@ describe('Provisioner', () => {
 
     adminPgClient = {
       query: jest.fn().mockReturnValue(null),
+      end: jest.fn()
     };
 
     cronPgClient = {
       query: jest.fn().mockReturnValue(null),
+      end: jest.fn()
     };
 
     userPgClientQuery = jest.fn().mockReturnValue(null);
     const PgClient = jest.fn().mockImplementation(() => {
       return {
         query: userPgClientQuery,
+        end: jest.fn()
       };
     });
 

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -140,6 +140,8 @@ export default class Provisioner {
             databaseName
           )
         );
+
+        await userCronPgClient.end();
       },
       'Failed to schedule log partition jobs'
     );
@@ -208,7 +210,10 @@ export default class Provisioner {
     await wrapError(async () => {
       const userDbConnectionParameters = await this.getPostgresConnectionParameters(userName);
       const userPgClient = new this.PgClient(userDbConnectionParameters);
+
       await userPgClient.query(pgFormatLib(METADATA_TABLE_UPSERT, schemaName, [[MetadataFields.STATUS, IndexerStatus.PROVISIONING]]));
+
+      await userPgClient.end();
     }, 'Failed to set provisioning status on metadata table');
   }
 


### PR DESCRIPTION
We create transient pg pools during provisioning, this closes them when finished to ensure we free up the connections.