### PR TITLE
feat: Implement Block Streamer Bitmap Operations

### DIFF
--- a/block-streamer/Cargo.lock
+++ b/block-streamer/Cargo.lock
@@ -905,6 +905,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,6 +969,7 @@ dependencies = [
  "aws-sdk-s3",
  "aws-smithy-runtime",
  "aws-smithy-types",
+ "base64 0.22.1",
  "borsh 0.10.3",
  "cached",
  "chrono",

--- a/block-streamer/Cargo.toml
+++ b/block-streamer/Cargo.toml
@@ -33,6 +33,7 @@ tonic = "0.10.2"
 wildmatch = "2.1.1"
 
 registry-types = { path = "../registry/types" }
+base64 = "0.22.1"
 
 [build-dependencies]
 tonic-build = "0.10"

--- a/block-streamer/src/bitmap.rs
+++ b/block-streamer/src/bitmap.rs
@@ -1,8 +1,6 @@
 use anyhow::anyhow;
 use base64::{engine::general_purpose, Engine as _};
 
-// const BLOCK_HEIGHTS_IN_DAY: usize = 86000;
-
 pub struct Base64Bitmap {
     pub start_block_height: usize,
     pub base64: String,

--- a/block-streamer/src/bitmap.rs
+++ b/block-streamer/src/bitmap.rs
@@ -1,0 +1,76 @@
+const BLOCK_HEIGHTS_IN_DAY: usize = 86000;
+
+pub struct Bitmap {
+    pub start_block_height: i32,
+    pub bitmap: [u8; BLOCK_HEIGHTS_IN_DAY / 8],
+}
+
+pub struct BitmapOperator {}
+
+#[cfg_attr(test, mockall::automock)]
+impl BitmapOperator {
+    pub fn new() -> Self {
+        Self {}
+    }
+    // pub fn add_compressed_bitmap(&self, base_bitmap: &mut Bitmap, add_bitmap: &Bitmap) -> () {}
+    //
+    // fn decompress_bitmap(&self, compressed_bitmap: &Bitmap) -> Bitmap {}
+    //
+    // fn index_of_first_bit_in_byte_array(
+    //     &self,
+    //     decompressed_bytes: &[u8],
+    //     start_bit_index: i32,
+    // ) -> i32 {
+    // }
+    //
+    // fn get_number_between_bits(
+    //     &self,
+    //     decompressed_bytes: &[u8],
+    //     start_bit_index: i32,
+    //     end_bit_index: i32,
+    // ) -> i32 {
+    // }
+
+    fn get_bit_in_byte_array(&self, decompressed_bytes: &[u8], bit_index: usize) -> bool {
+        let byte_index: usize = bit_index / 8;
+        let bit_index_in_byte: usize = bit_index % 8;
+        return (decompressed_bytes[byte_index] & (1 << (7 - bit_index_in_byte))) > 0;
+    }
+
+    // fn set_bit_in_byte_array(
+    //     &self,
+    //     decompressed_bytes: &mut [u8],
+    //     bit_index: i32,
+    //     bit_value: bool,
+    //     write_zero: Option<bool>,
+    // ) -> bool {
+    // }
+    //
+    // fn decode_elias_gamma_entry_from_bytes(
+    //     &self,
+    //     decompressed_bytes: &[u8],
+    //     start_bit: Option<i32>,
+    // ) -> &[u8] {
+    // }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_getting_bit_from_array() {
+        let operator: BitmapOperator = BitmapOperator::new();
+        let byte_array: &[u8; 3] = &[0x01, 0x00, 0x09]; // 0000 0001 0000 0000 0000 1001
+        let results: Vec<bool> = [7, 8, 9, 15, 19, 20, 22, 23]
+            .iter()
+            .map(|index| {
+                return operator.get_bit_in_byte_array(byte_array, *index);
+            })
+            .collect();
+        assert_eq!(
+            results,
+            [true, false, false, false, false, true, false, true]
+        );
+    }
+}

--- a/block-streamer/src/bitmap.rs
+++ b/block-streamer/src/bitmap.rs
@@ -34,17 +34,22 @@ impl BitmapOperator {
     fn get_bit_in_byte_array(&self, decompressed_bytes: &[u8], bit_index: usize) -> bool {
         let byte_index: usize = bit_index / 8;
         let bit_index_in_byte: usize = bit_index % 8;
-        return (decompressed_bytes[byte_index] & (1 << (7 - bit_index_in_byte))) > 0;
+        return (decompressed_bytes[byte_index] & (1u8 << (7 - bit_index_in_byte))) > 0;
     }
 
-    // fn set_bit_in_byte_array(
-    //     &self,
-    //     decompressed_bytes: &mut [u8],
-    //     bit_index: i32,
-    //     bit_value: bool,
-    //     write_zero: Option<bool>,
-    // ) -> bool {
-    // }
+    fn set_bit_in_byte_array(
+        &self,
+        decompressed_bytes: &mut [u8],
+        bit_index: usize,
+        bit_value: bool,
+        write_zero: Option<bool>,
+    ) {
+        if !bit_value && write_zero.unwrap_or(false) {
+            decompressed_bytes[bit_index / 8] &= !(1u8 << (7 - (bit_index % 8)));
+        } else if bit_value {
+            decompressed_bytes[bit_index / 8] |= 1u8 << (7 - (bit_index % 8));
+        }
+    }
     //
     // fn decode_elias_gamma_entry_from_bytes(
     //     &self,
@@ -72,5 +77,17 @@ mod tests {
             results,
             [true, false, false, false, false, true, false, true]
         );
+    }
+
+    #[test]
+    fn test_setting_bit_in_array() {
+        let operator: BitmapOperator = BitmapOperator::new();
+        let correct_byte_array: &[u8; 3] = &[0x01, 0x00, 0x09]; // 0000 0001 0000 0000 0000 1001
+        let test_byte_array: &mut [u8; 3] = &mut [0x80, 0x80, 0x09]; // 1000 0000 1000 0000 0000 1001
+        operator.set_bit_in_byte_array(test_byte_array, 0, false, Some(true));
+        operator.set_bit_in_byte_array(test_byte_array, 7, true, Some(true));
+        operator.set_bit_in_byte_array(test_byte_array, 8, false, Some(true));
+        operator.set_bit_in_byte_array(test_byte_array, 12, false, None);
+        assert_eq!(correct_byte_array, test_byte_array);
     }
 }

--- a/block-streamer/src/graphql/client.rs
+++ b/block-streamer/src/graphql/client.rs
@@ -1,6 +1,5 @@
 use ::reqwest;
 use graphql_client::{GraphQLQuery, Response};
-use std::error::Error;
 
 // TODO: Use Dataplatform account
 const HASURA_ACCOUNT: &str = "darunrs_near";

--- a/block-streamer/src/main.rs
+++ b/block-streamer/src/main.rs
@@ -1,5 +1,6 @@
 use tracing_subscriber::prelude::*;
 
+mod bitmap;
 mod block_stream;
 mod delta_lake_client;
 mod graphql;

--- a/coordinator/Cargo.lock
+++ b/coordinator/Cargo.lock
@@ -867,6 +867,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +929,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-s3",
+ "base64 0.22.1",
  "borsh 0.10.3",
  "cached",
  "chrono",


### PR DESCRIPTION
The bitmap indexer will return a list of bitmaps in the form of base 64 strings, and associated start block heights. We need a way to convert all that data into a single block height and an associated bitmap. 

This PR introduces a new BitmapOperator class which holds all the operations necessary to perform the function of returning a combined binary bitmap with the lowest start block height as index 0. 