### PR TITLE
feat: Store Forked Indexer when Publishing

### DIFF
--- a/frontend/src/components/Editor/Editor.jsx
+++ b/frontend/src/components/Editor/Editor.jsx
@@ -234,8 +234,10 @@ const Editor = ({ actionButtonText }) => {
       /getBlock\s*\([^)]*\)\s*{([\s\S]*)}/
     )[1];
     indexerName = indexerName.replaceAll(" ", "_");
-    let forkedAccountId = indexerDetails.forkedAccountId;
-    let forkedIndexerName = indexerDetails.forkedIndexerName;
+    let forkedFrom = 
+      (indexerDetails.forkedAccountId && indexerDetails.forkedIndexerName)
+      ? { account_id: indexerDetails.forkedAccountId, function_name: indexerDetails.forkedIndexerName }
+      : null;
 
     const startBlock =
     indexerConfig.startBlock === "startBlockHeight"
@@ -254,18 +256,18 @@ const Editor = ({ actionButtonText }) => {
         schema: validatedSchema,
         startBlock,
         contractFilter: indexerConfig.filter,
+        forkedFrom,
       });
       return;
     }
 
     request("register-function", {
       indexerName: indexerName,
-      forkedAccountId: forkedAccountId,
-      forkedIndexerName: forkedIndexerName,
       code: innerCode,
       schema: validatedSchema,
       startBlock,
       contractFilter: indexerConfig.filter,
+      ...(forkedFrom && { forkedFrom })
     });
 
     setShowPublishModal(false);

--- a/frontend/src/components/Editor/Editor.jsx
+++ b/frontend/src/components/Editor/Editor.jsx
@@ -220,6 +220,7 @@ const Editor = ({ actionButtonText }) => {
   };
 
   const registerFunction = async (indexerName, indexerConfig) => {
+    console.log('forked indexer:', indexerDetails.forkedAccountId, indexerDetails.forkedIndexerName);
     const { data: validatedSchema, error: schemaValidationError } =
       validateSQLSchema(schema);
     const { data: validatedCode, error: codeValidationError } =
@@ -234,6 +235,8 @@ const Editor = ({ actionButtonText }) => {
       /getBlock\s*\([^)]*\)\s*{([\s\S]*)}/
     )[1];
     indexerName = indexerName.replaceAll(" ", "_");
+    let forkedAccountId = indexerDetails.forkedAccountId;
+    let forkedIndexerName = indexerDetails.forkedIndexerName;
 
     const startBlock =
     indexerConfig.startBlock === "startBlockHeight"
