### PR TITLE
fix: Reduce lock contention in Lake Cache

### DIFF
--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -264,6 +264,7 @@ async fn process_near_lake_blocks(
         ChainId::Mainnet => near_lake_framework::LakeConfigBuilder::default().mainnet(),
         ChainId::Testnet => near_lake_framework::LakeConfigBuilder::default().testnet(),
     }
+    .s3_client(lake_s3_client)
     .start_block_height(start_block_height)
     .blocks_preload_pool_size(lake_prefetch_size)
     .build()


### PR DESCRIPTION
This PR addresses significant lock contention issues within the Lake Cache by replacing the `tokio::sync::Mutex` with `std::sync::Mutex`. The use of an asynchronous mutex exacerbated contention in our highly concurrent environment. Specifically, `tokio::sync::Mutex` yielding when the lock is unavailable, leads to all tasks requiring the lock to enter a repetitive cycle of acquisition attempts, failures, and subsequent yields. When the lock becomes available, all waiting tasks wake simultaneously, attempt to re-acquire the lock, and yield again if unsuccessful. This behaviour results in substantial scheduling overhead.

Switching to `std::sync::Mutex` alters this dynamic by blocking the thread attempting to acquire the lock, rather than merely yielding control. This change simplifies the lock acquisition process by eliminating the need to wake multiple tasks. Instead, the OS scheduler directly allocates the lock to one of the waiting threads when it becomes available. This approach reduces the complexity and overhead introduced by the task scheduler, enhancing performance and reliability under high contention.