### PR TITLE
fix: Target logs/metadata tables only for Hasura state check

### DIFF
--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -254,7 +254,6 @@ describe('Provisioner', () => {
     });
 
     it('ensuring consistent state tracks logs and metadata table once, adds permissions twice', async () => {
-      hasuraClient.getTableNames = jest.fn().mockReturnValue(['blocks', 'sys_logs', 'sys_metadata']);
       hasuraClient.getTrackedTablePermissions = jest.fn()
         .mockReturnValueOnce([
           generateTableConfig('morgs_near_test_function', 'blocks', 'morgs_near', ['select', 'insert', 'update', 'delete']),
@@ -267,13 +266,11 @@ describe('Provisioner', () => {
       await provisioner.ensureConsistentHasuraState(indexerConfig);
       await provisioner.ensureConsistentHasuraState(indexerConfig);
 
-      expect(hasuraClient.getTableNames).toBeCalledTimes(2);
       expect(hasuraClient.trackTables).toBeCalledTimes(1);
       expect(hasuraClient.addPermissionsToTables).toBeCalledTimes(2);
     });
 
     it('ensuring consistent state caches result', async () => {
-      hasuraClient.getTableNames = jest.fn().mockReturnValue(['blocks', 'sys_logs', 'sys_metadata']);
       hasuraClient.getTrackedTablePermissions = jest.fn().mockReturnValue([
         generateTableConfig('morgs_near_test_function', 'blocks', 'morgs_near', ['select', 'insert', 'update', 'delete']),
         generateTableConfig('morgs_near_test_function', 'sys_logs', 'morgs_near', ['select', 'insert', 'update', 'delete']),
@@ -282,7 +279,6 @@ describe('Provisioner', () => {
       await provisioner.ensureConsistentHasuraState(indexerConfig);
       await provisioner.ensureConsistentHasuraState(indexerConfig);
 
-      expect(hasuraClient.getTableNames).toBeCalledTimes(1);
       expect(hasuraClient.trackTables).not.toBeCalled();
       expect(hasuraClient.addPermissionsToTables).not.toBeCalled();
       expect(userPgClientQuery).not.toBeCalled();

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -279,7 +279,7 @@ export default class Provisioner {
   }
 
   /**
-    * Tracks and adds permissions to any Postgres tables successfully created in schema and which lack tracking and/or permissions.
+    * Tracks and adds permissions for successfully created sys_logs and sys_metadata tables in schema which lack tracking and/or permissions.
     *
     * */
   async ensureConsistentHasuraState (indexerConfig: IndexerConfig): Promise<void> {
@@ -288,7 +288,7 @@ export default class Provisioner {
     }
     await wrapError(
       async () => {
-        const tableNamesToCheck = await this.getTableNames(indexerConfig.schemaName(), indexerConfig.databaseName());
+        const tableNamesToCheck = ['sys_logs', 'sys_metadata'];
         const permissionsToAdd: HasuraPermission[] = ['select', 'insert', 'update', 'delete'];
 
         const hasuraTablesMetadata = await this.getTrackedTablesWithPermissions(indexerConfig);

--- a/runner/src/stream-handler/worker.ts
+++ b/runner/src/stream-handler/worker.ts
@@ -192,4 +192,3 @@ async function generateQueuePromise (workerContext: WorkerContext, blockHeight: 
     streamMessageId
   };
 }
-


### PR DESCRIPTION
Some indexers in prod, such as dataplatform.near/social_feed can have tables in the Indexer which should only have select permissions, rather than all permissions. Ensure Hasura State currently ignores which permissions are missing and instead simply tries to add all permissions for the user role. This causes problems. For the time being, I will have the function target the logs and metadata specifically. 