@@ -258,6 +261,8 @@ const Editor = ({ actionButtonText }) => {
 
     request("register-function", {
       indexerName: indexerName,
+      forkedAccountId: forkedAccountId,
+      forkedIndexerName: forkedIndexerName,
       code: innerCode,
       schema: validatedSchema,
       startBlock,

--- a/frontend/src/components/Editor/Editor.jsx
+++ b/frontend/src/components/Editor/Editor.jsx
@@ -220,7 +220,6 @@ const Editor = ({ actionButtonText }) => {
   };
 
   const registerFunction = async (indexerName, indexerConfig) => {
-    console.log('forked indexer:', indexerDetails.forkedAccountId, indexerDetails.forkedIndexerName);
     const { data: validatedSchema, error: schemaValidationError } =
       validateSQLSchema(schema);
     const { data: validatedCode, error: codeValidationError } =

--- a/frontend/src/components/Modals/ForkIndexerModal.jsx
+++ b/frontend/src/components/Modals/ForkIndexerModal.jsx
@@ -10,6 +10,8 @@ export const ForkIndexerModal = ({ registerFunction, forkIndexer }) => {
     setShowForkIndexerModal,
     setIsCreateNewIndexer,
     setIndexerName,
+    setForkedAccountId,
+    setForkedIndexerName,
     setIndexerConfig,
     isCreateNewIndexer,
   } = useContext(IndexerDetailsContext);
@@ -31,6 +33,8 @@ export const ForkIndexerModal = ({ registerFunction, forkIndexer }) => {
 
     setError(null);
     setIndexerName(indexerName);
+    setForkedAccountId(indexerDetails.accountId);
+    setForkedIndexerName(indexerDetails.indexerName);
     setIsCreateNewIndexer(true);
     forkIndexer(indexerName);
     setShowForkIndexerModal(false);

--- a/frontend/src/components/Modals/PublishModal.jsx
+++ b/frontend/src/components/Modals/PublishModal.jsx
@@ -9,6 +9,7 @@ export const PublishModal = ({
   actionButtonText,
 }) => {
   const {
+    indexerDetails,
     showPublishModal,
     setShowPublishModal,
   } = useContext(IndexerDetailsContext);

--- a/frontend/src/contexts/IndexerDetailsContext.js
+++ b/frontend/src/contexts/IndexerDetailsContext.js
@@ -74,8 +74,8 @@ export const IndexerDetailsProvider = ({ children }) => {
       const details = {
         accountId: accountId,
         indexerName: indexerName,
-        forkedAccountId: data.forkedAccountId,
-        forkedIndexerName: data.forkedIndexerName,
+        forkedAccountId: data.forked_from?.account_id,
+        forkedIndexerName: data.forked_from?.function_name,
         code: wrapCode(data.code),
         schema: data.schema,
         startBlock: data.start_block,

--- a/frontend/src/contexts/IndexerDetailsContext.js
+++ b/frontend/src/contexts/IndexerDetailsContext.js
@@ -22,7 +22,7 @@ import { getLatestBlockHeight } from "../utils/getLatestBlockHeight";
 // }
 
 export const IndexerDetailsContext = React.createContext({
-  indexerDetails: { code: undefined, schema: undefined, rule: { affected_account_id: "social.near" }, startBlock: "LATEST", accountId: "", indexerName: "" },
+  indexerDetails: { code: undefined, schema: undefined, rule: { affected_account_id: "social.near" }, startBlock: "LATEST", accountId: "", indexerName: "", forkedAccountId: null, forkedIndexerName: null },
   showResetCodeModel: false,
   setShowResetCodeModel: () => { },
   showPublishModal: false,
@@ -39,6 +39,10 @@ export const IndexerDetailsContext = React.createContext({
   setAccountId: () => { },
   indexerName: undefined,
   setIndexerName: () => { },
+  forkedAccountId: undefined,
+  setForkedAccountId: () => { }, 
+  forkedIndexerName: undefined,
+  setForkedIndexerName: () => { },
   setIndexerDetails: () => { },
   showLogsView: false,
   setShowLogsView: () => { },
@@ -47,7 +51,9 @@ export const IndexerDetailsContext = React.createContext({
 export const IndexerDetailsProvider = ({ children }) => {
   const [accountId, setAccountId] = useState(undefined);
   const [indexerName, setIndexerName] = useState(undefined);
-  const [indexerDetails, setIndexerDetails] = useState({ code: undefined, schema: undefined, rule: { affected_account_id: "social.near" }, startBlock: "LATEST", accountId: accountId, indexerName: indexerName })
+  const [forkedAccountId, setForkedAccountId] = useState(undefined);
+  const [forkedIndexerName, setForkedIndexerName] = useState(undefined);
+  const [indexerDetails, setIndexerDetails] = useState({ code: undefined, schema: undefined, rule: { affected_account_id: "social.near" }, startBlock: "LATEST", accountId: accountId, indexerName: indexerName, forkedAccountId: forkedAccountId, forkedIndexerName: forkedIndexerName })
   const [showResetCodeModel, setShowResetCodeModel] = useState(false);
   const [showPublishModal, setShowPublishModal] = useState(false);
   const [showForkIndexerModal, setShowForkIndexerModal] = useState(false);
@@ -68,6 +74,8 @@ export const IndexerDetailsProvider = ({ children }) => {
       const details = {
         accountId: accountId,
         indexerName: indexerName,
+        forkedAccountId: data.forkedAccountId,
+        forkedIndexerName: data.forkedIndexerName,
         code: wrapCode(data.code),
         schema: data.schema,
         startBlock: data.start_block,
@@ -89,6 +97,8 @@ export const IndexerDetailsProvider = ({ children }) => {
         ...prevDetails,
         accountId: accountId,
         indexerName: indexerName,
+        forkedAccountId: forkedAccountId,
+        forkedIndexerName: forkedIndexerName,
       }));
       return
     }
@@ -97,6 +107,8 @@ export const IndexerDetailsProvider = ({ children }) => {
       const details = {
         accountId: indexer.accountId,
         indexerName: indexer.indexerName,
+        forkedAccountId: indexer.forkedAccountId,
+        forkedIndexerName: indexer.forkedIndexerName,
         code: indexer.code,
         schema: indexer.schema,
         startBlock: indexer.startBlock,
@@ -105,7 +117,7 @@ export const IndexerDetailsProvider = ({ children }) => {
       setIndexerDetails(details);
     })();
 
-  }, [accountId, indexerName, isCreateNewIndexer]);
+  }, [accountId, indexerName, forkedAccountId, forkedIndexerName, isCreateNewIndexer]);
 
   return (
     <IndexerDetailsContext.Provider
@@ -114,6 +126,8 @@ export const IndexerDetailsProvider = ({ children }) => {
         indexerName,
         setAccountId,
         setIndexerName,
+        setForkedAccountId,
+        setForkedIndexerName,
         indexerDetails,
         showResetCodeModel,
         setShowResetCodeModel,

--- a/frontend/widgets/src/QueryApi.Editor.jsx
+++ b/frontend/widgets/src/QueryApi.Editor.jsx
@@ -28,8 +28,8 @@ const registerFunctionHandler = (request, response) => {
     "register",
     {
       function_name: indexerName,
-      forked_account_id: forkedAccountId,
-      forked_indexer_name: forkedIndexerName,
+      forked_from_account_id: forkedAccountId,
+      forked_from_function_name: forkedIndexerName,
       code,
       schema,
       start_block: startBlock,

--- a/frontend/widgets/src/QueryApi.Editor.jsx
+++ b/frontend/widgets/src/QueryApi.Editor.jsx
@@ -18,7 +18,7 @@ const initialPayload = {
 
 const registerFunctionHandler = (request, response) => {
   const gas = 200000000000000;
-  const { indexerName, code, schema, startBlock, contractFilter } =
+  const { indexerName, forkedAccountId, forkedIndexerName, code, schema, startBlock, contractFilter } =
     request.payload;
 
   const jsonFilter = `{"indexer_rule_kind":"Action","matching_rule":{"rule":"ACTION_ANY","affected_account_id":"${contractFilter || "social.near"}","status":"SUCCESS"}}`
@@ -28,6 +28,8 @@ const registerFunctionHandler = (request, response) => {
     "register",
     {
       function_name: indexerName,
+      forked_account_id: forkedAccountId,
+      forked_indexer_name: forkedIndexerName,
       code,
       schema,
       start_block: startBlock,

--- a/frontend/widgets/src/QueryApi.Editor.jsx
+++ b/frontend/widgets/src/QueryApi.Editor.jsx
@@ -28,8 +28,10 @@ const registerFunctionHandler = (request, response) => {
     "register",
     {
       function_name: indexerName,
-      forked_from_account_id: forkedAccountId,
-      forked_from_function_name: forkedIndexerName,
+      forked_from: {
+        account_id: forkedAccountId,
+        fuction_name: forkedIndexerName,
+      },
       code,
       schema,
       start_block: startBlock,

--- a/frontend/widgets/src/QueryApi.Editor.jsx
+++ b/frontend/widgets/src/QueryApi.Editor.jsx
@@ -18,7 +18,7 @@ const initialPayload = {
 
 const registerFunctionHandler = (request, response) => {
   const gas = 200000000000000;
-  const { indexerName, forkedAccountId, forkedIndexerName, code, schema, startBlock, contractFilter } =
+  const { indexerName, code, schema, startBlock, contractFilter, forkedFrom } =
     request.payload;
 
   const jsonFilter = `{"indexer_rule_kind":"Action","matching_rule":{"rule":"ACTION_ANY","affected_account_id":"${contractFilter || "social.near"}","status":"SUCCESS"}}`
@@ -28,10 +28,6 @@ const registerFunctionHandler = (request, response) => {
     "register",
     {
       function_name: indexerName,
-      forked_from: {
-        account_id: forkedAccountId,
-        fuction_name: forkedIndexerName,
-      },
       code,
       schema,
       start_block: startBlock,
@@ -39,7 +35,8 @@ const registerFunctionHandler = (request, response) => {
         kind: "ACTION_ANY",
         affected_account_id: contractFilter,
         status: "SUCCESS"
-      } 
+      },
+      ...(forkedFrom && { forked_from: forkedFrom }),
     },
     gas
   );

--- a/registry/contract/src/lib.rs
+++ b/registry/contract/src/lib.rs
@@ -260,8 +260,7 @@ impl Contract {
         &mut self,
         account_id: Option<String>,
         function_name: String,
-        forked_from_account_id: Option<String>,
-        forked_from_function_name: Option<String>,
+        forked_from: Option<IndexerIdentity>,
         code: String,
         schema: String,
         rule: Rule,
@@ -279,20 +278,6 @@ impl Contract {
                 env::signer_account_id()
             }
         };
-
-        let forked_from: match (forked_from_account_id, forked_from_function_name) {
-            (Some(account_id), Some(function_name)) => {
-                const account_id_parsed = account_id.parse::<AccountId>().unwrap_or_else(|_| {
-                    env::panic_str(&format!("Account ID {} is invalid", account_id));
-                });
-                IndexerIdentity {
-                    account_id_parsed,
-                    function_name
-                }
-            },
-            (None, None) => Ok(None),
-            _ => env::panic_str(&format!("Either the account {} or name {} of the forked indexer is missing", forked_from_account_id, forked_from_function_name),
-        }
 
         log!(
             "Registering function {} for account {}",

--- a/registry/contract/src/lib.rs
+++ b/registry/contract/src/lib.rs
@@ -258,13 +258,25 @@ impl Contract {
 
     pub fn register(
         &mut self,
+        account_id: Option<String>,
         function_name: String,
         code: String,
         schema: String,
         rule: Rule,
         start_block: StartBlock,
     ) {
-        let account_id = env::signer_account_id();
+        let account_id = match account_id {
+            Some(account_id) => {
+                self.assert_roles(vec![Role::Owner]);
+
+                account_id.parse::<AccountId>().unwrap_or_else(|_| {
+                    env::panic_str(&format!("Account ID {} is invalid", account_id));
+                })
+            }
+            None => {
+                env::signer_account_id()
+            }
+        };
 
         log!(
             "Registering function {} for account {}",

--- a/registry/contract/src/lib.rs
+++ b/registry/contract/src/lib.rs
@@ -5,8 +5,7 @@ use near_sdk::store::UnorderedMap;
 use near_sdk::{env, log, near_bindgen, serde_json, AccountId, BorshStorageKey, CryptoHash};
 
 use registry_types::{
-    AccountIndexers, AllIndexers, IndexerConfig, IndexerRuleKind, MatchingRule,
-    OldAccountOrAllIndexers, OldIndexerConfig, OldIndexerRule, Rule, StartBlock, Status,
+    AccountIndexers, AccountOrAllIndexers, AllIndexers, IndexerConfig, IndexerIdentity, OldIndexerConfig, Rule, StartBlock, Status,
 };
 
 type FunctionName = String;
@@ -17,9 +16,9 @@ pub struct OldContract {
     account_roles: Vec<AccountRole>,
 }
 
-pub type OldIndexersByAccount = UnorderedMap<AccountId, OldIndexerConfigByFunctionName>;
+type OldIndexersByAccount = UnorderedMap<AccountId, OldIndexerConfigByFunctionName>;
 
-pub type OldIndexerConfigByFunctionName = UnorderedMap<FunctionName, OldIndexerConfig>;
+type OldIndexerConfigByFunctionName = UnorderedMap<FunctionName, OldIndexerConfig>;
 
 // Define the contract structure
 #[near_bindgen]
@@ -44,6 +43,8 @@ enum StorageKeys {
     AccountV2(CryptoHash),
     RegistryV3,
     AccountV3(CryptoHash),
+    RegistryV4,
+    AccountV4(CryptoHash),
 }
 
 /// These roles are used to control access across the various contract methods.
@@ -72,7 +73,7 @@ pub struct AccountRole {
 impl Default for Contract {
     fn default() -> Self {
         Self {
-            registry: IndexersByAccount::new(StorageKeys::RegistryV3),
+            registry: IndexersByAccount::new(StorageKeys::RegistryV4),
             account_roles: vec![
                 AccountRole {
                     account_id: "morgs.near".parse().unwrap(),
@@ -115,15 +116,17 @@ impl Contract {
     pub fn migrate() -> Self {
         let state: OldContract = env::state_read().expect("failed to parse existing state");
 
-        let mut registry = IndexersByAccount::new(StorageKeys::RegistryV3);
+        let mut registry = IndexersByAccount::new(StorageKeys::RegistryV4);
 
         for (account_id, indexers) in state.registry.iter() {
             let mut new_indexers: IndexerConfigByFunctionName = IndexerConfigByFunctionName::new(
-                StorageKeys::AccountV3(env::sha256_array(account_id.as_bytes())),
+                StorageKeys::AccountV4(env::sha256_array(account_id.as_bytes())),
             );
 
+
             for (function_name, indexer_config) in indexers.iter() {
-                new_indexers.insert(function_name.to_string(), indexer_config.clone().into());
+                let new_config: IndexerConfig = indexer_config.clone().into();
+                new_indexers.insert(function_name.to_string(), new_config);
             }
 
             registry.insert(account_id.clone(), new_indexers);
@@ -135,28 +138,11 @@ impl Contract {
         }
     }
 
-    pub fn near_social_indexer_rule() -> OldIndexerRule {
-        let contract = "social.near";
-        let method = "set";
-        let matching_rule = MatchingRule::ActionFunctionCall {
-            affected_account_id: contract.to_string(),
-            function: method.to_string(),
-            status: Status::Any,
-        };
-        OldIndexerRule {
-            indexer_rule_kind: IndexerRuleKind::Action,
-            matching_rule,
-            id: None,
-            name: None,
-        }
-    }
-
-    // Public method - returns a function previously registered under this name or empty string
     pub fn read_indexer_function(
         &self,
         function_name: String,
         account_id: Option<String>,
-    ) -> OldIndexerConfig {
+    ) -> IndexerConfig {
         let account_id = match account_id {
             Some(account_id) => account_id.parse::<AccountId>().unwrap_or_else(|_| {
                 env::panic_str(&format!("Account ID {} is invalid", account_id));
@@ -178,7 +164,7 @@ impl Contract {
             )
         });
 
-        config.clone().into()
+        config.clone()
     }
 
     pub fn assert_roles(&self, permitted_roles: Vec<Role>) {
@@ -258,13 +244,13 @@ impl Contract {
 
     pub fn register(
         &mut self,
-        account_id: Option<String>,
         function_name: String,
         forked_from: Option<IndexerIdentity>,
         code: String,
         schema: String,
         rule: Rule,
         start_block: StartBlock,
+        account_id: Option<String>,
     ) {
         let account_id = match account_id {
             Some(account_id) => {
@@ -294,7 +280,7 @@ impl Contract {
                 affected_account_id,
                 ..
             } => {
-                if affected_account_id == "*" {
+                if affected_account_id.contains("*") {
                     self.assert_roles(vec![Role::Owner]);
                 }
             }
@@ -330,101 +316,6 @@ impl Contract {
                     updated_at_block_height: None,
                     created_at_block_height: env::block_height(),
                     forked_from,
-                });
-            }
-        }
-    }
-
-    // Public method - registers indexer code under <account_id> then function_name
-    pub fn register_indexer_function(
-        &mut self,
-        function_name: String,
-        code: String,
-        start_block_height: Option<u64>,
-        schema: Option<String>,
-        account_id: Option<String>,
-        filter_json: Option<String>,
-    ) {
-        let account_id = match account_id {
-            Some(account_id) => {
-                self.assert_roles(vec![Role::Owner]);
-
-                account_id.parse::<AccountId>().unwrap_or_else(|_| {
-                    env::panic_str(&format!("Account ID {} is invalid", account_id));
-                })
-            }
-            None => {
-                self.assert_roles(vec![Role::Owner, Role::User]);
-                env::signer_account_id()
-            }
-        };
-
-        let filter: OldIndexerRule = match filter_json {
-            Some(filter_json) => {
-                let filter_rule: OldIndexerRule = serde_json::from_str(&filter_json)
-                    .unwrap_or_else(|e| {
-                        env::panic_str(&format!("Invalid filter JSON {}", e));
-                    });
-
-                match &filter_rule.matching_rule {
-                    MatchingRule::ActionAny {
-                        affected_account_id,
-                        ..
-                    }
-                    | MatchingRule::ActionFunctionCall {
-                        affected_account_id,
-                        ..
-                    } => {
-                        if affected_account_id == "*" {
-                            self.assert_roles(vec![Role::Owner]);
-                        }
-                    }
-                    _ => {}
-                }
-
-                filter_rule
-            }
-            None => Contract::near_social_indexer_rule(),
-        };
-
-        log!(
-            "Registering function {} for account {}",
-            &function_name,
-            &account_id
-        );
-
-        let account_indexers =
-            self.registry
-                .entry(account_id.clone())
-                .or_insert(IndexerConfigByFunctionName::new(StorageKeys::AccountV3(
-                    env::sha256_array(account_id.as_bytes()),
-                )));
-
-        let start_block = match start_block_height {
-            Some(height) => StartBlock::Height(height),
-            None => StartBlock::Latest,
-        };
-
-        match account_indexers.entry(function_name) {
-            near_sdk::store::unordered_map::Entry::Occupied(mut entry) => {
-                let indexer = entry.get();
-                entry.insert(IndexerConfig {
-                    code,
-                    start_block,
-                    schema: schema.unwrap_or(String::new()),
-                    rule: filter.matching_rule.into(),
-                    updated_at_block_height: Some(env::block_height()),
-                    created_at_block_height: indexer.created_at_block_height,
-                });
-            }
-            near_sdk::store::unordered_map::Entry::Vacant(entry) => {
-                entry.insert(IndexerConfig {
-                    code,
-                    start_block,
-                    schema: schema.unwrap_or(String::new()),
-                    rule: filter.matching_rule.into(),
-                    updated_at_block_height: None,
-                    created_at_block_height: env::block_height(),
                 });
             }
         }
@@ -470,44 +361,16 @@ impl Contract {
         }
     }
 
-    pub fn list_indexer_functions(&self, account_id: Option<String>) -> OldAccountOrAllIndexers {
+    pub fn list_indexer_functions(&self, account_id: Option<String>) -> AccountOrAllIndexers {
         match account_id {
             Some(account_id) => {
                 let account_id = account_id.parse::<AccountId>().unwrap_or_else(|_| {
                     env::panic_str(&format!("Account ID {} is invalid", account_id));
                 });
 
-                let account_indexers = self.registry.get(&account_id).unwrap_or_else(|| {
-                    env::panic_str(
-                        format!("Account {} has no registered functions", account_id).as_str(),
-                    )
-                });
-
-                OldAccountOrAllIndexers::Account(
-                    account_indexers
-                        .iter()
-                        .map(|(function_name, config)| {
-                            (function_name.clone(), config.clone().into())
-                        })
-                        .collect(),
-                )
+                AccountOrAllIndexers::AccountIndexers(self.list_by_account(account_id))
             }
-            None => OldAccountOrAllIndexers::All(
-                self.registry
-                    .iter()
-                    .map(|(account_id, account_indexers)| {
-                        (
-                            account_id.clone(),
-                            account_indexers
-                                .iter()
-                                .map(|(function_name, config)| {
-                                    (function_name.clone(), config.clone().into())
-                                })
-                                .collect(),
-                        )
-                    })
-                    .collect(),
-            ),
+            None => AccountOrAllIndexers::AllIndexers(self.list_all())
         }
     }
 
@@ -546,9 +409,9 @@ mod tests {
 
     #[test]
     fn migrate() {
-        let mut registry = OldIndexersByAccount::new(StorageKeys::RegistryV2);
+        let mut registry = OldIndexersByAccount::new(StorageKeys::RegistryV3);
         let account_id = "morgs.near".parse::<AccountId>().unwrap();
-        let mut functions = OldIndexerConfigByFunctionName::new(StorageKeys::AccountV2(
+        let mut functions = OldIndexerConfigByFunctionName::new(StorageKeys::AccountV3(
             env::sha256_array(account_id.as_bytes()),
         ));
 
@@ -556,30 +419,29 @@ mod tests {
             "test".to_string(),
             OldIndexerConfig {
                 code: "return block;".to_string(),
-                start_block_height: None,
-                schema: None,
-                filter: Contract::near_social_indexer_rule(),
-                created_at_block_height: 10,
+                start_block: StartBlock::Latest,
+                schema: String::new(),
+                rule: Rule::ActionFunctionCall {
+                    affected_account_id: String::from("social.near"),
+                    status: Status::Any,
+                    function: String::from("set")
+                },
                 updated_at_block_height: None,
+                created_at_block_height: 10,
             },
         );
         functions.insert(
             "test2".to_string(),
             OldIndexerConfig {
                 code: "return block2;".to_string(),
-                start_block_height: Some(100),
-                schema: Some(String::from("create table blah")),
-                filter: OldIndexerRule {
-                    id: None,
-                    name: None,
-                    indexer_rule_kind: IndexerRuleKind::Action,
-                    matching_rule: MatchingRule::ActionAny {
-                        affected_account_id: String::from("social.near"),
-                        status: Status::Success,
-                    },
+                schema: String::from("create table blah"),
+                start_block: StartBlock::Height(100),
+                rule: Rule::ActionAny {
+                    affected_account_id: String::from("social.near"),
+                    status: Status::Success
                 },
-                created_at_block_height: 10,
                 updated_at_block_height: Some(20),
+                created_at_block_height: 10,
             },
         );
         registry.insert(account_id.clone(), functions);
@@ -609,6 +471,7 @@ mod tests {
                 },
                 updated_at_block_height: None,
                 created_at_block_height: 10,
+                forked_from: None,
             }
         );
         assert_eq!(
@@ -628,6 +491,7 @@ mod tests {
                 },
                 updated_at_block_height: Some(20),
                 created_at_block_height: 10,
+                forked_from: None,
             }
         );
         assert_eq!(contract.account_roles, Contract::default().account_roles);
@@ -862,26 +726,36 @@ mod tests {
                 role: Role::User,
             }],
         };
-        let config = OldIndexerConfig {
+        let config = IndexerConfig {
             code: "var x= 1;".to_string(),
-            start_block_height: Some(43434343),
-            schema: None,
-            filter: Contract::near_social_indexer_rule(),
+            start_block: StartBlock::Height(43434343),
+            schema: String::new(),
+            rule: Rule::ActionFunctionCall {
+                affected_account_id: String::from("social.near"),
+                status: Status::Any,
+                function: String::from("set")
+            },
             updated_at_block_height: None,
             created_at_block_height: 0,
+            forked_from: None,
         };
 
-        contract.register_indexer_function(
-            "test".to_string(),
-            config.code.clone(),
-            config.start_block_height,
-            config.schema.clone(),
+        contract.register(
+            "test_function".to_string(),
             None,
+            config.code.clone(),
+            config.schema.clone(),
+            Rule::ActionFunctionCall {
+                affected_account_id: String::from("social.near"),
+                status: Status::Any,
+                function: String::from("set"),
+            },
+            config.start_block.clone(),
             None,
         );
 
         assert_eq!(
-            contract.read_indexer_function("test".to_string(), None),
+            contract.read_indexer_function("test_function".to_string(), None),
             config
         );
     }
@@ -895,42 +769,65 @@ mod tests {
                 role: Role::Owner,
             }],
         };
-        let config = OldIndexerConfig {
+        let config = IndexerConfig {
             code: "var x= 1;".to_string(),
-            start_block_height: Some(43434343),
-            schema: None,
-            filter: Contract::near_social_indexer_rule(),
+            start_block: StartBlock::Height(43434343),
+            schema: String::new(),
+            rule: Rule::ActionFunctionCall {
+                affected_account_id: String::from("social.near"),
+                status: Status::Any,
+                function: String::from("set"),
+            },
             updated_at_block_height: None,
             created_at_block_height: 0,
+            forked_from: Some(IndexerIdentity {
+                account_id: "some_other_account.near".parse().unwrap(),
+                function_name: String::from("some_other_function"),
+            }),
         };
-        contract.register_indexer_function(
-            "test".to_string(),
+        contract.register(
+            "test_function".to_string(),
+            Some(IndexerIdentity {
+                account_id: "some_other_account.near".parse().unwrap(),
+                function_name: String::from("some_other_function"),
+            }),
             config.code.clone(),
-            config.start_block_height,
             config.schema.clone(),
-            None,
+            Rule::ActionFunctionCall {
+                affected_account_id: String::from("social.near"),
+                status: Status::Any,
+                function: String::from("set"),
+            },
+            config.start_block.clone(),
             None,
         );
         assert_eq!(
-            contract.read_indexer_function("test".to_string(), None),
+            contract.read_indexer_function("test_function".to_string(), None),
             config
         );
     }
 
     #[test]
-    #[should_panic(expected = "Account bob.near does not have any roles")]
-    fn anonymous_cannot_register_functions_for_themselves() {
+    fn anonymous_can_register_functions_for_themselves() {
         let mut contract = Contract {
             registry: IndexersByAccount::new(StorageKeys::Registry),
             account_roles: vec![],
         };
 
-        contract.register_indexer_function(
-            "test".to_string(),
-            "var x= 1;".to_string(),
-            Some(43434343),
-            None,
-            None,
+        contract.register(
+            "test_function".to_string(),
+            Some(IndexerIdentity {
+                account_id: "some_other_account.near".parse().unwrap(),
+                function_name: String::from("some_other_function"),
+            }),
+            String::new(),
+            String::new(),
+            Rule::ActionFunctionCall {
+                affected_account_id: String::from("social.near"),
+                status: Status::Any,
+                function: String::from("set"),
+            },
+            StartBlock::Latest,
             None,
         );
     }
@@ -943,13 +840,21 @@ mod tests {
             account_roles: vec![],
         };
 
-        contract.register_indexer_function(
-            "test".to_string(),
-            "var x= 1;".to_string(),
-            Some(43434343),
-            None,
+        contract.register(
+            "test_function".to_string(),
+            Some(IndexerIdentity {
+                account_id: "some_other_account.near".parse().unwrap(),
+                function_name: String::from("some_other_function"),
+            }),
+            String::new(),
+            String::new(),
+            Rule::ActionFunctionCall {
+                affected_account_id: String::from("social.near"),
+                status: Status::Any,
+                function: String::from("set"),
+            },
+            StartBlock::Latest,
             Some("alice.near".to_string()),
-            None,
         );
     }
 
@@ -964,13 +869,21 @@ mod tests {
             }],
         };
 
-        contract.register_indexer_function(
-            "test".to_string(),
-            "var x = 1;".to_string(),
-            Some(434343),
-            None,
+        contract.register(
+            "test_function".to_string(),
+            Some(IndexerIdentity {
+                account_id: "some_other_account.near".parse().unwrap(),
+                function_name: String::from("some_other_function"),
+            }),
+            String::new(),
+            String::new(),
+            Rule::ActionFunctionCall {
+                affected_account_id: String::from("social.near"),
+                status: Status::Any,
+                function: String::from("set"),
+            },
+            StartBlock::Latest,
             Some("alice.near".to_string()),
-            None,
         );
     }
 
@@ -984,62 +897,29 @@ mod tests {
             }],
         };
 
-        contract.register_indexer_function(
-            "test".to_string(),
-            "var x = 1;".to_string(),
-            Some(434343),
-            None,
+        contract.register(
+            "test_function".to_string(),
+            Some(IndexerIdentity {
+                account_id: "some_other_account.near".parse().unwrap(),
+                function_name: String::from("some_other_function"),
+            }),
+            String::new(),
+            String::new(),
+            Rule::ActionFunctionCall {
+                affected_account_id: String::from("social.near"),
+                status: Status::Any,
+                function: String::from("set"),
+            },
+            StartBlock::Latest,
             Some("alice.near".to_string()),
-            None,
         );
 
         assert!(contract
             .registry
             .get(&"alice.near".parse::<AccountId>().unwrap())
             .unwrap()
-            .get("test")
+            .get("test_function")
             .is_some());
-    }
-
-    #[test]
-    fn register_indexer_function_for_new_account() {
-        let mut contract = Contract {
-            registry: IndexersByAccount::new(StorageKeys::Registry),
-            account_roles: vec![AccountRole {
-                account_id: "bob.near".parse().unwrap(),
-                role: Role::User,
-            }],
-        };
-        let config = OldIndexerConfig {
-            code: "var x= 1;".to_string(),
-            start_block_height: None,
-            schema: None,
-            filter: Contract::near_social_indexer_rule(),
-            updated_at_block_height: None,
-            created_at_block_height: 0,
-        };
-
-        contract.register_indexer_function(
-            "test".to_string(),
-            config.code.clone(),
-            config.start_block_height,
-            config.schema.clone(),
-            None,
-            None,
-        );
-
-        assert_eq!(
-            OldIndexerConfig::from(
-                contract
-                    .registry
-                    .get(&"bob.near".parse::<AccountId>().unwrap())
-                    .unwrap()
-                    .get("test")
-                    .unwrap()
-                    .clone()
-            ),
-            config
-        );
     }
 
     #[test]
@@ -1051,13 +931,31 @@ mod tests {
                 role: Role::User,
             }],
         };
+        let config = IndexerConfig {
+            code: "var x= 1;".to_string(),
+            start_block: StartBlock::Height(43434343),
+            schema: String::new(),
+            rule: Rule::ActionFunctionCall {
+                affected_account_id: String::from("social.near"),
+                status: Status::Any,
+                function: String::from("set")
+            },
+            updated_at_block_height: None,
+            created_at_block_height: 0,
+            forked_from: None,
+        };
 
-        contract.register_indexer_function(
-            "test".to_string(),
-            "".to_string(),
-            Some(100),
-            Some("".to_string()),
+        contract.register(
+            "test_function".to_string(),
             None,
+            config.code.clone(),
+            config.schema.clone(),
+            Rule::ActionFunctionCall {
+                affected_account_id: String::from("social.near"),
+                status: Status::Any,
+                function: String::from("set"),
+            },
+            config.start_block.clone(),
             None,
         );
 
@@ -1065,7 +963,7 @@ mod tests {
             .registry
             .get(&"bob.near".parse::<AccountId>().unwrap())
             .unwrap()
-            .get("test")
+            .get("test_function")
             .unwrap();
 
         assert_eq!(indexer_config.updated_at_block_height, None);
@@ -1081,170 +979,44 @@ mod tests {
                 role: Role::User,
             }],
         };
-        let config = OldIndexerConfig {
+        let config = IndexerConfig {
+            start_block: StartBlock::Latest,
             code: "var x= 1;".to_string(),
-            start_block_height: None,
-            schema: None,
-            filter: OldIndexerRule {
-                indexer_rule_kind: IndexerRuleKind::Action,
-                matching_rule: MatchingRule::ActionFunctionCall {
-                    affected_account_id: "test".to_string(),
-                    function: "test".to_string(),
-                    status: Status::Fail,
-                },
-                id: None,
-                name: None,
+            schema: String::new(),
+            rule: Rule:: ActionFunctionCall {
+                affected_account_id: "test".to_string(),
+                function: "test".to_string(),
+                status: Status::Fail,
             },
             updated_at_block_height: None,
             created_at_block_height: 0,
+            forked_from: None,
         };
 
-        contract.register_indexer_function(
-            "test".to_string(),
-            config.code.clone(),
-            config.start_block_height,
-            config.schema.clone(),
+        contract.register(
+            "test_function".to_string(),
             None,
-            Some(r#"{"indexer_rule_kind":"Action","matching_rule":{"rule":"ACTION_FUNCTION_CALL","affected_account_id":"test","function":"test","status":"FAIL"}}"#.to_string()),
+            config.code.clone(),
+            config.schema.clone(),
+            Rule::ActionFunctionCall {
+                affected_account_id: String::from("test"),
+                status: Status::Fail,
+                function: String::from("test"),
+            },
+            config.start_block.clone(),
+            None,
         );
 
         assert_eq!(
-            OldIndexerConfig::from(
-                contract
-                    .registry
-                    .get(&"bob.near".parse::<AccountId>().unwrap())
-                    .unwrap()
-                    .get("test")
-                    .unwrap()
-                    .clone()
-            ),
+            contract
+                .registry
+                .get(&"bob.near".parse::<AccountId>().unwrap())
+                .unwrap()
+                .get("test_function")
+                .unwrap()
+                .clone(),
             config
         );
-    }
-
-    #[test]
-    fn register_indexer_function_with_filter() {
-        let mut contract = Contract {
-            registry: IndexersByAccount::new(StorageKeys::Registry),
-            account_roles: vec![AccountRole {
-                account_id: "bob.near".parse().unwrap(),
-                role: Role::User,
-            }],
-        };
-        let config = OldIndexerConfig {
-            code: "var x= 1;".to_string(),
-            start_block_height: None,
-            schema: None,
-            filter: OldIndexerRule {
-                indexer_rule_kind: IndexerRuleKind::Action,
-                matching_rule: MatchingRule::ActionAny {
-                    affected_account_id: "test".to_string(),
-                    status: Status::Success,
-                },
-                id: None,
-                name: None,
-            },
-            updated_at_block_height: None,
-            created_at_block_height: 0,
-        };
-
-        contract.register_indexer_function(
-            "test".to_string(),
-            config.code.clone(),
-            config.start_block_height,
-            config.schema.clone(),
-            None,
-            Some(r#"{"indexer_rule_kind":"Action","matching_rule":{"rule":"ACTION_ANY","affected_account_id":"test","status":"SUCCESS"}}"#.to_string()),
-        );
-
-        assert_eq!(
-            OldIndexerConfig::from(
-                contract
-                    .registry
-                    .get(&"bob.near".parse::<AccountId>().unwrap())
-                    .unwrap()
-                    .get("test")
-                    .unwrap()
-                    .clone()
-            ),
-            config
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "Invalid filter JSON")]
-    fn register_indexer_function_with_invalid_filter() {
-        let mut contract = Contract {
-            registry: IndexersByAccount::new(StorageKeys::Registry),
-            account_roles: vec![AccountRole {
-                account_id: "bob.near".parse().unwrap(),
-                role: Role::User,
-            }],
-        };
-
-        let filter_json_missing_rule_type = r#"{"indexer_rule_kind":"Action","matching_rule":{"affected_account_id":"test","function":"test","status":"FAIL"}}"#;
-
-        contract.register_indexer_function(
-            "test".to_string(),
-            "var x= 1;".to_string(),
-            None,
-            None,
-            None,
-            Some(filter_json_missing_rule_type.to_string()),
-        );
-    }
-
-    #[test]
-    fn sets_updated_at_and_created_at_for_existing_account() {
-        let account_id = "bob.near".parse::<AccountId>().unwrap();
-        let mut account_indexers = IndexerConfigByFunctionName::new(StorageKeys::Account(
-            env::sha256_array(account_id.as_bytes()),
-        ));
-        account_indexers.insert(
-            "test".to_string(),
-            IndexerConfig {
-                code: "var x= 1;".to_string(),
-                start_block: StartBlock::Latest,
-                schema: String::new(),
-                rule: Rule::ActionAny {
-                    affected_account_id: String::from("social.near"),
-                    status: Status::Success,
-                },
-                updated_at_block_height: None,
-                created_at_block_height: 100,
-            },
-        );
-        let mut registry = IndexersByAccount::new(StorageKeys::Registry);
-        registry.insert(account_id, account_indexers);
-        let mut contract = Contract {
-            registry,
-            account_roles: vec![AccountRole {
-                account_id: "bob.near".parse().unwrap(),
-                role: Role::User,
-            }],
-        };
-
-        contract.register_indexer_function(
-            "test".to_string(),
-            "".to_string(),
-            Some(100),
-            Some("".to_string()),
-            None,
-            None,
-        );
-
-        let indexer_config = contract
-            .registry
-            .get(&"bob.near".parse::<AccountId>().unwrap())
-            .unwrap()
-            .get("test")
-            .unwrap();
-
-        assert_eq!(
-            indexer_config.updated_at_block_height,
-            Some(env::block_height())
-        );
-        assert_eq!(indexer_config.created_at_block_height, 100);
     }
 
     #[test]
@@ -1254,17 +1026,19 @@ mod tests {
             env::sha256_array(account_id.as_bytes()),
         ));
         account_indexers.insert(
-            "test".to_string(),
+            "test_function".to_string(),
             IndexerConfig {
-                code: "var x= 1;".to_string(),
                 start_block: StartBlock::Latest,
+                code: "var x= 1;".to_string(),
                 schema: String::new(),
-                rule: Rule::ActionAny {
-                    affected_account_id: String::from("social.near"),
-                    status: Status::Success,
+                rule: Rule:: ActionFunctionCall {
+                    affected_account_id: "test".to_string(),
+                    function: "test".to_string(),
+                    status: Status::Fail,
                 },
                 updated_at_block_height: None,
-                created_at_block_height: 100,
+                created_at_block_height: 0,
+                forked_from: None,
             },
         );
         let mut registry = IndexersByAccount::new(StorageKeys::Registry);
@@ -1276,21 +1050,31 @@ mod tests {
                 role: Role::User,
             }],
         };
-        let config = OldIndexerConfig {
+        let config = IndexerConfig {
+            start_block: StartBlock::Latest,
             code: "var x= 1;".to_string(),
-            start_block_height: None,
-            schema: None,
-            filter: Contract::near_social_indexer_rule(),
+            schema: String::new(),
+            rule: Rule:: ActionFunctionCall {
+                affected_account_id: "test".to_string(),
+                function: "test".to_string(),
+                status: Status::Fail,
+            },
             updated_at_block_height: None,
             created_at_block_height: 0,
+            forked_from: None,
         };
 
-        contract.register_indexer_function(
-            "test2".to_string(),
-            config.code.clone(),
-            config.start_block_height,
-            config.schema,
+        contract.register(
+            "test_function2".to_string(),
             None,
+            config.code.clone(),
+            config.schema.clone(),
+            Rule::ActionFunctionCall {
+                affected_account_id: String::from("test"),
+                status: Status::Fail,
+                function: String::from("test"),
+            },
+            config.start_block.clone(),
             None,
         );
 
@@ -1313,13 +1097,18 @@ mod tests {
             role: Role::User,
         });
 
-        contract.register_indexer_function(
-            String::from("name"),
-            String::from("code"),
-            Some(0),
-            Some(String::from("schema")),
+        contract.register(
+            "test_function".to_string(),
             None,
-            Some(r#"{"indexer_rule_kind":"Action","matching_rule":{"rule":"ACTION_ANY","affected_account_id":"*","status":"SUCCESS"}}"#.to_string()),
+            String::new(), 
+            String::new(),
+            Rule::ActionFunctionCall {
+                affected_account_id: String::from("*"),
+                status: Status::Fail,
+                function: String::from("test"),
+            },
+            StartBlock::Latest,
+            None,
         );
     }
 
@@ -1331,13 +1120,17 @@ mod tests {
             role: Role::Owner,
         });
 
-        contract.register_indexer_function(
-            String::from("name"),
-            String::from("code"),
-            Some(0),
-            Some(String::from("schema")),
+        contract.register(
+            "test_function".to_string(),
             None,
-            Some(r#"{"indexer_rule_kind":"Action","matching_rule":{"rule":"ACTION_ANY","affected_account_id":"*","status":"SUCCESS"}}"#.to_string()),
+            String::new(), 
+            String::new(),
+            Rule::ActionAny {
+                affected_account_id: String::from("*"),
+                status: Status::Success,
+            },
+            StartBlock::Latest,
+            None,
         );
 
         assert_eq!(contract.registry.len(), 1);
@@ -1352,15 +1145,16 @@ mod tests {
         account_indexers.insert(
             "test".to_string(),
             IndexerConfig {
-                code: "var x= 1;".to_string(),
                 start_block: StartBlock::Latest,
+                code: "var x= 1;".to_string(),
                 schema: String::new(),
-                rule: Rule::ActionAny {
-                    affected_account_id: String::from("social.near"),
+                rule: Rule:: ActionAny {
+                    affected_account_id: "social.near".to_string(),
                     status: Status::Success,
                 },
                 updated_at_block_height: None,
-                created_at_block_height: 100,
+                created_at_block_height: 0,
+                forked_from: None,
             },
         );
         let mut registry = IndexersByAccount::new(StorageKeys::Registry);
@@ -1390,15 +1184,16 @@ mod tests {
         account_indexers.insert(
             "test".to_string(),
             IndexerConfig {
-                code: "var x= 1;".to_string(),
                 start_block: StartBlock::Latest,
+                code: "var x= 1;".to_string(),
                 schema: String::new(),
-                rule: Rule::ActionAny {
-                    affected_account_id: String::from("social.near"),
+                rule: Rule:: ActionAny {
+                    affected_account_id: "social.near".to_string(),
                     status: Status::Success,
                 },
                 updated_at_block_height: None,
-                created_at_block_height: 100,
+                created_at_block_height: 0,
+                forked_from: None,
             },
         );
         let mut registry = IndexersByAccount::new(StorageKeys::Registry);
@@ -1429,15 +1224,16 @@ mod tests {
         account_indexers.insert(
             "test".to_string(),
             IndexerConfig {
-                code: "var x= 1;".to_string(),
                 start_block: StartBlock::Latest,
+                code: "var x= 1;".to_string(),
                 schema: String::new(),
-                rule: Rule::ActionAny {
-                    affected_account_id: String::from("social.near"),
+                rule: Rule:: ActionAny {
+                    affected_account_id: "social.near".to_string(),
                     status: Status::Success,
                 },
                 updated_at_block_height: None,
-                created_at_block_height: 100,
+                created_at_block_height: 0,
+                forked_from: None,
             },
         );
         let mut registry = IndexersByAccount::new(StorageKeys::Registry);
@@ -1462,15 +1258,16 @@ mod tests {
         account_indexers.insert(
             "test".to_string(),
             IndexerConfig {
-                code: "var x= 1;".to_string(),
                 start_block: StartBlock::Latest,
+                code: "var x= 1;".to_string(),
                 schema: String::new(),
-                rule: Rule::ActionAny {
-                    affected_account_id: String::from("social.near"),
+                rule: Rule:: ActionAny {
+                    affected_account_id: "social.near".to_string(),
                     status: Status::Success,
                 },
                 updated_at_block_height: None,
-                created_at_block_height: 100,
+                created_at_block_height: 0,
+                forked_from: None,
             },
         );
         let mut registry = IndexersByAccount::new(StorageKeys::Registry);
@@ -1501,15 +1298,16 @@ mod tests {
         account_indexers.insert(
             "test".to_string(),
             IndexerConfig {
-                code: "var x= 1;".to_string(),
                 start_block: StartBlock::Latest,
+                code: "var x= 1;".to_string(),
                 schema: String::new(),
-                rule: Rule::ActionAny {
-                    affected_account_id: String::from("social.near"),
+                rule: Rule:: ActionAny {
+                    affected_account_id: "social.near".to_string(),
                     status: Status::Success,
                 },
                 updated_at_block_height: None,
-                created_at_block_height: 100,
+                created_at_block_height: 0,
+                forked_from: None,
             },
         );
         let mut registry = IndexersByAccount::new(StorageKeys::Registry);
@@ -1531,29 +1329,31 @@ mod tests {
         account_indexers.insert(
             "test".to_string(),
             IndexerConfig {
-                code: "var x= 1;".to_string(),
                 start_block: StartBlock::Latest,
+                code: "var x= 1;".to_string(),
                 schema: String::new(),
-                rule: Rule::ActionAny {
-                    affected_account_id: String::from("social.near"),
+                rule: Rule:: ActionAny {
+                    affected_account_id: "social.near".to_string(),
                     status: Status::Success,
                 },
                 updated_at_block_height: None,
-                created_at_block_height: 100,
+                created_at_block_height: 0,
+                forked_from: None,
             },
         );
         account_indexers.insert(
             "test2".to_string(),
             IndexerConfig {
-                code: "var x= 1;".to_string(),
                 start_block: StartBlock::Latest,
+                code: "var x= 1;".to_string(),
                 schema: String::new(),
-                rule: Rule::ActionAny {
-                    affected_account_id: String::from("social.near"),
+                rule: Rule:: ActionAny {
+                    affected_account_id: "social.near".to_string(),
                     status: Status::Success,
                 },
                 updated_at_block_height: None,
-                created_at_block_height: 100,
+                created_at_block_height: 0,
+                forked_from: None,
             },
         );
         let mut registry = IndexersByAccount::new(StorageKeys::Registry);
@@ -1597,13 +1397,17 @@ mod tests {
 
     #[test]
     fn read_indexer_function() {
-        let config = OldIndexerConfig {
+        let config = IndexerConfig {
+            start_block: StartBlock::Latest,
             code: "var x= 1;".to_string(),
-            start_block_height: None,
-            schema: None,
-            filter: Contract::near_social_indexer_rule(),
+            schema: String::new(),
+            rule: Rule:: ActionAny {
+                affected_account_id: "social.near".to_string(),
+                status: Status::Success,
+            },
             updated_at_block_height: None,
             created_at_block_height: 0,
+            forked_from: None,
         };
 
         let account_id = "bob.near".parse::<AccountId>().unwrap();
@@ -1626,13 +1430,17 @@ mod tests {
 
     #[test]
     fn read_indexer_function_from_other_account() {
-        let config = OldIndexerConfig {
+        let config = IndexerConfig {
+            start_block: StartBlock::Latest,
             code: "var x= 1;".to_string(),
-            start_block_height: None,
-            schema: None,
-            filter: Contract::near_social_indexer_rule(),
+            schema: String::new(),
+            rule: Rule:: ActionAny {
+                affected_account_id: "social.near".to_string(),
+                status: Status::Success,
+            },
             updated_at_block_height: None,
             created_at_block_height: 0,
+            forked_from: None,
         };
         let account_id = "alice.near".parse::<AccountId>().unwrap();
         let mut account_indexers = IndexerConfigByFunctionName::new(StorageKeys::Account(
@@ -1662,13 +1470,17 @@ mod tests {
 
     #[test]
     fn list_indexer_functions() {
-        let config = OldIndexerConfig {
+        let config = IndexerConfig {
+            start_block: StartBlock::Latest,
             code: "var x= 1;".to_string(),
-            start_block_height: Some(43434343),
-            schema: None,
-            filter: Contract::near_social_indexer_rule(),
+            schema: String::new(),
+            rule: Rule:: ActionAny {
+                affected_account_id: "social.near".to_string(),
+                status: Status::Success,
+            },
             updated_at_block_height: None,
             created_at_block_height: 0,
+            forked_from: None,
         };
         let account_id = "bob.near".parse::<AccountId>().unwrap();
         let mut account_indexers = IndexerConfigByFunctionName::new(StorageKeys::Account(
@@ -1684,7 +1496,7 @@ mod tests {
 
         assert_eq!(
             contract.list_indexer_functions(None),
-            OldAccountOrAllIndexers::All(HashMap::from([(
+            AccountOrAllIndexers::AllIndexers(HashMap::from([(
                 "bob.near".parse().unwrap(),
                 HashMap::from([("test".to_string(), config)])
             )]))
@@ -1693,13 +1505,17 @@ mod tests {
 
     #[test]
     fn list_account_indexer_functions() {
-        let config = OldIndexerConfig {
+        let config = IndexerConfig {
+            start_block: StartBlock::Latest,
             code: "var x= 1;".to_string(),
-            start_block_height: Some(43434343),
-            schema: None,
-            filter: Contract::near_social_indexer_rule(),
+            schema: String::new(),
+            rule: Rule:: ActionAny {
+                affected_account_id: "social.near".to_string(),
+                status: Status::Success,
+            },
             updated_at_block_height: None,
             created_at_block_height: 0,
+            forked_from: None,
         };
         let account_id = "bob.near".parse::<AccountId>().unwrap();
         let mut account_indexers = IndexerConfigByFunctionName::new(StorageKeys::Account(
@@ -1715,30 +1531,23 @@ mod tests {
 
         assert_eq!(
             contract.list_indexer_functions(Some("bob.near".to_string())),
-            OldAccountOrAllIndexers::Account(HashMap::from([("test".to_string(), config)]))
+            AccountOrAllIndexers::AccountIndexers(HashMap::from([("test".to_string(), config)]))
         );
     }
 
     #[test]
-    #[should_panic(expected = "Account bob.near has no registered functions")]
-    fn list_account_empty_indexer_functions() {
-        let contract = Contract {
-            registry: IndexersByAccount::new(StorageKeys::Registry),
-            account_roles: vec![],
-        };
-
-        contract.list_indexer_functions(Some("bob.near".to_string()));
-    }
-
-    #[test]
     fn list_other_account_indexer_functions() {
-        let config = OldIndexerConfig {
+        let config = IndexerConfig {
+            start_block: StartBlock::Latest,
             code: "var x= 1;".to_string(),
-            start_block_height: Some(43434343),
-            schema: None,
-            filter: Contract::near_social_indexer_rule(),
+            schema: String::new(),
+            rule: Rule:: ActionAny {
+                affected_account_id: "social.near".to_string(),
+                status: Status::Success,
+            },
             updated_at_block_height: None,
             created_at_block_height: 0,
+            forked_from: None,
         };
         let account_id = "alice.near".parse::<AccountId>().unwrap();
         let mut account_indexers = IndexerConfigByFunctionName::new(StorageKeys::Account(
@@ -1754,7 +1563,7 @@ mod tests {
 
         assert_eq!(
             contract.list_indexer_functions(Some("alice.near".to_string())),
-            OldAccountOrAllIndexers::Account(HashMap::from([("test".to_string(), config)]))
+            AccountOrAllIndexers::AccountIndexers(HashMap::from([("test".to_string(), config)]))
         );
     }
 
@@ -1763,7 +1572,11 @@ mod tests {
         let mut contract = Contract::default();
 
         contract.register(
-            String::from("test"),
+            "test".to_string(),
+            Some(IndexerIdentity {
+                account_id: "some_other_account.near".parse().unwrap(),
+                function_name: String::from("some_other_function"),
+            }),
             String::from("code"),
             String::from("schema"),
             Rule::ActionAny {
@@ -1771,6 +1584,7 @@ mod tests {
                 status: Status::Any,
             },
             StartBlock::Latest,
+            None,
         );
 
         assert_eq!(
@@ -1780,16 +1594,20 @@ mod tests {
                 HashMap::from([(
                     String::from("test"),
                     IndexerConfig {
+                        start_block: StartBlock::Latest,
                         code: String::from("code"),
                         schema: String::from("schema"),
-                        rule: Rule::ActionAny {
-                            affected_account_id: String::from("social.near"),
+                        rule: Rule:: ActionAny {
+                            affected_account_id: "social.near".to_string(),
                             status: Status::Any,
                         },
-                        start_block: StartBlock::Latest,
                         updated_at_block_height: None,
-                        created_at_block_height: env::block_height(),
-                    }
+                        created_at_block_height: 0,
+                        forked_from: Some(IndexerIdentity {
+                            account_id: "some_other_account.near".parse().unwrap(),
+                            function_name: String::from("some_other_function"),
+                        }),
+                    },
                 )])
             )])
         );
@@ -1800,7 +1618,11 @@ mod tests {
         let mut contract = Contract::default();
 
         contract.register(
-            String::from("test"),
+            "test".to_string(),
+            Some(IndexerIdentity {
+                account_id: "some_other_account.near".parse().unwrap(),
+                function_name: String::from("some_other_function"),
+            }),
             String::from("code"),
             String::from("schema"),
             Rule::ActionAny {
@@ -1808,6 +1630,7 @@ mod tests {
                 status: Status::Any,
             },
             StartBlock::Latest,
+            None,
         );
 
         assert_eq!(
@@ -1821,7 +1644,11 @@ mod tests {
         let mut contract = Contract::default();
 
         contract.register(
-            String::from("test"),
+            "test".to_string(),
+            Some(IndexerIdentity {
+                account_id: "some_other_account.near".parse().unwrap(),
+                function_name: String::from("some_other_function"),
+            }),
             String::from("code"),
             String::from("schema"),
             Rule::ActionAny {
@@ -1829,6 +1656,7 @@ mod tests {
                 status: Status::Any,
             },
             StartBlock::Latest,
+            None,
         );
 
         assert_eq!(
@@ -1836,16 +1664,20 @@ mod tests {
             HashMap::from([(
                 String::from("test"),
                 IndexerConfig {
+                    start_block: StartBlock::Latest,
                     code: String::from("code"),
                     schema: String::from("schema"),
-                    rule: Rule::ActionAny {
-                        affected_account_id: String::from("social.near"),
+                    rule: Rule:: ActionAny {
+                        affected_account_id: "social.near".to_string(),
                         status: Status::Any,
                     },
-                    start_block: StartBlock::Latest,
                     updated_at_block_height: None,
-                    created_at_block_height: env::block_height(),
-                }
+                    created_at_block_height: 0,
+                    forked_from: Some(IndexerIdentity {
+                        account_id: "some_other_account.near".parse().unwrap(),
+                        function_name: String::from("some_other_function"),
+                    }),
+                },
             )])
         );
     }

--- a/registry/types/src/lib.rs
+++ b/registry/types/src/lib.rs
@@ -206,6 +206,12 @@ pub enum StartBlock {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct IndexerIdentity {
+    pub account_id: AccountId,
+    pub function_name: FunctionName,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct IndexerConfig {
     pub code: String,
     pub start_block: StartBlock,
@@ -213,6 +219,7 @@ pub struct IndexerConfig {
     pub rule: Rule,
     pub updated_at_block_height: Option<u64>,
     pub created_at_block_height: u64,
+    pub forked_from: Option<IndexerIdentity>,
 }
 
 impl From<OldIndexerConfig> for IndexerConfig {
@@ -227,6 +234,7 @@ impl From<OldIndexerConfig> for IndexerConfig {
             rule: config.filter.matching_rule.into(),
             created_at_block_height: config.created_at_block_height,
             updated_at_block_height: config.updated_at_block_height,
+            forked_from: None,
         }
     }
 }

--- a/registry/types/src/lib.rs
+++ b/registry/types/src/lib.rs
@@ -15,123 +15,6 @@ use serde::{Deserialize, Serialize};
 type FunctionName = String;
 
 #[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
-#[serde(tag = "rule", rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum MatchingRule {
-    ActionAny {
-        affected_account_id: String,
-        status: Status,
-    },
-    ActionFunctionCall {
-        affected_account_id: String,
-        status: Status,
-        function: String,
-    },
-    Event {
-        contract_account_id: String,
-        standard: String,
-        version: String,
-        event: String,
-    },
-}
-
-impl From<Rule> for MatchingRule {
-    fn from(value: Rule) -> Self {
-        match value {
-            Rule::ActionAny {
-                affected_account_id,
-                status,
-            } => MatchingRule::ActionAny {
-                affected_account_id,
-                status,
-            },
-            Rule::Event {
-                contract_account_id,
-                standard,
-                version,
-                event,
-            } => MatchingRule::Event {
-                contract_account_id,
-                standard,
-                version,
-                event,
-            },
-            Rule::ActionFunctionCall {
-                affected_account_id,
-                status,
-                function,
-            } => MatchingRule::ActionFunctionCall {
-                affected_account_id,
-                status,
-                function,
-            },
-        }
-    }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
-pub enum IndexerRuleKind {
-    Action,
-    Event,
-    AnyBlock,
-    Shard,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
-pub struct OldIndexerRule {
-    pub indexer_rule_kind: IndexerRuleKind,
-    pub matching_rule: MatchingRule,
-    // These are not set, and not used anywhere
-    pub id: Option<u32>,
-    pub name: Option<String>,
-}
-
-#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct OldIndexerConfig {
-    pub code: String,
-    pub start_block_height: Option<u64>,
-    pub schema: Option<String>,
-    pub filter: OldIndexerRule,
-    pub updated_at_block_height: Option<u64>,
-    pub created_at_block_height: u64,
-}
-
-impl From<IndexerConfig> for OldIndexerConfig {
-    fn from(config: IndexerConfig) -> Self {
-        let start_block_height = match config.start_block {
-            StartBlock::Latest => None,
-            StartBlock::Continue => None,
-            StartBlock::Height(height) => Some(height),
-        };
-
-        let schema = if config.schema.is_empty() {
-            None
-        } else {
-            Some(config.schema)
-        };
-
-        OldIndexerConfig {
-            start_block_height,
-            schema,
-            code: config.code,
-            filter: OldIndexerRule {
-                indexer_rule_kind: IndexerRuleKind::Action,
-                matching_rule: config.rule.into(),
-                id: None,
-                name: None,
-            },
-            created_at_block_height: config.created_at_block_height,
-            updated_at_block_height: config.updated_at_block_height,
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub enum OldAccountOrAllIndexers {
-    All(HashMap<AccountId, HashMap<FunctionName, OldIndexerConfig>>),
-    Account(HashMap<FunctionName, OldIndexerConfig>),
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Status {
     Any,
@@ -159,40 +42,6 @@ pub enum Rule {
     },
 }
 
-impl From<MatchingRule> for Rule {
-    fn from(value: MatchingRule) -> Self {
-        match value {
-            MatchingRule::ActionAny {
-                affected_account_id,
-                status,
-            } => Rule::ActionAny {
-                affected_account_id,
-                status,
-            },
-            MatchingRule::Event {
-                contract_account_id,
-                standard,
-                version,
-                event,
-            } => Rule::Event {
-                contract_account_id,
-                standard,
-                version,
-                event,
-            },
-            MatchingRule::ActionFunctionCall {
-                affected_account_id,
-                status,
-                function,
-            } => Rule::ActionFunctionCall {
-                affected_account_id,
-                status,
-                function,
-            },
-        }
-    }
-}
-
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum StartBlock {
@@ -212,6 +61,16 @@ pub struct IndexerIdentity {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct OldIndexerConfig {
+    pub code: String,
+    pub start_block: StartBlock,
+    pub schema: String,
+    pub rule: Rule,
+    pub updated_at_block_height: Option<u64>,
+    pub created_at_block_height: u64,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct IndexerConfig {
     pub code: String,
     pub start_block: StartBlock,
@@ -225,13 +84,10 @@ pub struct IndexerConfig {
 impl From<OldIndexerConfig> for IndexerConfig {
     fn from(config: OldIndexerConfig) -> Self {
         Self {
-            start_block: match config.start_block_height {
-                Some(height) => StartBlock::Height(height),
-                None => StartBlock::Latest,
-            },
-            schema: config.schema.unwrap_or(String::new()),
+            start_block: config.start_block,
+            schema: config.schema,
             code: config.code,
-            rule: config.filter.matching_rule.into(),
+            rule: config.rule,
             created_at_block_height: config.created_at_block_height,
             updated_at_block_height: config.updated_at_block_height,
             forked_from: None,
@@ -242,3 +98,9 @@ impl From<OldIndexerConfig> for IndexerConfig {
 pub type AccountIndexers = HashMap<FunctionName, IndexerConfig>;
 
 pub type AllIndexers = HashMap<AccountId, AccountIndexers>;
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum AccountOrAllIndexers {
+    AccountIndexers(HashMap<FunctionName, IndexerConfig>),
+    AllIndexers(HashMap<AccountId, AccountIndexers>),
+}

--- a/runner/src/stream-handler/stream-handler.ts
+++ b/runner/src/stream-handler/stream-handler.ts
@@ -83,7 +83,7 @@ export default class StreamHandler {
   private handleMessage (message: WorkerMessage): void {
     switch (message.type) {
       case WorkerMessageType.STATUS:
-        this.executorContext.status = message.data;
+        this.executorContext.status = message.data.status;
         break;
       case WorkerMessageType.BLOCK_HEIGHT:
         this.executorContext.block_height = message.data;


### PR DESCRIPTION
Maintaining what Indexer was forked during development is useful for various usage statistics. I've updated the frontend to now store what indexer was forked from and store that information in the contract after publishing. We specifically store the indexer which was directly forked. 

With this information, we can construct a graph using the "forked_from" as edge information, and calculate various other statistics such as how many indexers used some other indexer as a base by doing path counts. This can be done by creating an indexer which indexes the QueryApi contract. 

There are some bugs in the workflow currently. Specifically, refreshing while in the forked page will cause the loss of whatever code was written. You need to re-fork the Indexer. While this benefits to ensuring the forked from field is correct, if we end up fixing this behavior, we need to then ensure forked from is stored persistently. 


As part of updating the contract, I've removed various old functions which are no longer necessary. 