### PR TITLE
refactor: Introduce struct to manager persistent indexer state

### DIFF
--- a/coordinator/src/block_streams/synchronise.rs
+++ b/coordinator/src/block_streams/synchronise.rs
@@ -105,7 +105,7 @@ async fn synchronise_block_stream(
         .start(start_block_height, indexer_config)
         .await?;
 
-    indexer_manager.set_synced(indexer_config);
+    indexer_manager.set_synced(indexer_config).await?;
 
     Ok(())
 }

--- a/coordinator/src/block_streams/synchronise.rs
+++ b/coordinator/src/block_streams/synchronise.rs
@@ -105,8 +105,7 @@ async fn synchronise_block_stream(
         .start(start_block_height, indexer_config)
         .await?;
 
-    // use indexer manager
-    redis_client.set_stream_version(indexer_config).await?;
+    indexer_manager.set_synced(indexer_config);
 
     Ok(())
 }
@@ -191,17 +190,17 @@ mod tests {
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| SyncStatus::Synced);
+        mock_indexer_manager
+            .expect_set_synced()
+            .with(predicate::eq(indexer_config.clone()))
+            .returning(|_| Ok(()))
+            .once();
 
         let mut redis_client = RedisClient::default();
         redis_client
             .expect_get_last_published_block()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| Ok(Some(500)))
-            .once();
-        redis_client
-            .expect_set_stream_version()
-            .with(predicate::eq(indexer_config.clone()))
-            .returning(|_| Ok(()))
             .once();
         redis_client.expect_clear_block_stream().never();
 
@@ -249,15 +248,15 @@ mod tests {
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| SyncStatus::Outdated);
+        mock_indexer_manager
+            .expect_set_synced()
+            .with(predicate::eq(indexer_config.clone()))
+            .returning(|_| Ok(()))
+            .once();
 
         let mut redis_client = RedisClient::default();
         redis_client
             .expect_clear_block_stream()
-            .with(predicate::eq(indexer_config.clone()))
-            .returning(|_| Ok(()))
-            .once();
-        redis_client
-            .expect_set_stream_version()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| Ok(()))
             .once();
@@ -306,15 +305,15 @@ mod tests {
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| SyncStatus::Outdated);
+        mock_indexer_manager
+            .expect_set_synced()
+            .with(predicate::eq(indexer_config.clone()))
+            .returning(|_| Ok(()))
+            .once();
 
         let mut redis_client = RedisClient::default();
         redis_client
             .expect_clear_block_stream()
-            .with(predicate::eq(indexer_config.clone()))
-            .returning(|_| Ok(()))
-            .once();
-        redis_client
-            .expect_set_stream_version()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| Ok(()))
             .once();
@@ -363,17 +362,17 @@ mod tests {
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| SyncStatus::Outdated);
+        mock_indexer_manager
+            .expect_set_synced()
+            .with(predicate::eq(indexer_config.clone()))
+            .returning(|_| Ok(()))
+            .once();
 
         let mut redis_client = RedisClient::default();
         redis_client
             .expect_get_last_published_block()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| Ok(Some(100)))
-            .once();
-        redis_client
-            .expect_set_stream_version()
-            .with(predicate::eq(indexer_config.clone()))
-            .returning(|_| Ok(()))
             .once();
 
         let mut block_stream_handler = BlockStreamsHandler::default();
@@ -401,7 +400,7 @@ mod tests {
 
         let redis_client = RedisClient::default();
 
-        let mut mock_indexer_manager = IndexerManager::default();
+        let mock_indexer_manager = IndexerManager::default();
 
         let mut block_stream_handler = BlockStreamsHandler::default();
         block_stream_handler.expect_list().returning(|| {
@@ -503,15 +502,15 @@ mod tests {
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| SyncStatus::Outdated);
+        mock_indexer_manager
+            .expect_set_synced()
+            .with(predicate::eq(indexer_config.clone()))
+            .returning(|_| Ok(()))
+            .once();
 
         let mut redis_client = RedisClient::default();
         redis_client
             .expect_clear_block_stream()
-            .with(predicate::eq(indexer_config.clone()))
-            .returning(|_| Ok(()))
-            .once();
-        redis_client
-            .expect_set_stream_version()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| Ok(()))
             .once();
@@ -619,13 +618,13 @@ mod tests {
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| SyncStatus::New);
-
-        let mut redis_client = RedisClient::default();
-        redis_client
-            .expect_set_stream_version()
+        mock_indexer_manager
+            .expect_set_synced()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| Ok(()))
             .once();
+
+        let redis_client = RedisClient::default();
 
         let mut block_stream_handler = BlockStreamsHandler::default();
         block_stream_handler.expect_list().returning(|| Ok(vec![]));

--- a/coordinator/src/block_streams/synchronise.rs
+++ b/coordinator/src/block_streams/synchronise.rs
@@ -1,7 +1,7 @@
 use registry_types::StartBlock;
 
 use crate::indexer_config::IndexerConfig;
-use crate::indexer_manager::{IndexerManager, SyncStatus};
+use crate::indexer_state::{IndexerStateManager, SyncStatus};
 use crate::redis::RedisClient;
 use crate::registry::IndexerRegistry;
 
@@ -9,7 +9,7 @@ use super::handler::{BlockStreamsHandler, StreamInfo};
 
 pub async fn synchronise_block_streams(
     indexer_registry: &IndexerRegistry,
-    indexer_manager: &IndexerManager,
+    indexer_manager: &IndexerStateManager,
     redis_client: &RedisClient,
     block_streams_handler: &BlockStreamsHandler,
 ) -> anyhow::Result<()> {
@@ -70,7 +70,7 @@ pub async fn synchronise_block_streams(
 async fn synchronise_block_stream(
     active_block_stream: Option<StreamInfo>,
     indexer_config: &IndexerConfig,
-    indexer_manager: &IndexerManager,
+    indexer_manager: &IndexerStateManager,
     redis_client: &RedisClient,
     block_streams_handler: &BlockStreamsHandler,
 ) -> anyhow::Result<()> {
@@ -185,7 +185,7 @@ mod tests {
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
 
-        let mut mock_indexer_manager = IndexerManager::default();
+        let mut mock_indexer_manager = IndexerStateManager::default();
         mock_indexer_manager
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))
@@ -243,7 +243,7 @@ mod tests {
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
 
-        let mut mock_indexer_manager = IndexerManager::default();
+        let mut mock_indexer_manager = IndexerStateManager::default();
         mock_indexer_manager
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))
@@ -300,7 +300,7 @@ mod tests {
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
 
-        let mut mock_indexer_manager = IndexerManager::default();
+        let mut mock_indexer_manager = IndexerStateManager::default();
         mock_indexer_manager
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))
@@ -357,7 +357,7 @@ mod tests {
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
 
-        let mut mock_indexer_manager = IndexerManager::default();
+        let mut mock_indexer_manager = IndexerStateManager::default();
         mock_indexer_manager
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))
@@ -400,7 +400,7 @@ mod tests {
 
         let redis_client = RedisClient::default();
 
-        let mock_indexer_manager = IndexerManager::default();
+        let mock_indexer_manager = IndexerStateManager::default();
 
         let mut block_stream_handler = BlockStreamsHandler::default();
         block_stream_handler.expect_list().returning(|| {
@@ -449,7 +449,7 @@ mod tests {
 
         let redis_client = RedisClient::default();
 
-        let mut mock_indexer_manager = IndexerManager::default();
+        let mut mock_indexer_manager = IndexerStateManager::default();
         mock_indexer_manager
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))
@@ -497,7 +497,7 @@ mod tests {
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
 
-        let mut mock_indexer_manager = IndexerManager::default();
+        let mut mock_indexer_manager = IndexerStateManager::default();
         mock_indexer_manager
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))
@@ -565,7 +565,7 @@ mod tests {
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
 
-        let mut mock_indexer_manager = IndexerManager::default();
+        let mut mock_indexer_manager = IndexerStateManager::default();
         mock_indexer_manager
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))
@@ -613,7 +613,7 @@ mod tests {
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
 
-        let mut mock_indexer_manager = IndexerManager::default();
+        let mut mock_indexer_manager = IndexerStateManager::default();
         mock_indexer_manager
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))

