### PR TITLE
Fix dead Links.

### DIFF
--- a/frontend/widgets/src/QueryApi.Dashboard.jsx
+++ b/frontend/widgets/src/QueryApi.Dashboard.jsx
@@ -324,8 +324,8 @@ const selectIndexerPage = (viewName) => {
   });
 };
 const indexerView = (accountId, indexerName) => {
-  const editUrl = `https://near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}`;
-  const statusUrl = `https://near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}&view=indexer&activeIndexerView=status`;
+  const editUrl = `https://dev.near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}`;
+  const statusUrl = `https://dev.near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}&view=indexer&activeIndexerView=status`;
   const playgroundLink = `https://cloud.hasura.io/public/graphiql?endpoint=${REPL_GRAPHQL_ENDPOINT}/v1/graphql&header=x-hasura-role%3A${accountId.replaceAll(
     ".",
     "_"
@@ -406,7 +406,7 @@ return (
     <Main>
       <Section active={state.activeTab === "explore"}>
         <NavBarLogo
-          href={`https://near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App`}
+          href={`https://dev.near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App`}
           title="QueryApi"
           onClick={() => selectTab("explore")}
         >

--- a/frontend/widgets/src/QueryApi.IndexerCard.jsx
+++ b/frontend/widgets/src/QueryApi.IndexerCard.jsx
@@ -1,7 +1,7 @@
 const accountId = props.accountId || context.accountId;
 const indexerName = props.indexerName;
-const editUrl = `https://near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}`;
-const statusUrl = `https://near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}&view=indexer&activeIndexerView=status`;
+const editUrl = `https://dev.near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}`;
+const statusUrl = `https://dev.near.org/#/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}&view=indexer&activeIndexerView=status`;
 const playgroundLink = `https://cloud.hasura.io/public/graphiql?endpoint=${REPL_GRAPHQL_ENDPOINT}/v1/graphql&header=x-hasura-role%3A${accountId.replaceAll(
   ".",
   "_"

--- a/frontend/widgets/src/QueryApi.IndexerExplorer.jsx
+++ b/frontend/widgets/src/QueryApi.IndexerExplorer.jsx
@@ -254,7 +254,7 @@ return (
         </H2>
         <H2>
           To learn more about QueryAPI, visit
-          <TextLink target="_blank" href="https://docs.near.org/bos/community/indexers" as="a" bold>
+          <TextLink target="_blank" href="https://docs.near.org/build/data-infrastructure/query-api/indexers" as="a" bold>
             QueryAPI Docs
           </TextLink>
         </H2>


### PR DESCRIPTION
The new website for [near.org](http://near.org/) is simply a marketing website now served by this repo and will no longer serve as the gatway: https://github.com/near/nearorg
The gateway now lives at [dev.near.org](http://dev.near.org/) and remains the same: https://github.com/near/near-discovery

Looked for dead links in queryAPI repo. A few I avoided that used alpha.near have not been modified. 
Changed most near.org to dev.near.org
