### PR TITLE
fix: Stable hasura state fix

### DIFF
--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -264,7 +264,7 @@ async fn process_near_lake_blocks(
         ChainId::Mainnet => near_lake_framework::LakeConfigBuilder::default().mainnet(),
         ChainId::Testnet => near_lake_framework::LakeConfigBuilder::default().testnet(),
     }
-    .s3_client(lake_s3_client)
+    // .s3_client(lake_s3_client)
     .start_block_height(start_block_height)
     .blocks_preload_pool_size(lake_prefetch_size)
     .build()

--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -251,7 +251,6 @@ describe('Provisioner', () => {
     });
 
     it('ensuring consistent state tracks logs and metadata table once, adds permissions twice', async () => {
-      hasuraClient.getTableNames = jest.fn().mockReturnValue(['blocks', 'sys_logs', 'sys_metadata']);
       hasuraClient.getTrackedTablePermissions = jest.fn()
         .mockReturnValueOnce([
           generateTableConfig('morgs_near_test_function', 'blocks', 'morgs_near', ['select', 'insert', 'update', 'delete']),
@@ -264,13 +263,11 @@ describe('Provisioner', () => {
       await provisioner.ensureConsistentHasuraState(indexerConfig);
       await provisioner.ensureConsistentHasuraState(indexerConfig);
 
-      expect(hasuraClient.getTableNames).toBeCalledTimes(2);
       expect(hasuraClient.trackTables).toBeCalledTimes(1);
       expect(hasuraClient.addPermissionsToTables).toBeCalledTimes(2);
     });
 
     it('ensuring consistent state caches result', async () => {
-      hasuraClient.getTableNames = jest.fn().mockReturnValue(['blocks', 'sys_logs', 'sys_metadata']);
       hasuraClient.getTrackedTablePermissions = jest.fn().mockReturnValue([
         generateTableConfig('morgs_near_test_function', 'blocks', 'morgs_near', ['select', 'insert', 'update', 'delete']),
         generateTableConfig('morgs_near_test_function', 'sys_logs', 'morgs_near', ['select', 'insert', 'update', 'delete']),
@@ -279,7 +276,6 @@ describe('Provisioner', () => {
       await provisioner.ensureConsistentHasuraState(indexerConfig);
       await provisioner.ensureConsistentHasuraState(indexerConfig);
 
-      expect(hasuraClient.getTableNames).toBeCalledTimes(1);
       expect(hasuraClient.trackTables).not.toBeCalled();
       expect(hasuraClient.addPermissionsToTables).not.toBeCalled();
       expect(userPgClientQuery).not.toBeCalled();

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -283,7 +283,7 @@ export default class Provisioner {
     }
     await wrapError(
       async () => {
-        const tableNamesToCheck = await this.getTableNames(indexerConfig.schemaName(), indexerConfig.databaseName());
+        const tableNamesToCheck = ['sys_logs', 'sys_metadata'];
         const permissionsToAdd: HasuraPermission[] = ['select', 'insert', 'update', 'delete'];
 
         const hasuraTablesMetadata = await this.getTrackedTablesWithPermissions(indexerConfig);


### PR DESCRIPTION
Not intended for actual merge. I will instead grab the commit hash and use it in prod runner. This is to side step having to force push commit history in the prod release but still have this fix in place. 