### PR TITLE
fix: Set backend only mutation

### DIFF
--- a/runner/src/hasura-client/__snapshots__/hasura-client.test.ts.snap
+++ b/runner/src/hasura-client/__snapshots__/hasura-client.test.ts.snap
@@ -46,6 +46,7 @@ exports[`HasuraClient adds the specified permissions for the specified roles/tab
     {
       "args": {
         "permission": {
+          "backend_only": true,
           "check": {},
           "columns": "*",
           "computed_fields": [],
@@ -63,6 +64,7 @@ exports[`HasuraClient adds the specified permissions for the specified roles/tab
     {
       "args": {
         "permission": {
+          "backend_only": true,
           "check": {},
           "columns": "*",
           "computed_fields": [],
@@ -80,6 +82,7 @@ exports[`HasuraClient adds the specified permissions for the specified roles/tab
     {
       "args": {
         "permission": {
+          "backend_only": true,
           "check": {},
           "columns": "*",
           "computed_fields": [],
@@ -115,6 +118,7 @@ exports[`HasuraClient adds the specified permissions for the specified roles/tab
     {
       "args": {
         "permission": {
+          "backend_only": true,
           "check": {},
           "columns": "*",
           "computed_fields": [],
@@ -132,6 +136,7 @@ exports[`HasuraClient adds the specified permissions for the specified roles/tab
     {
       "args": {
         "permission": {
+          "backend_only": true,
           "check": {},
           "columns": "*",
           "computed_fields": [],
@@ -149,6 +154,7 @@ exports[`HasuraClient adds the specified permissions for the specified roles/tab
     {
       "args": {
         "permission": {
+          "backend_only": true,
           "check": {},
           "columns": "*",
           "computed_fields": [],

--- a/runner/src/hasura-client/hasura-client.ts
+++ b/runner/src/hasura-client/hasura-client.ts
@@ -415,6 +415,7 @@ export default class HasuraClient {
                 check: {},
                 computed_fields: [],
                 filter: {},
+                ...(permission !== 'select' && { backend_only: true }),
                 ...(permission === 'select' && { allow_aggregations: true })
               },
             },


### PR DESCRIPTION
Hasura permissions were set without backend only mutations set. We no longer want to allow users to make mutations to the indexer data as the data should be consistent with the results of indexer code execution. For non-select permissions, Runner now sets backend only mutations. 