--- a/coordinator/src/block_streams/synchronise.rs
+++ b/coordinator/src/block_streams/synchronise.rs
@@ -89,7 +89,9 @@ async fn synchronise_block_stream(
             .await?;
     }
 
-    let sync_status = indexer_manager.get_sync_status(indexer_config).await?;
+    let sync_status = indexer_manager
+        .get_block_stream_sync_status(indexer_config)
+        .await?;
 
     clear_block_stream_if_needed(&sync_status, indexer_config, redis_client).await?;
 
@@ -105,7 +107,9 @@ async fn synchronise_block_stream(
         .start(start_block_height, indexer_config)
         .await?;
 
-    indexer_manager.set_synced(indexer_config).await?;
+    indexer_manager
+        .set_block_stream_synced(indexer_config)
+        .await?;
 
     Ok(())
 }
@@ -187,11 +191,11 @@ mod tests {
 
         let mut mock_indexer_manager = IndexerStateManager::default();
         mock_indexer_manager
-            .expect_get_sync_status()
+            .expect_get_block_stream_sync_status()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| Ok(SyncStatus::Synced));
         mock_indexer_manager
-            .expect_set_synced()
+            .expect_set_block_stream_synced()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| Ok(()))
             .once();
@@ -245,11 +249,11 @@ mod tests {
 
         let mut mock_indexer_manager = IndexerStateManager::default();
         mock_indexer_manager
-            .expect_get_sync_status()
+            .expect_get_block_stream_sync_status()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| Ok(SyncStatus::Outdated));
         mock_indexer_manager
-            .expect_set_synced()
+            .expect_set_block_stream_synced()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| Ok(()))
             .once();
@@ -302,11 +306,11 @@ mod tests {
 
         let mut mock_indexer_manager = IndexerStateManager::default();
         mock_indexer_manager
-            .expect_get_sync_status()
+            .expect_get_block_stream_sync_status()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| Ok(SyncStatus::Outdated));
         mock_indexer_manager
-            .expect_set_synced()
+            .expect_set_block_stream_synced()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| Ok(()))
             .once();
@@ -359,11 +363,11 @@ mod tests {
 
         let mut mock_indexer_manager = IndexerStateManager::default();
         mock_indexer_manager
-            .expect_get_sync_status()
+            .expect_get_block_stream_sync_status()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| Ok(SyncStatus::Outdated));
         mock_indexer_manager
-            .expect_set_synced()
+            .expect_set_block_stream_synced()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| Ok(()))
             .once();
@@ -451,7 +455,7 @@ mod tests {
 
         let mut mock_indexer_manager = IndexerStateManager::default();
         mock_indexer_manager
-            .expect_get_sync_status()
+            .expect_get_block_stream_sync_status()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| Ok(SyncStatus::Synced));
 
@@ -499,11 +503,11 @@ mod tests {
 
         let mut mock_indexer_manager = IndexerStateManager::default();
         mock_indexer_manager
-            .expect_get_sync_status()
+            .expect_get_block_stream_sync_status()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| Ok(SyncStatus::Outdated));
         mock_indexer_manager
-            .expect_set_synced()
+            .expect_set_block_stream_synced()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| Ok(()))
             .once();
@@ -567,7 +571,7 @@ mod tests {
 
         let mut mock_indexer_manager = IndexerStateManager::default();
         mock_indexer_manager
-            .expect_get_sync_status()
+            .expect_get_block_stream_sync_status()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| Ok(SyncStatus::Outdated));
 
@@ -615,11 +619,11 @@ mod tests {
 
         let mut mock_indexer_manager = IndexerStateManager::default();
         mock_indexer_manager
-            .expect_get_sync_status()
+            .expect_get_block_stream_sync_status()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| Ok(SyncStatus::New));
         mock_indexer_manager
-            .expect_set_synced()
+            .expect_set_block_stream_synced()
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| Ok(()))
             .once();

--- a/coordinator/src/block_streams/synchronise.rs
+++ b/coordinator/src/block_streams/synchronise.rs
@@ -89,7 +89,7 @@ async fn synchronise_block_stream(
             .await?;
     }
 
-    let sync_status = indexer_manager.get_sync_status(indexer_config);
+    let sync_status = indexer_manager.get_sync_status(indexer_config).await?;
 
     clear_block_stream_if_needed(&sync_status, indexer_config, redis_client).await?;
 
@@ -189,7 +189,7 @@ mod tests {
         mock_indexer_manager
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))
-            .returning(|_| SyncStatus::Synced);
+            .returning(|_| Ok(SyncStatus::Synced));
         mock_indexer_manager
             .expect_set_synced()
             .with(predicate::eq(indexer_config.clone()))
@@ -247,7 +247,7 @@ mod tests {
         mock_indexer_manager
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))
-            .returning(|_| SyncStatus::Outdated);
+            .returning(|_| Ok(SyncStatus::Outdated));
         mock_indexer_manager
             .expect_set_synced()
             .with(predicate::eq(indexer_config.clone()))
@@ -304,7 +304,7 @@ mod tests {
         mock_indexer_manager
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))
-            .returning(|_| SyncStatus::Outdated);
+            .returning(|_| Ok(SyncStatus::Outdated));
         mock_indexer_manager
             .expect_set_synced()
             .with(predicate::eq(indexer_config.clone()))
@@ -361,7 +361,7 @@ mod tests {
         mock_indexer_manager
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))
-            .returning(|_| SyncStatus::Outdated);
+            .returning(|_| Ok(SyncStatus::Outdated));
         mock_indexer_manager
             .expect_set_synced()
             .with(predicate::eq(indexer_config.clone()))
