### PR TITLE
fix: Remove hasura execution hooks

### DIFF
--- a/runner/src/indexer/indexer.test.ts
+++ b/runner/src/indexer/indexer.test.ts
@@ -951,8 +951,8 @@ describe('Indexer unit tests', () => {
     expect(indexerMeta.setStatus).toHaveBeenNthCalledWith(1, IndexerStatus.RUNNING);
     expect(provisioner.provisionUserApi).toHaveBeenCalledTimes(1);
     expect(provisioner.provisionUserApi).toHaveBeenCalledWith(simpleSchemaConfig);
-    expect(provisioner.provisionLogsAndMetadataIfNeeded).toHaveBeenCalledTimes(1);
-    expect(provisioner.ensureConsistentHasuraState).toHaveBeenCalledTimes(1);
+    // expect(provisioner.provisionLogsAndMetadataIfNeeded).toHaveBeenCalledTimes(1);
+    // expect(provisioner.ensureConsistentHasuraState).toHaveBeenCalledTimes(1);
     expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
   });
 
@@ -991,8 +991,8 @@ describe('Indexer unit tests', () => {
 
     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
     expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
-    expect(provisioner.provisionLogsAndMetadataIfNeeded).toHaveBeenCalledTimes(1);
-    expect(provisioner.ensureConsistentHasuraState).toHaveBeenCalledTimes(1);
+    // expect(provisioner.provisionLogsAndMetadataIfNeeded).toHaveBeenCalledTimes(1);
+    // expect(provisioner.ensureConsistentHasuraState).toHaveBeenCalledTimes(1);
   });
 
   test('Indexer.execute() skips database credentials fetch second time onward', async () => {
@@ -1037,8 +1037,8 @@ describe('Indexer unit tests', () => {
 
     expect(provisioner.provisionUserApi).not.toHaveBeenCalled();
     expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
-    expect(provisioner.provisionLogsAndMetadataIfNeeded).toHaveBeenCalled();
-    expect(provisioner.ensureConsistentHasuraState).toHaveBeenCalled();
+    // expect(provisioner.provisionLogsAndMetadataIfNeeded).toHaveBeenCalled();
+    // expect(provisioner.ensureConsistentHasuraState).toHaveBeenCalled();
     expect(indexerMeta.setStatus).toHaveBeenCalledTimes(1); // Status is cached, so only called once
     expect(indexerMeta.setStatus).toHaveBeenCalledWith(IndexerStatus.RUNNING);
     expect(indexerMeta.updateBlockHeight).toHaveBeenCalledTimes(3);
@@ -1091,8 +1091,8 @@ describe('Indexer unit tests', () => {
     expect(indexerMeta.setStatus).toHaveBeenNthCalledWith(1, IndexerStatus.RUNNING);
     expect(mockFetch.mock.calls).toMatchSnapshot();
     expect(provisioner.getPgBouncerConnectionParameters).toHaveBeenCalledTimes(1);
-    expect(provisioner.provisionLogsAndMetadataIfNeeded).toHaveBeenCalledTimes(1);
-    expect(provisioner.ensureConsistentHasuraState).toHaveBeenCalledTimes(1);
+    // expect(provisioner.provisionLogsAndMetadataIfNeeded).toHaveBeenCalledTimes(1);
+    // expect(provisioner.ensureConsistentHasuraState).toHaveBeenCalledTimes(1);
     expect(indexerMeta.updateBlockHeight).toHaveBeenCalledWith(blockHeight);
   });
 

--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -95,8 +95,8 @@ export default class Indexer {
           await this.deps.provisioner.provisionUserApi(this.indexerConfig);
           logEntries.push(LogEntry.systemInfo('Provisioning endpoint: successful', blockHeight));
         }
-        await this.deps.provisioner.provisionLogsAndMetadataIfNeeded(this.indexerConfig);
-        await this.deps.provisioner.ensureConsistentHasuraState(this.indexerConfig);
+        // await this.deps.provisioner.provisionLogsAndMetadataIfNeeded(this.indexerConfig);
+        // await this.deps.provisioner.ensureConsistentHasuraState(this.indexerConfig);
       } catch (e) {
         const error = e as Error;
         if (this.IS_FIRST_EXECUTION) {


### PR DESCRIPTION
On Runner start up, _all_ executors call Hasura, overloading Hasura and eventually causing failures. This PR temp removes these calls to avoid the thundering herd.