### PR TITLE
fix: Ensure Terminating Thread error is correctly templatized

### DIFF
--- a/runner/src/stream-handler/stream-handler.ts
+++ b/runner/src/stream-handler/stream-handler.ts
@@ -67,7 +67,7 @@ export default class StreamHandler {
     indexer.setStoppedStatus().catch((e) => {
       this.logger.error('Failed to set stopped status for indexer', e);
     });
-    const errorAsString = error.toString() === '[object Object]' ? JSON.stringify(error) : error.toString();
+    const errorAsString = error instanceof Error ? error.toString() : JSON.stringify(error);
     const streamErrorLogEntry = LogEntry.systemError(`Encountered error processing stream: ${this.indexerConfig.redisStreamKey}, terminating thread\n${errorAsString}`, this.executorContext.block_height);
 
     indexer.writeCrashedWorkerLog(streamErrorLogEntry)

--- a/runner/src/stream-handler/stream-handler.ts
+++ b/runner/src/stream-handler/stream-handler.ts
@@ -67,8 +67,8 @@ export default class StreamHandler {
     indexer.setStoppedStatus().catch((e) => {
       this.logger.error('Failed to set stopped status for indexer', e);
     });
-
-    const streamErrorLogEntry = LogEntry.systemError(`Encountered error processing stream: ${this.indexerConfig.redisStreamKey}, terminating thread\n${error.toString()}`, this.executorContext.block_height);
+    const errorAsString = error.toString() === '[object Object]' ? JSON.stringify(error) : error.toString();
+    const streamErrorLogEntry = LogEntry.systemError(`Encountered error processing stream: ${this.indexerConfig.redisStreamKey}, terminating thread\n${errorAsString}`, this.executorContext.block_height);
 
     indexer.writeCrashedWorkerLog(streamErrorLogEntry)
       .catch((e) => {

--- a/runner/src/stream-handler/stream-handler.ts
+++ b/runner/src/stream-handler/stream-handler.ts
@@ -67,8 +67,8 @@ export default class StreamHandler {
     indexer.setStoppedStatus().catch((e) => {
       this.logger.error('Failed to set stopped status for indexer', e);
     });
-    const errorAsString = error instanceof Error ? error.toString() : JSON.stringify(error);
-    const streamErrorLogEntry = LogEntry.systemError(`Encountered error processing stream: ${this.indexerConfig.redisStreamKey}, terminating thread\n${errorAsString}`, this.executorContext.block_height);
+    const errorContent = error instanceof Error ? error.toString() : JSON.stringify(error);
+    const streamErrorLogEntry = LogEntry.systemError(`Encountered error processing stream: ${this.indexerConfig.redisStreamKey}, terminating thread\n${errorContent}`, this.executorContext.block_height);
 
     indexer.writeCrashedWorkerLog(streamErrorLogEntry)
       .catch((e) => {


### PR DESCRIPTION
The error given to Stream Handler is occasionally a JSON object in disguise, and not an Error. As a result, calling error.toString() returns `[Object object]` rather than the error contents. I've added a check so that if the result of toString() is the earlier value, return a JSON.stringify result instead. Doing JSON.stringify on a proper Error type results in `{}`. The two cases must be handled separately. 

To test this, I created test indexers which called one of the two pieces of code which throw unawaited async errors. I verified both wrote the error message and stack trace into the log table. 

```
const timeoutPromise = new Promise((_, reject) => {
  setTimeout(() => {
      reject(new Error('Error thrown after 100ms'));
  }, 100);
});
```
```context.db.IndexerStorage.upsert({}, [], []); ```