### PR TITLE
refactor: Simplify nested registry iteration

### DIFF
--- a/coordinator/src/block_streams/synchronise.rs
+++ b/coordinator/src/block_streams/synchronise.rs
@@ -184,7 +184,7 @@ mod tests {
             start_block: StartBlock::Height(100),
         };
 
-        let indexer_registry = HashMap::from([(
+        let indexer_registry = IndexerRegistry::from(&[(
             "morgs.near".parse().unwrap(),
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
@@ -242,7 +242,7 @@ mod tests {
             start_block: StartBlock::Latest,
         };
 
-        let indexer_registry = HashMap::from([(
+        let indexer_registry = IndexerRegistry::from(&[(
             "morgs.near".parse().unwrap(),
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
@@ -299,7 +299,7 @@ mod tests {
             updated_at_block_height: Some(200),
             start_block: StartBlock::Height(100),
         };
-        let indexer_registry = HashMap::from([(
+        let indexer_registry = IndexerRegistry::from(&[(
             "morgs.near".parse().unwrap(),
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
@@ -356,7 +356,7 @@ mod tests {
             updated_at_block_height: Some(200),
             start_block: StartBlock::Continue,
         };
-        let indexer_registry = HashMap::from([(
+        let indexer_registry = IndexerRegistry::from(&[(
             "morgs.near".parse().unwrap(),
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
@@ -400,7 +400,7 @@ mod tests {
 
     #[tokio::test]
     async fn stops_stream_not_in_registry() {
-        let indexer_registry = HashMap::from([]);
+        let indexer_registry = IndexerRegistry::from(&[]);
 
         let redis_client = RedisClient::default();
 
@@ -446,7 +446,7 @@ mod tests {
             updated_at_block_height: None,
             start_block: StartBlock::Latest,
         };
-        let indexer_registry = HashMap::from([(
+        let indexer_registry = IndexerRegistry::from(&[(
             "morgs.near".parse().unwrap(),
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
@@ -496,7 +496,7 @@ mod tests {
             updated_at_block_height: Some(199),
             start_block: StartBlock::Height(1000),
         };
-        let indexer_registry = HashMap::from([(
+        let indexer_registry = IndexerRegistry::from(&[(
             "morgs.near".parse().unwrap(),
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
@@ -564,7 +564,7 @@ mod tests {
             updated_at_block_height: Some(200),
             start_block: StartBlock::Continue,
         };
-        let indexer_registry = HashMap::from([(
+        let indexer_registry = IndexerRegistry::from(&[(
             "morgs.near".parse().unwrap(),
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);
@@ -612,7 +612,7 @@ mod tests {
             updated_at_block_height: None,
             start_block: StartBlock::Height(50),
         };
-        let indexer_registry = HashMap::from([(
+        let indexer_registry = IndexerRegistry::from(&[(
             "morgs.near".parse().unwrap(),
             HashMap::from([("test".to_string(), indexer_config.clone())]),
         )]);

--- a/coordinator/src/block_streams/synchronise.rs
+++ b/coordinator/src/block_streams/synchronise.rs
@@ -15,32 +15,31 @@ pub async fn synchronise_block_streams(
 ) -> anyhow::Result<()> {
     let mut active_block_streams = block_streams_handler.list().await?;
 
-    for (account_id, indexers) in indexer_registry.iter() {
-        for (function_name, indexer_config) in indexers.iter() {
-            let active_block_stream = active_block_streams
-                .iter()
-                .position(|stream| {
-                    stream.account_id == *account_id && &stream.function_name == function_name
-                })
-                .map(|index| active_block_streams.swap_remove(index));
+    for indexer_config in indexer_registry.iter() {
+        let active_block_stream = active_block_streams
+            .iter()
+            .position(|stream| {
+                stream.account_id == *indexer_config.account_id
+                    && stream.function_name == indexer_config.function_name
+            })
+            .map(|index| active_block_streams.swap_remove(index));
 
-            let _ = synchronise_block_stream(
-                active_block_stream,
-                indexer_config,
-                indexer_manager,
-                redis_client,
-                block_streams_handler,
+        let _ = synchronise_block_stream(
+            active_block_stream,
+            indexer_config,
+            indexer_manager,
+            redis_client,
+            block_streams_handler,
+        )
+        .await
+        .map_err(|err| {
+            tracing::error!(
+                account_id = indexer_config.account_id.as_str(),
+                function_name = indexer_config.function_name,
+                version = indexer_config.get_registry_version(),
+                "failed to sync block stream: {err:?}"
             )
-            .await
-            .map_err(|err| {
-                tracing::error!(
-                    account_id = account_id.as_str(),
-                    function_name,
-                    version = indexer_config.get_registry_version(),
-                    "failed to sync block stream: {err:?}"
-                )
-            });
-        }
+        });
     }
 
     for unregistered_block_stream in active_block_streams {

--- a/coordinator/src/executors/synchronise.rs
+++ b/coordinator/src/executors/synchronise.rs
@@ -113,10 +113,10 @@ mod tests {
             updated_at_block_height: None,
             start_block: StartBlock::Height(100),
         };
-        let indexer_registry = HashMap::from([(
+        let indexer_registry = IndexerRegistry(HashMap::from([(
             "morgs.near".parse().unwrap(),
             HashMap::from([("test".to_string(), indexer_config.clone())]),
-        )]);
+        )]));
 
         let mut executors_handler = ExecutorsHandler::default();
         executors_handler.expect_list().returning(|| Ok(vec![]));
@@ -146,10 +146,10 @@ mod tests {
             updated_at_block_height: Some(2),
             start_block: StartBlock::Height(100),
         };
-        let indexer_registry = HashMap::from([(
+        let indexer_registry = IndexerRegistry(HashMap::from([(
             "morgs.near".parse().unwrap(),
             HashMap::from([("test".to_string(), indexer_config.clone())]),
-        )]);
+        )]));
 
         let mut executors_handler = ExecutorsHandler::default();
         executors_handler.expect_list().returning(|| {
@@ -180,7 +180,7 @@ mod tests {
 
     #[tokio::test]
     async fn ignores_executor_with_matching_registry_version() {
-        let indexer_registry = HashMap::from([(
+        let indexer_registry = IndexerRegistry(HashMap::from([(
             "morgs.near".parse().unwrap(),
             HashMap::from([(
                 "test".to_string(),
@@ -198,7 +198,7 @@ mod tests {
                     start_block: StartBlock::Height(100),
                 },
             )]),
-        )]);
+        )]));
 
         let mut executors_handler = ExecutorsHandler::default();
         executors_handler.expect_list().returning(|| {
@@ -221,7 +221,7 @@ mod tests {
 
     #[tokio::test]
     async fn stops_executor_not_in_registry() {
-        let indexer_registry = HashMap::from([]);
+        let indexer_registry = IndexerRegistry::from(&[]);
 
         let mut executors_handler = ExecutorsHandler::default();
         executors_handler.expect_list().returning(|| {

--- a/coordinator/src/executors/synchronise.rs
+++ b/coordinator/src/executors/synchronise.rs
@@ -3,19 +3,11 @@ use crate::registry::IndexerRegistry;
 
 use super::handler::{ExecutorInfo, ExecutorsHandler};
 
-const V1_EXECUTOR_VERSION: u64 = 0;
-
 pub async fn synchronise_executors(
     indexer_registry: &IndexerRegistry,
     executors_handler: &ExecutorsHandler,
 ) -> anyhow::Result<()> {
-    let active_executors = executors_handler.list().await?;
-
-    // Ignore V1 executors
-    let mut active_executors: Vec<_> = active_executors
-        .into_iter()
-        .filter(|executor| executor.version != V1_EXECUTOR_VERSION)
-        .collect();
+    let mut active_executors = executors_handler.list().await?;
 
     for indexer_config in indexer_registry.iter() {
         let active_executor = active_executors

--- a/coordinator/src/indexer_state.rs
+++ b/coordinator/src/indexer_state.rs
@@ -65,17 +65,15 @@ impl IndexerStateManagerImpl {
 
         tracing::info!("Migrating indexer state");
 
-        for (_, indexers) in indexer_registry.iter() {
-            for (_, indexer_config) in indexers.iter() {
-                if let Some(version) = self.redis_client.get_stream_version(indexer_config).await? {
-                    self.set_state(
-                        indexer_config,
-                        IndexerState {
-                            block_stream_synced_at: Some(version),
-                        },
-                    )
-                    .await?;
-                }
+        for indexer_config in indexer_registry.iter() {
+            if let Some(version) = self.redis_client.get_stream_version(indexer_config).await? {
+                self.set_state(
+                    indexer_config,
+                    IndexerState {
+                        block_stream_synced_at: Some(version),
+                    },
+                )
+                .await?;
             }
         }
 

--- a/coordinator/src/indexer_state.rs
+++ b/coordinator/src/indexer_state.rs
@@ -164,7 +164,7 @@ mod tests {
             start_block: StartBlock::Height(100),
         };
 
-        let indexer_registry = HashMap::from([
+        let indexer_registry = IndexerRegistry(HashMap::from([
             (
                 "morgs.near".parse().unwrap(),
                 HashMap::from([("test".to_string(), morgs_config.clone())]),
@@ -173,7 +173,7 @@ mod tests {
                 "darunrs.near".parse().unwrap(),
                 HashMap::from([("test".to_string(), darunrs_config.clone())]),
             ),
-        ]);
+        ]));
 
         let mut mock_redis_client = RedisClient::default();
         mock_redis_client
@@ -235,10 +235,10 @@ mod tests {
             start_block: StartBlock::Height(100),
         };
 
-        let indexer_registry = HashMap::from([(
+        let indexer_registry = IndexerRegistry(HashMap::from([(
             "morgs.near".parse().unwrap(),
             HashMap::from([("test".to_string(), morgs_config.clone())]),
-        )]);
+        )]));
 
         let mut mock_redis_client = RedisClient::default();
         mock_redis_client


### PR DESCRIPTION
In Coordinator, to iterate over all Indexers you need two loops: one for the accounts, and another for its functions. As iteration is quite common, I've added a custom `Iterator` implementation which achieves the same with a single loop.