### PR TITLE
fix: Use Sanitized strings when constructing logs graphQL query

### DIFF
--- a/frontend/src/components/Logs/IndexerLogs.jsx
+++ b/frontend/src/components/Logs/IndexerLogs.jsx
@@ -18,24 +18,6 @@ const IndexerLogsComponent = () => {
   const schemaName = functionName.replace(/[^a-zA-Z0-9]/g, '_').replace(/^([0-9])/, '_$1');
   const tableName = `${schemaName}_sys_logs`;
 
-  console.log('GET_INDEXER_LOGS:', `
-  query GetIndexerLogs($limit: Int, $offset: Int) {
-    ${tableName}(limit: $limit, offset: $offset, order_by: {timestamp: desc}) {
-      block_height
-      date
-      id
-      level
-      message
-      timestamp
-      type
-    }
-    ${tableName}_aggregate {
-      aggregate {
-        count
-      }
-    }
-  }
-`);
   const GET_INDEXER_LOGS = gql`
     query GetIndexerLogs($limit: Int, $offset: Int) {
       ${tableName}(limit: $limit, offset: $offset, order_by: {timestamp: desc}) {

--- a/frontend/src/components/Logs/IndexerLogs.jsx
+++ b/frontend/src/components/Logs/IndexerLogs.jsx
@@ -15,7 +15,7 @@ const IndexerLogsComponent = () => {
   const sanitizedAccountId = indexerDetails.accountId.replace(/[^a-zA-Z0-9]/g, '_').replace(/^([0-9])/, '_$1');
   const sanitizedIndexerName = indexerDetails.indexerName.replace(/[^a-zA-Z0-9]/g, '_').replace(/^([0-9])/, '_$1');
   const functionName = `${sanitizedAccountId}/${sanitizedIndexerName}`;
-  const schemaName = functionName.replace(/[^a-zA-Z0-9]/g, '_').replace(/^([0-9])/, '_$1');
+  const schemaName = `${sanitizedAccountId}_${sanitizedIndexerName}`;
   const tableName = `${schemaName}_sys_logs`;
 
   const GET_INDEXER_LOGS = gql`


### PR DESCRIPTION
Logs GraphQL query was using unsanitized account and indexer names. This will fail during construction causing the page to fail to load. I've used sanitized strings which fixes the issue. 