### PR TITLE
fix: Remove release whitelist from code

### DIFF
--- a/runner/src/redis-client/redis-client.ts
+++ b/runner/src/redis-client/redis-client.ts
@@ -30,10 +30,6 @@ export default class RedisClient {
     await this.client.disconnect();
   }
 
-  async getWhiteList (): Promise<string[]> {
-    return await this.client.sMembers('whitelist_accounts');
-  }
-
   async getStreamMessages (
     streamKey: string,
     streamId = this.SMALLEST_STREAM_ID,

--- a/runner/src/stream-handler/worker.ts
+++ b/runner/src/stream-handler/worker.ts
@@ -138,8 +138,7 @@ async function blockQueueConsumer (workerContext: WorkerContext): Promise<void> 
 
         await tracer.startActiveSpan(`Process Block ${currBlockHeight}`, async (executeSpan: Span) => {
           try {
-            const whitelist = await workerContext.redisClient.getWhiteList();
-            await indexer.execute(block, whitelist);
+            await indexer.execute(block);
           } finally {
             executeSpan.end();
           }


### PR DESCRIPTION
Production has fully rolled out the new provisioning of logs/metadata. As a result, whitelist is no longer necessary. 