@@ -453,7 +453,7 @@ mod tests {
         mock_indexer_manager
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))
-            .returning(|_| SyncStatus::Synced);
+            .returning(|_| Ok(SyncStatus::Synced));
 
         let mut block_stream_handler = BlockStreamsHandler::default();
         block_stream_handler.expect_list().returning(|| {
@@ -501,7 +501,7 @@ mod tests {
         mock_indexer_manager
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))
-            .returning(|_| SyncStatus::Outdated);
+            .returning(|_| Ok(SyncStatus::Outdated));
         mock_indexer_manager
             .expect_set_synced()
             .with(predicate::eq(indexer_config.clone()))
@@ -569,7 +569,7 @@ mod tests {
         mock_indexer_manager
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))
-            .returning(|_| SyncStatus::Outdated);
+            .returning(|_| Ok(SyncStatus::Outdated));
 
         let mut redis_client = RedisClient::default();
         redis_client
@@ -617,7 +617,7 @@ mod tests {
         mock_indexer_manager
             .expect_get_sync_status()
             .with(predicate::eq(indexer_config.clone()))
-            .returning(|_| SyncStatus::New);
+            .returning(|_| Ok(SyncStatus::New));
         mock_indexer_manager
             .expect_set_synced()
             .with(predicate::eq(indexer_config.clone()))

--- a/coordinator/src/block_streams/synchronise.rs
+++ b/coordinator/src/block_streams/synchronise.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 use registry_types::StartBlock;
 
 use crate::indexer_config::IndexerConfig;
+use crate::indexer_manager::{IndexerManager, IndexerState, SyncStatus};
 use crate::redis::RedisClient;
 use crate::registry::IndexerRegistry;
 
@@ -10,6 +11,7 @@ use super::handler::{BlockStreamsHandler, StreamInfo};
 
 pub async fn synchronise_block_streams(
     indexer_registry: &IndexerRegistry,
+    indexer_manager: &IndexerManager,
     redis_client: &RedisClient,
     block_streams_handler: &BlockStreamsHandler,
 ) -> anyhow::Result<()> {
@@ -24,9 +26,12 @@ pub async fn synchronise_block_streams(
                 })
                 .map(|index| active_block_streams.swap_remove(index));
 
+            let indexer_state = indexer_manager.get_state(indexer_config);
+
             let _ = synchronise_block_stream(
                 active_block_stream,
                 indexer_config,
+                &indexer_state,
                 redis_client,
                 block_streams_handler,
             )
@@ -69,6 +74,7 @@ pub async fn synchronise_block_streams(
 async fn synchronise_block_stream(
     active_block_stream: Option<StreamInfo>,
     indexer_config: &IndexerConfig,
+    indexer_state: &IndexerState,
     redis_client: &RedisClient,
     block_streams_handler: &BlockStreamsHandler,
 ) -> anyhow::Result<()> {
@@ -87,12 +93,12 @@ async fn synchronise_block_stream(
             .await?;
     }
 
-    let stream_status = get_stream_status(indexer_config, redis_client).await?;
+    let sync_status = indexer_state.get_sync_status(indexer_config);
 
-    clear_block_stream_if_needed(&stream_status, indexer_config, redis_client).await?;
+    clear_block_stream_if_needed(&sync_status, indexer_config, redis_client).await?;
 
     let start_block_height =
-        determine_start_block_height(&stream_status, indexer_config, redis_client).await?;
+        determine_start_block_height(&sync_status, indexer_config, redis_client).await?;
 
     tracing::info!(
         "Starting new block stream starting at block {}",
@@ -103,50 +109,18 @@ async fn synchronise_block_stream(
         .start(start_block_height, indexer_config)
         .await?;
 
+    // use indexer manager
     redis_client.set_stream_version(indexer_config).await?;
 
     Ok(())
 }
 
-#[derive(Debug, PartialEq, Eq)]
-enum StreamStatus {
-    /// Stream version is synchronized with the registry
-    Synced,
-    /// Stream version does not match registry
-    Outdated,
-    /// No stream version, therefore new
-    New,
-}
-
-async fn get_stream_status(
-    indexer_config: &IndexerConfig,
-    redis_client: &RedisClient,
-) -> anyhow::Result<StreamStatus> {
-    let stream_version = redis_client.get_stream_version(indexer_config).await?;
-
-    if stream_version.is_none() {
-        return Ok(StreamStatus::New);
-    }
-
-    let stream_version = stream_version.unwrap();
-
-    match indexer_config.get_registry_version().cmp(&stream_version) {
-        Ordering::Equal => Ok(StreamStatus::Synced),
-        Ordering::Greater => Ok(StreamStatus::Outdated),
-        Ordering::Less => {
-            tracing::warn!("Found stream with version greater than registry, treating as outdated");
-
-            Ok(StreamStatus::Outdated)
-        }
-    }
-}
-
 async fn clear_block_stream_if_needed(
-    stream_status: &StreamStatus,
+    sync_status: &SyncStatus,
     indexer_config: &IndexerConfig,
     redis_client: &RedisClient,
 ) -> anyhow::Result<()> {
-    if matches!(stream_status, StreamStatus::Synced | StreamStatus::New)
+    if matches!(sync_status, SyncStatus::Synced | SyncStatus::New)
         || indexer_config.start_block == StartBlock::Continue
     {
         return Ok(());
@@ -158,11 +132,11 @@ async fn clear_block_stream_if_needed(
 }
 
 async fn determine_start_block_height(
-    stream_status: &StreamStatus,
+    sync_status: &SyncStatus,
     indexer_config: &IndexerConfig,
     redis_client: &RedisClient,
 ) -> anyhow::Result<u64> {
-    if stream_status == &StreamStatus::Synced {
+    if sync_status == &SyncStatus::Synced {
         tracing::info!("Resuming block stream");
 
         return get_continuation_block_height(indexer_config, redis_client).await;
@@ -196,7 +170,7 @@ mod tests {
     use registry_types::{Rule, Status};
 
     #[tokio::test]
-    async fn resumes_stream_with_matching_redis_version() {
+    async fn resumes_previously_synced_stream() {
         let indexer_config = IndexerConfig {
             account_id: "morgs.near".parse().unwrap(),
             function_name: "test".to_string(),
@@ -216,12 +190,15 @@ mod tests {
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
 
-        let mut redis_client = RedisClient::default();
-        redis_client
-            .expect_get_stream_version()
+        let mut mock_indexer_manager = IndexerManager::default();
+        mock_indexer_manager
+            .expect_get_state()
             .with(predicate::eq(indexer_config.clone()))
-            .returning(|_| Ok(Some(200)))
-            .once();
+            .returning(|_| IndexerState {
+                synced_at: Some(200),
+            });
+
+        let mut redis_client = RedisClient::default();
         redis_client
             .expect_get_last_published_block()
             .with(predicate::eq(indexer_config.clone()))
@@ -242,9 +219,14 @@ mod tests {
             .returning(|_, _| Ok(()))
             .once();
 
-        synchronise_block_streams(&indexer_registry, &redis_client, &block_stream_handler)
-            .await
-            .unwrap();
+        synchronise_block_streams(
+            &indexer_registry,
+            &mock_indexer_manager,
+            &redis_client,
+            &block_stream_handler,
+        )
+        .await
+        .unwrap();
     }
 
     #[tokio::test]
@@ -262,17 +244,19 @@ mod tests {
             updated_at_block_height: Some(200),
             start_block: StartBlock::Latest,
         };
+
         let indexer_registry = HashMap::from([(
             "morgs.near".parse().unwrap(),
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
 
-        let mut redis_client = RedisClient::default();
-        redis_client
-            .expect_get_stream_version()
+        let mut mock_indexer_manager = IndexerManager::default();
+        mock_indexer_manager
+            .expect_get_state()
             .with(predicate::eq(indexer_config.clone()))
-            .returning(|_| Ok(Some(1)))
-            .once();
+            .returning(|_| IndexerState { synced_at: Some(1) });
+
+        let mut redis_client = RedisClient::default();
         redis_client
             .expect_clear_block_stream()
             .with(predicate::eq(indexer_config.clone()))
@@ -293,9 +277,14 @@ mod tests {
             .returning(|_, _| Ok(()))
             .once();
 
-        synchronise_block_streams(&indexer_registry, &redis_client, &block_stream_handler)
-            .await
-            .unwrap();
+        synchronise_block_streams(
+            &indexer_registry,
+            &mock_indexer_manager,
+            &redis_client,
+            &block_stream_handler,
+        )
+        .await
+        .unwrap();
     }
 
     #[tokio::test]
@@ -318,12 +307,13 @@ mod tests {
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
 
-        let mut redis_client = RedisClient::default();
-        redis_client
-            .expect_get_stream_version()
+        let mut mock_indexer_manager = IndexerManager::default();
+        mock_indexer_manager
+            .expect_get_state()
             .with(predicate::eq(indexer_config.clone()))
-            .returning(|_| Ok(Some(1)))
-            .once();
+            .returning(|_| IndexerState { synced_at: Some(1) });
+
+        let mut redis_client = RedisClient::default();
         redis_client
             .expect_clear_block_stream()
             .with(predicate::eq(indexer_config.clone()))
@@ -344,9 +334,14 @@ mod tests {
             .returning(|_, _| Ok(()))
             .once();
 
-        synchronise_block_streams(&indexer_registry, &redis_client, &block_stream_handler)
-            .await
-            .unwrap();
+        synchronise_block_streams(
+            &indexer_registry,
+            &mock_indexer_manager,
+            &redis_client,
+            &block_stream_handler,
+        )
+        .await
+        .unwrap();
     }
 
     #[tokio::test]
@@ -369,12 +364,13 @@ mod tests {
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
 
-        let mut redis_client = RedisClient::default();
-        redis_client
-            .expect_get_stream_version()
+        let mut mock_indexer_manager = IndexerManager::default();
+        mock_indexer_manager
+            .expect_get_state()
             .with(predicate::eq(indexer_config.clone()))
-            .returning(|_| Ok(Some(1)))
-            .once();
+            .returning(|_| IndexerState { synced_at: Some(1) });
+
+        let mut redis_client = RedisClient::default();
         redis_client
             .expect_get_last_published_block()
             .with(predicate::eq(indexer_config.clone()))
@@ -395,9 +391,14 @@ mod tests {
             .returning(|_, _| Ok(()))
             .once();
 
-        synchronise_block_streams(&indexer_registry, &redis_client, &block_stream_handler)
-            .await
-            .unwrap();
+        synchronise_block_streams(
+            &indexer_registry,
+            &mock_indexer_manager,
+            &redis_client,
+            &block_stream_handler,
+        )
+        .await
+        .unwrap();
     }
 
     #[tokio::test]
@@ -405,6 +406,8 @@ mod tests {
         let indexer_registry = HashMap::from([]);
 
         let redis_client = RedisClient::default();
+
+        let mut mock_indexer_manager = IndexerManager::default();
 
         let mut block_stream_handler = BlockStreamsHandler::default();
         block_stream_handler.expect_list().returning(|| {
@@ -421,34 +424,45 @@ mod tests {
             .returning(|_| Ok(()))
             .once();
 
-        synchronise_block_streams(&indexer_registry, &redis_client, &block_stream_handler)
-            .await
-            .unwrap();
+        synchronise_block_streams(
+            &indexer_registry,
+            &mock_indexer_manager,
+            &redis_client,
+            &block_stream_handler,
+        )
+        .await
+        .unwrap();
     }
 
     #[tokio::test]
-    async fn ignores_stream_with_matching_registry_version() {
+    async fn ignores_synced_stream() {
+        let indexer_config = IndexerConfig {
+            account_id: "morgs.near".parse().unwrap(),
+            function_name: "test".to_string(),
+            code: String::new(),
+            schema: String::new(),
+            rule: Rule::ActionAny {
+                affected_account_id: "queryapi.dataplatform.near".to_string(),
+                status: Status::Any,
+            },
+            created_at_block_height: 101,
+            updated_at_block_height: None,
+            start_block: StartBlock::Latest,
+        };
         let indexer_registry = HashMap::from([(
             "morgs.near".parse().unwrap(),
-            HashMap::from([(
-                "test".to_string(),
-                IndexerConfig {
-                    account_id: "morgs.near".parse().unwrap(),
-                    function_name: "test".to_string(),
-                    code: String::new(),
-                    schema: String::new(),
-                    rule: Rule::ActionAny {
-                        affected_account_id: "queryapi.dataplatform.near".to_string(),
-                        status: Status::Any,
-                    },
-                    created_at_block_height: 101,
-                    updated_at_block_height: None,
-                    start_block: StartBlock::Latest,
-                },
-            )]),
+            HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
 
         let redis_client = RedisClient::default();
+
+        let mut mock_indexer_manager = IndexerManager::default();
+        mock_indexer_manager
+            .expect_get_state()
+            .with(predicate::eq(indexer_config))
+            .returning(|_| IndexerState {
+                synced_at: Some(101),
+            });
 
         let mut block_stream_handler = BlockStreamsHandler::default();
         block_stream_handler.expect_list().returning(|| {
@@ -462,13 +476,18 @@ mod tests {
         block_stream_handler.expect_stop().never();
         block_stream_handler.expect_start().never();
 
-        synchronise_block_streams(&indexer_registry, &redis_client, &block_stream_handler)
-            .await
-            .unwrap();
+        synchronise_block_streams(
+            &indexer_registry,
+            &mock_indexer_manager,
+            &redis_client,
+            &block_stream_handler,
+        )
+        .await
+        .unwrap();
     }
 
     #[tokio::test]
-    async fn restarts_streams_when_registry_version_differs() {
+    async fn restarts_unsynced_streams() {
         let indexer_config = IndexerConfig {
             account_id: "morgs.near".parse().unwrap(),
             function_name: "test".to_string(),
@@ -487,12 +506,15 @@ mod tests {
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
 
-        let mut redis_client = RedisClient::default();
-        redis_client
-            .expect_get_stream_version()
+        let mut mock_indexer_manager = IndexerManager::default();
+        mock_indexer_manager
+            .expect_get_state()
             .with(predicate::eq(indexer_config.clone()))
-            .returning(|_| Ok(Some(101)))
-            .once();
+            .returning(|_| IndexerState {
+                synced_at: Some(250),
+            });
+
+        let mut redis_client = RedisClient::default();
         redis_client
             .expect_clear_block_stream()
             .with(predicate::eq(indexer_config.clone()))
@@ -524,9 +546,14 @@ mod tests {
             .returning(|_, _| Ok(()))
             .once();
 
-        synchronise_block_streams(&indexer_registry, &redis_client, &block_stream_handler)
-            .await
-            .unwrap();
+        synchronise_block_streams(
+            &indexer_registry,
+            &mock_indexer_manager,
+            &redis_client,
+            &block_stream_handler,
+        )
+        .await
+        .unwrap();
     }
 
     #[tokio::test]
@@ -549,12 +576,15 @@ mod tests {
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
 
-        let mut redis_client = RedisClient::default();
-        redis_client
-            .expect_get_stream_version()
+        let mut mock_indexer_manager = IndexerManager::default();
+        mock_indexer_manager
+            .expect_get_state()
             .with(predicate::eq(indexer_config.clone()))
-            .returning(|_| Ok(Some(101)))
-            .once();
+            .returning(|_| IndexerState {
+                synced_at: Some(101),
+            });
+
+        let mut redis_client = RedisClient::default();
         redis_client
             .expect_get_last_published_block()
             .with(predicate::eq(indexer_config.clone()))
@@ -566,13 +596,18 @@ mod tests {
         block_stream_handler.expect_stop().never();
         block_stream_handler.expect_start().never();
 
-        synchronise_block_streams(&indexer_registry, &redis_client, &block_stream_handler)
-            .await
-            .unwrap();
+        synchronise_block_streams(
+            &indexer_registry,
+            &mock_indexer_manager,
+            &redis_client,
+            &block_stream_handler,
+        )
+        .await
+        .unwrap();
     }
 
     #[tokio::test]
-    async fn starts_block_stream_for_first_time() {
+    async fn starts_new_stream() {
         let indexer_config = IndexerConfig {
             account_id: "morgs.near".parse().unwrap(),
             function_name: "test".to_string(),
@@ -591,12 +626,13 @@ mod tests {
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
 
-        let mut redis_client = RedisClient::default();
-        redis_client
-            .expect_get_stream_version()
+        let mut mock_indexer_manager = IndexerManager::default();
+        mock_indexer_manager
+            .expect_get_state()
             .with(predicate::eq(indexer_config.clone()))
-            .returning(|_| Ok(None))
-            .once();
+            .returning(|_| IndexerState { synced_at: None });
+
+        let mut redis_client = RedisClient::default();
         redis_client
             .expect_set_stream_version()
             .with(predicate::eq(indexer_config.clone()))
@@ -612,8 +648,13 @@ mod tests {
             .returning(|_, _| Ok(()))
             .once();
 
-        synchronise_block_streams(&indexer_registry, &redis_client, &block_stream_handler)
-            .await
-            .unwrap();
+        synchronise_block_streams(
+            &indexer_registry,
+            &mock_indexer_manager,
+            &redis_client,
+            &block_stream_handler,
+        )
+        .await
+        .unwrap();
     }
 }

--- a/coordinator/src/indexer_config.rs
+++ b/coordinator/src/indexer_config.rs
@@ -26,6 +26,10 @@ impl IndexerConfig {
         format!("{}:last_published_block", self.get_full_name())
     }
 
+    pub fn get_redis_stream_version_key(&self) -> String {
+        format!("{}:version", self.get_redis_stream_key())
+    }
+
     pub fn get_state_key(&self) -> String {
         format!("{}:state", self.get_full_name())
     }

--- a/coordinator/src/indexer_config.rs
+++ b/coordinator/src/indexer_config.rs
@@ -26,8 +26,8 @@ impl IndexerConfig {
         format!("{}:last_published_block", self.get_full_name())
     }
 
-    pub fn get_redis_stream_version_key(&self) -> String {
-        format!("{}:version", self.get_redis_stream_key())
+    pub fn get_state_key(&self) -> String {
+        format!("{}:state", self.get_full_name())
     }
 
     pub fn get_registry_version(&self) -> u64 {

--- a/coordinator/src/indexer_manager.rs
+++ b/coordinator/src/indexer_manager.rs
@@ -1,9 +1,7 @@
 use std::cmp::Ordering;
-use std::collections::HashMap;
-
-use near_primitives::types::AccountId;
 
 use crate::indexer_config::IndexerConfig;
+use crate::redis::RedisClient;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum SyncStatus {
@@ -12,15 +10,10 @@ pub enum SyncStatus {
     New,
 }
 
-// default if not exist?
-#[derive(Default, Clone)]
-pub struct IndexerState {
-    pub synced_at: Option<u64>,
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct IndexerState {
+    synced_at_block_height: u64,
 }
-
-type FunctionName = String;
-
-type IndexerStates = HashMap<(AccountId, FunctionName), IndexerState>;
 
 #[cfg(not(test))]
 pub use IndexerManagerImpl as IndexerManager;
@@ -29,21 +22,167 @@ pub use MockIndexerManagerImpl as IndexerManager;
 
 // binary semaphore to protect updating redis simultaneously
 // or wrap redis in a mutex
-pub struct IndexerManagerImpl;
+pub struct IndexerManagerImpl {
+    redis_client: RedisClient,
+}
 
 // IndexerStateManager?
 // StateManager?
 #[cfg_attr(test, mockall::automock)]
 impl IndexerManagerImpl {
-    pub fn new() -> Self {
-        Self
+    pub fn new(redis_client: RedisClient) -> Self {
+        Self { redis_client }
     }
 
-    pub fn get_sync_status(&self, indexer_config: &IndexerConfig) -> SyncStatus {
-        SyncStatus::Synced
+    async fn get_state(
+        &self,
+        indexer_config: &IndexerConfig,
+    ) -> anyhow::Result<Option<IndexerState>> {
+        let raw_state = self.redis_client.get_indexer_state(indexer_config).await?;
+
+        raw_state
+            .map(|raw_state| serde_json::from_str(&raw_state).map_err(Into::into))
+            .transpose()
+    }
+
+    pub async fn get_sync_status(
+        &self,
+        indexer_config: &IndexerConfig,
+    ) -> anyhow::Result<SyncStatus> {
+        let indexer_state = self.get_state(indexer_config).await?;
+
+        if indexer_state.is_none() {
+            return Ok(SyncStatus::New);
+        }
+
+        let indexer_state = indexer_state.unwrap();
+
+        match indexer_config
+            .get_registry_version()
+            .cmp(&indexer_state.synced_at_block_height)
+        {
+            Ordering::Equal => Ok(SyncStatus::Synced),
+            Ordering::Greater => Ok(SyncStatus::Outdated),
+            Ordering::Less => {
+                tracing::warn!(
+                    "Found stream with version greater than registry, treating as outdated"
+                );
+
+                Ok(SyncStatus::Outdated)
+            }
+        }
     }
 
     pub fn set_synced(&self, indexer_config: &IndexerConfig) -> anyhow::Result<()> {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use mockall::predicate;
+    use registry_types::{Rule, StartBlock, Status};
+
+    #[tokio::test]
+    pub async fn outdated_indexer() {
+        let indexer_config = IndexerConfig {
+            account_id: "morgs.near".parse().unwrap(),
+            function_name: "test".to_string(),
+            code: String::new(),
+            schema: String::new(),
+            rule: Rule::ActionAny {
+                affected_account_id: "queryapi.dataplatform.near".to_string(),
+                status: Status::Any,
+            },
+            created_at_block_height: 1,
+            updated_at_block_height: Some(200),
+            start_block: StartBlock::Continue,
+        };
+
+        let mut redis_client = RedisClient::default();
+        redis_client
+            .expect_get_indexer_state()
+            .with(predicate::eq(indexer_config.clone()))
+            .returning(|_| {
+                Ok(Some(
+                    serde_json::json!({ "synced_at_block_height": 300 }).to_string(),
+                ))
+            });
+
+        let indexer_manager = IndexerManagerImpl::new(redis_client);
+        let result = indexer_manager
+            .get_sync_status(&indexer_config)
+            .await
+            .unwrap();
+
+        assert_eq!(result, SyncStatus::Outdated);
+    }
+
+    #[tokio::test]
+    pub async fn synced_indexer() {
+        let indexer_config = IndexerConfig {
+            account_id: "morgs.near".parse().unwrap(),
+            function_name: "test".to_string(),
+            code: String::new(),
+            schema: String::new(),
+            rule: Rule::ActionAny {
+                affected_account_id: "queryapi.dataplatform.near".to_string(),
+                status: Status::Any,
+            },
+            created_at_block_height: 1,
+            updated_at_block_height: Some(200),
+            start_block: StartBlock::Continue,
+        };
+
+        let mut redis_client = RedisClient::default();
+        redis_client
+            .expect_get_indexer_state()
+            .with(predicate::eq(indexer_config.clone()))
+            .returning(|_| {
+                Ok(Some(
+                    serde_json::json!({ "synced_at_block_height": 200 }).to_string(),
+                ))
+            });
+
+        let indexer_manager = IndexerManagerImpl::new(redis_client);
+        let result = indexer_manager
+            .get_sync_status(&indexer_config)
+            .await
+            .unwrap();
+
+        assert_eq!(result, SyncStatus::Synced);
+    }
+
+    #[tokio::test]
+    pub async fn new_indexer() {
+        let indexer_config = IndexerConfig {
+            account_id: "morgs.near".parse().unwrap(),
+            function_name: "test".to_string(),
+            code: String::new(),
+            schema: String::new(),
+            rule: Rule::ActionAny {
+                affected_account_id: "queryapi.dataplatform.near".to_string(),
+                status: Status::Any,
+            },
+            created_at_block_height: 1,
+            updated_at_block_height: None,
+            start_block: StartBlock::Continue,
+        };
+
+        let mut redis_client = RedisClient::default();
+        redis_client
+            .expect_get_indexer_state()
+            .with(predicate::eq(indexer_config.clone()))
+            .returning(|_| Ok(None));
+
+        let indexer_manager = IndexerManagerImpl::new(redis_client);
+        let result = indexer_manager
+            .get_sync_status(&indexer_config)
+            .await
+            .unwrap();
+
+        assert_eq!(result, SyncStatus::New);
     }
 }

--- a/coordinator/src/indexer_manager.rs
+++ b/coordinator/src/indexer_manager.rs
@@ -7,11 +7,8 @@ use crate::indexer_config::IndexerConfig;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum SyncStatus {
-    /// Stream version is synchronized with the registry
     Synced,
-    /// Stream version does not match registry
     Outdated,
-    /// No stream version, therefore new
     New,
 }
 
@@ -19,53 +16,30 @@ pub enum SyncStatus {
 #[derive(Default, Clone)]
 pub struct IndexerState {
     pub synced_at: Option<u64>,
-    // merge in indexer config so don't need to pass in?
-}
-
-impl IndexerState {
-    pub fn get_sync_status(&self, indexer_config: &IndexerConfig) -> SyncStatus {
-        if self.synced_at.is_none() {
-            return SyncStatus::New;
-        }
-
-        match indexer_config
-            .get_registry_version()
-            .cmp(&self.synced_at.unwrap())
-        {
-            Ordering::Equal => SyncStatus::Synced,
-            Ordering::Greater => SyncStatus::Outdated,
-            Ordering::Less => {
-                tracing::warn!(
-                    "Found stream with version greater than registry, treating as outdated"
-                );
-
-                SyncStatus::Outdated
-            }
-        }
-    }
 }
 
 type FunctionName = String;
 
 type IndexerStates = HashMap<(AccountId, FunctionName), IndexerState>;
 
-// binary semaphore to protect updating redis simultaneously
-// or wrap redis in a mutex
 #[cfg(not(test))]
 pub use IndexerManagerImpl as IndexerManager;
 #[cfg(test)]
 pub use MockIndexerManagerImpl as IndexerManager;
 
+// binary semaphore to protect updating redis simultaneously
+// or wrap redis in a mutex
 pub struct IndexerManagerImpl;
 
 // IndexerStateManager?
+// StateManager?
 #[cfg_attr(test, mockall::automock)]
 impl IndexerManagerImpl {
     pub fn new() -> Self {
         Self
     }
 
-    pub fn get_state(&self, indexer_config: &IndexerConfig) -> IndexerState {
-        Default::default()
+    pub fn get_sync_status(&self, indexer_config: &IndexerConfig) -> SyncStatus {
+        SyncStatus::Synced
     }
 }

--- a/coordinator/src/indexer_manager.rs
+++ b/coordinator/src/indexer_manager.rs
@@ -42,4 +42,8 @@ impl IndexerManagerImpl {
     pub fn get_sync_status(&self, indexer_config: &IndexerConfig) -> SyncStatus {
         SyncStatus::Synced
     }
+
+    pub fn set_synced(&self, indexer_config: &IndexerConfig) -> anyhow::Result<()> {
+        Ok(())
+    }
 }

--- a/coordinator/src/indexer_manager.rs
+++ b/coordinator/src/indexer_manager.rs
@@ -1,0 +1,71 @@
+use std::cmp::Ordering;
+use std::collections::HashMap;
+
+use near_primitives::types::AccountId;
+
+use crate::indexer_config::IndexerConfig;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum SyncStatus {
+    /// Stream version is synchronized with the registry
+    Synced,
+    /// Stream version does not match registry
+    Outdated,
+    /// No stream version, therefore new
+    New,
+}
+
+// default if not exist?
+#[derive(Default, Clone)]
+pub struct IndexerState {
+    pub synced_at: Option<u64>,
+    // merge in indexer config so don't need to pass in?
+}
+
+impl IndexerState {
+    pub fn get_sync_status(&self, indexer_config: &IndexerConfig) -> SyncStatus {
+        if self.synced_at.is_none() {
+            return SyncStatus::New;
+        }
+
+        match indexer_config
+            .get_registry_version()
+            .cmp(&self.synced_at.unwrap())
+        {
+            Ordering::Equal => SyncStatus::Synced,
+            Ordering::Greater => SyncStatus::Outdated,
+            Ordering::Less => {
+                tracing::warn!(
+                    "Found stream with version greater than registry, treating as outdated"
+                );
+
+                SyncStatus::Outdated
+            }
+        }
+    }
+}
+
+type FunctionName = String;
+
+type IndexerStates = HashMap<(AccountId, FunctionName), IndexerState>;
+
+// binary semaphore to protect updating redis simultaneously
+// or wrap redis in a mutex
+#[cfg(not(test))]
+pub use IndexerManagerImpl as IndexerManager;
+#[cfg(test)]
+pub use MockIndexerManagerImpl as IndexerManager;
+
+pub struct IndexerManagerImpl;
+
+// IndexerStateManager?
+#[cfg_attr(test, mockall::automock)]
+impl IndexerManagerImpl {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn get_state(&self, indexer_config: &IndexerConfig) -> IndexerState {
+        Default::default()
+    }
+}

--- a/coordinator/src/indexer_state.rs
+++ b/coordinator/src/indexer_state.rs
@@ -18,20 +18,20 @@ struct IndexerState {
 }
 
 #[cfg(not(test))]
-pub use IndexerManagerImpl as IndexerManager;
+pub use IndexerStateManagerImpl as IndexerStateManager;
 #[cfg(test)]
-pub use MockIndexerManagerImpl as IndexerManager;
+pub use MockIndexerStateManagerImpl as IndexerStateManager;
 
 // binary semaphore to protect updating redis simultaneously
 // or wrap redis in a mutex
-pub struct IndexerManagerImpl {
+pub struct IndexerStateManagerImpl {
     redis_client: RedisClient,
 }
 
 // IndexerStateManager?
 // StateManager?
 #[cfg_attr(test, mockall::automock)]
-impl IndexerManagerImpl {
+impl IndexerStateManagerImpl {
     pub fn new(redis_client: RedisClient) -> Self {
         Self { redis_client }
     }
@@ -214,7 +214,7 @@ mod tests {
             .returning(|_, _| Ok(()))
             .once();
 
-        let indexer_manager = IndexerManagerImpl::new(mock_redis_client);
+        let indexer_manager = IndexerStateManagerImpl::new(mock_redis_client);
 
         indexer_manager
             .migrate_state_if_needed(&indexer_registry)
@@ -266,7 +266,7 @@ mod tests {
             .returning(|_, _| Ok(()))
             .never();
 
-        let indexer_manager = IndexerManagerImpl::new(mock_redis_client);
+        let indexer_manager = IndexerStateManagerImpl::new(mock_redis_client);
 
         indexer_manager
             .migrate_state_if_needed(&indexer_registry)
@@ -300,7 +300,7 @@ mod tests {
                 ))
             });
 
-        let indexer_manager = IndexerManagerImpl::new(redis_client);
+        let indexer_manager = IndexerStateManagerImpl::new(redis_client);
         let result = indexer_manager
             .get_sync_status(&indexer_config)
             .await
@@ -335,7 +335,7 @@ mod tests {
                 ))
             });
 
-        let indexer_manager = IndexerManagerImpl::new(redis_client);
+        let indexer_manager = IndexerStateManagerImpl::new(redis_client);
         let result = indexer_manager
             .get_sync_status(&indexer_config)
             .await
@@ -366,7 +366,7 @@ mod tests {
             .with(predicate::eq(indexer_config.clone()))
             .returning(|_| Ok(None));
 
-        let indexer_manager = IndexerManagerImpl::new(redis_client);
+        let indexer_manager = IndexerStateManagerImpl::new(redis_client);
         let result = indexer_manager
             .get_sync_status(&indexer_config)
             .await

--- a/coordinator/src/indexer_state.rs
+++ b/coordinator/src/indexer_state.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(dead_code))]
+
 use std::cmp::Ordering;
 
 use crate::indexer_config::IndexerConfig;

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -55,7 +55,9 @@ async fn main() -> anyhow::Result<()> {
     loop {
         let indexer_registry = registry.fetch().await?;
 
-        // migrate state
+        indexer_manager
+            .migrate_state_if_needed(&indexer_registry)
+            .await?;
 
         tokio::try_join!(
             synchronise_executors(&indexer_registry, &executors_handler),
@@ -70,7 +72,5 @@ async fn main() -> anyhow::Result<()> {
                 Ok(())
             }
         )?;
-
-        // flush state
     }
 }

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -41,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
     let redis_client = RedisClient::connect(&redis_url).await?;
     let block_streams_handler = BlockStreamsHandler::connect(&block_streamer_url)?;
     let executors_handler = ExecutorsHandler::connect(&runner_url)?;
-    let indexer_manager = IndexerManager::new();
+    let indexer_manager = IndexerManager::new(redis_client.clone());
 
     tracing::info!(
         rpc_url,

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -6,12 +6,14 @@ use tracing_subscriber::prelude::*;
 
 use crate::block_streams::{synchronise_block_streams, BlockStreamsHandler};
 use crate::executors::{synchronise_executors, ExecutorsHandler};
+use crate::indexer_manager::IndexerManager;
 use crate::redis::RedisClient;
 use crate::registry::Registry;
 
 mod block_streams;
 mod executors;
 mod indexer_config;
+mod indexer_manager;
 mod redis;
 mod registry;
 mod utils;
@@ -39,6 +41,7 @@ async fn main() -> anyhow::Result<()> {
     let redis_client = RedisClient::connect(&redis_url).await?;
     let block_streams_handler = BlockStreamsHandler::connect(&block_streamer_url)?;
     let executors_handler = ExecutorsHandler::connect(&runner_url)?;
+    let indexer_manager = IndexerManager::new();
 
     tracing::info!(
         rpc_url,
@@ -52,13 +55,22 @@ async fn main() -> anyhow::Result<()> {
     loop {
         let indexer_registry = registry.fetch().await?;
 
+        // migrate state
+
         tokio::try_join!(
             synchronise_executors(&indexer_registry, &executors_handler),
-            synchronise_block_streams(&indexer_registry, &redis_client, &block_streams_handler),
+            synchronise_block_streams(
+                &indexer_registry,
+                &indexer_manager,
+                &redis_client,
+                &block_streams_handler
+            ),
             async {
                 sleep(CONTROL_LOOP_THROTTLE_SECONDS).await;
                 Ok(())
             }
         )?;
+
+        // flush state
     }
 }

--- a/coordinator/src/redis.rs
+++ b/coordinator/src/redis.rs
@@ -12,11 +12,11 @@ pub use MockRedisClientImpl as RedisClient;
 #[cfg(not(test))]
 pub use RedisClientImpl as RedisClient;
 
+#[derive(Clone)]
 pub struct RedisClientImpl {
     connection: ConnectionManager,
 }
 
-#[cfg_attr(test, mockall::automock)]
 impl RedisClientImpl {
     pub async fn connect(redis_url: &str) -> anyhow::Result<Self> {
         let connection = redis::Client::open(redis_url)?
@@ -99,5 +99,23 @@ impl RedisClientImpl {
             indexer_config.get_registry_version(),
         )
         .await
+    }
+}
+
+#[cfg(test)]
+mockall::mock! {
+    pub RedisClientImpl {
+        pub async fn connect(redis_url: &str) -> anyhow::Result<Self>;
+
+        pub async fn get_last_published_block(
+            &self,
+            indexer_config: &IndexerConfig,
+        ) -> anyhow::Result<Option<u64>>;
+
+        pub async fn clear_block_stream(&self, indexer_config: &IndexerConfig) -> anyhow::Result<()>;
+    }
+
+    impl Clone for RedisClientImpl {
+        fn clone(&self) -> Self;
     }
 }

--- a/coordinator/src/redis.rs
+++ b/coordinator/src/redis.rs
@@ -73,14 +73,6 @@ impl RedisClientImpl {
         Ok(())
     }
 
-    pub async fn get_stream_version(
-        &self,
-        indexer_config: &IndexerConfig,
-    ) -> anyhow::Result<Option<u64>> {
-        self.get::<_, u64>(indexer_config.get_redis_stream_version_key())
-            .await
-    }
-
     pub async fn get_last_published_block(
         &self,
         indexer_config: &IndexerConfig,
@@ -93,12 +85,11 @@ impl RedisClientImpl {
         self.del(indexer_config.get_redis_stream_key()).await
     }
 
-    pub async fn set_stream_version(&self, indexer_config: &IndexerConfig) -> anyhow::Result<()> {
-        self.set(
-            indexer_config.get_redis_stream_version_key(),
-            indexer_config.get_registry_version(),
-        )
-        .await
+    pub async fn get_indexer_state(
+        &self,
+        indexer_config: &IndexerConfig,
+    ) -> anyhow::Result<Option<String>> {
+        self.get(indexer_config.get_state_key()).await
     }
 }
 
@@ -106,6 +97,8 @@ impl RedisClientImpl {
 mockall::mock! {
     pub RedisClientImpl {
         pub async fn connect(redis_url: &str) -> anyhow::Result<Self>;
+
+        pub async fn get_indexer_state(&self, indexer_config: &IndexerConfig) -> anyhow::Result<Option<String>>;
 
         pub async fn get_last_published_block(
             &self,

--- a/coordinator/src/redis.rs
+++ b/coordinator/src/redis.rs
@@ -91,6 +91,14 @@ impl RedisClientImpl {
     ) -> anyhow::Result<Option<String>> {
         self.get(indexer_config.get_state_key()).await
     }
+
+    pub async fn set_indexer_state(
+        &self,
+        indexer_config: &IndexerConfig,
+        state: String,
+    ) -> anyhow::Result<()> {
+        self.set(indexer_config.get_state_key(), state).await
+    }
 }
 
 #[cfg(test)]
@@ -99,6 +107,12 @@ mockall::mock! {
         pub async fn connect(redis_url: &str) -> anyhow::Result<Self>;
 
         pub async fn get_indexer_state(&self, indexer_config: &IndexerConfig) -> anyhow::Result<Option<String>>;
+
+        pub async fn set_indexer_state(
+            &self,
+            indexer_config: &IndexerConfig,
+            state: String,
+        ) -> anyhow::Result<()>;
 
         pub async fn get_last_published_block(
             &self,

--- a/coordinator/src/redis.rs
+++ b/coordinator/src/redis.rs
@@ -73,6 +73,14 @@ impl RedisClientImpl {
         Ok(())
     }
 
+    pub async fn get_stream_version(
+        &self,
+        indexer_config: &IndexerConfig,
+    ) -> anyhow::Result<Option<u64>> {
+        self.get::<_, u64>(indexer_config.get_redis_stream_version_key())
+            .await
+    }
+
     pub async fn get_last_published_block(
         &self,
         indexer_config: &IndexerConfig,
@@ -99,6 +107,14 @@ impl RedisClientImpl {
     ) -> anyhow::Result<()> {
         self.set(indexer_config.get_state_key(), state).await
     }
+
+    pub async fn set_migration_complete(&self) -> anyhow::Result<()> {
+        self.set("indexer_manager_migration_complete", true).await
+    }
+
+    pub async fn is_migration_complete(&self) -> anyhow::Result<Option<bool>> {
+        self.get("indexer_manager_migration_complete").await
+    }
 }
 
 #[cfg(test)]
@@ -114,12 +130,21 @@ mockall::mock! {
             state: String,
         ) -> anyhow::Result<()>;
 
+        pub async fn get_stream_version(
+            &self,
+            indexer_config: &IndexerConfig,
+        ) -> anyhow::Result<Option<u64>>;
+
         pub async fn get_last_published_block(
             &self,
             indexer_config: &IndexerConfig,
         ) -> anyhow::Result<Option<u64>>;
 
         pub async fn clear_block_stream(&self, indexer_config: &IndexerConfig) -> anyhow::Result<()>;
+
+        pub async fn set_migration_complete(&self) -> anyhow::Result<()>;
+
+        pub async fn is_migration_complete(&self) -> anyhow::Result<Option<bool>>;
     }
 
     impl Clone for RedisClientImpl {


### PR DESCRIPTION
This PR centralises persistent Indexer State within the `IndexerStateManager` struct. Currently, we only persist the "stream version", but this will soon grow to "enabled/disabled", which will be implemented in my next PR. This is just a tidy up to make the next step a bit easier.

Indexer state will be stored as stringified JSON under `{account_id}/{function_name}:state`, currently this only includes when the block stream was last synced. I've included a migration step in to move from the old key/structure to the new.