### PR TITLE
fix: Catch failed Lake S3 request to prevent unhandled rejections

### DIFF
--- a/runner/src/indexer/indexer.ts
+++ b/runner/src/indexer/indexer.ts
@@ -79,6 +79,8 @@ export default class Indexer {
   async execute (
     block: lakePrimitives.Block,
   ): Promise<string[]> {
+    this.logger.debug('Executing block', { blockHeight: block.blockHeight });
+
     const blockHeight: number = block.blockHeight;
 
     const lag = Date.now() - Math.floor(Number(block.header().timestampNanosec) / 1000000);

--- a/runner/src/lake-client/lake-client.ts
+++ b/runner/src/lake-client/lake-client.ts
@@ -6,7 +6,10 @@ import RedisClient from '../redis-client';
 export default class LakeClient {
   constructor (
     private readonly network: string = 'mainnet',
-    private readonly s3Client: S3Client = new S3Client(),
+    private readonly s3Client: S3Client = new S3Client({
+      maxAttempts: 5,
+      retryMode: 'adaptive'
+    }),
     private readonly redisClient: RedisClient = new RedisClient()
   ) {}
 

--- a/runner/src/stream-handler/worker.ts
+++ b/runner/src/stream-handler/worker.ts
@@ -19,7 +19,7 @@ if (isMainThread) {
 }
 
 interface QueueMessage {
-  block: Block
+  block?: Block
   streamMessageId: string
 }
 
@@ -42,7 +42,8 @@ void (async function main () {
   const logger = parentLogger.child({
     service: 'StreamHandler/worker',
     accountId: indexerConfig.accountId,
-    functionName: indexerConfig.functionName
+    functionName: indexerConfig.functionName,
+    version: indexerConfig.version
   });
   const redisClient = new RedisClient();
 
@@ -115,13 +116,14 @@ async function blockQueueConsumer (workerContext: WorkerContext): Promise<void> 
         const queueMessage = await wrapSpan(async () => {
           return await workerContext.queue.at(0);
         }, tracer, 'Wait for block to download');
+
         if (queueMessage === undefined) {
           workerContext.logger.warn('Block promise is undefined');
           return;
         }
 
         const block = queueMessage.block;
-        if (block === undefined || block.blockHeight == null) {
+        if (!block?.blockHeight) {
           throw new Error(`Block ${currBlockHeight} failed to process or does not have block height`);
         }
 
@@ -182,7 +184,11 @@ async function blockQueueConsumer (workerContext: WorkerContext): Promise<void> 
 }
 
 async function generateQueuePromise (workerContext: WorkerContext, blockHeight: number, streamMessageId: string): Promise<QueueMessage> {
-  const block = await workerContext.lakeClient.fetchBlock(blockHeight);
+  const block = await workerContext.lakeClient.fetchBlock(blockHeight).catch((err) => {
+    workerContext.logger.error(`Error fetching block ${blockHeight}`, err);
+    return undefined;
+  });
+
   return {
     block,
     streamMessageId


### PR DESCRIPTION
Rejected promises must be handled via `await` or `.catch()`, without either of these Node will exit due to the "unhandled rejection". Currently, Lake S3 requests are created in advance, and then handled later when the block is ready to be executed. Usually, this is not an issue, as the delay between promise creation/handling is not too large. But for slow indexers (i.e. `nearpavel_near/bitmap_v2`), this delay is long enough for Node to consider it "unhandled".

This PR attaches a rejection handler to block requests, so that failures can be handled gracefully. This does not affect the "pre-fetch" behaviour, these requests will still be executed ahead of time, but failed requests will be handled within our code. Explicit handling binds the error to our execution context providing a meaningful call-stack, as opposed to a lonesome error which seemingly comes from no-where.

To mitigate the problem itself - failed S3 requests, I have bumped `maxAttempts`, and changed the `retryMode` in the hopes that the transient error can be overcome.