### PR TITLE
fix: Runner Hasura Test Container failing to start

### DIFF
--- a/runner/package-lock.json
+++ b/runner/package-lock.json
@@ -18,11 +18,12 @@
         "@opentelemetry/api": "^1.8.0",
         "@opentelemetry/exporter-zipkin": "^1.22.0",
         "@opentelemetry/resources": "^1.22.0",
-        "@opentelemetry/sdk-node": "^0.49.1",
+        "@opentelemetry/sdk-node": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.22.0",
         "@opentelemetry/sdk-trace-node": "^1.22.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "express": "^4.18.2",
+        "graphql": "^16.8.1",
         "long": "^5.2.3",
         "node-fetch": "^2.6.11",
         "node-sql-parser": "^5.0.0",
@@ -2794,9 +2795,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.49.1.tgz",
-      "integrity": "sha512-kaNl/T7WzyMUQHQlVq7q0oV4Kev6+0xFwqzofryC66jgGMacd0QH5TwfpbUwSTby+SdAdprAe5UKMvBw4tKS5Q==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.50.0.tgz",
+      "integrity": "sha512-JdZuKrhOYggqOpUljAq4WWNi5nB10PmgoF0y2CvedLGXd0kSawb/UBnWT8gg1ND3bHCNHStAIVT0ELlxJJRqrA==",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -2805,9 +2806,9 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.22.0.tgz",
-      "integrity": "sha512-Nfdxyg8YtWqVWkyrCukkundAjPhUXi93JtVQmqDT1mZRVKqA7e2r7eJCrI+F651XUBMp0hsOJSGiFk3QSpaIJw==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.23.0.tgz",
+      "integrity": "sha512-wazGJZDRevibOJ+VgyrT+9+8sybZAxpZx2G7vy30OAtk92OpZCg7HgNxT11NUx0VBDWcRx1dOatMYGOVplQ7QA==",
       "engines": {
         "node": ">=14"
       },
@@ -2816,11 +2817,11 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.22.0.tgz",
-      "integrity": "sha512-0VoAlT6x+Xzik1v9goJ3pZ2ppi6+xd3aUfg4brfrLkDBHRIVjMP0eBHrKrhB+NKcDyMAg8fAbGL3Npg/F6AwWA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+      "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -2830,16 +2831,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.49.1.tgz",
-      "integrity": "sha512-Zbd7f3zF7fI2587MVhBizaW21cO/SordyrZGtMtvhoxU6n4Qb02Gx71X4+PzXH620e0+JX+Pcr9bYb1HTeVyJA==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.50.0.tgz",
+      "integrity": "sha512-w/NF4TrwHxx+Uz1M0rCOSVr6KgcoQPv3zF9JRqcebY2euD7ddWnLP0hE8JavyA1uq4UchnMp9faAk9n7hTCePw==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -2849,15 +2850,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.49.1.tgz",
-      "integrity": "sha512-KOLtZfZvIrpGZLVvblKsiVQT7gQUZNKcUUH24Zz6Xbi7LJb9Vt6xtUZFYdR5IIjvt47PIqBKDWUQlU0o1wAsRw==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.50.0.tgz",
+      "integrity": "sha512-L7OtIMT7MsFqkmhbQlPBGRXt7152VN5esHpQEJYIBFedOEo3Da+yHpu5ojMZtPzpIvSpB5Xr5lnJUjJCbkttCA==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -2867,16 +2868,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.49.1.tgz",
-      "integrity": "sha512-n8ON/c9pdMyYAfSFWKkgsPwjYoxnki+6Olzo+klKfW7KqLWoyEkryNkbcMIYnGGNXwdkMIrjoaP0VxXB26Oxcg==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.50.0.tgz",
+      "integrity": "sha512-vavD9Ow6yOLiD+ocuS/oeciCsXNdsN41aYUrEljNaLXogvnkfMhJ+JLAhOnRSpzlVtRp7Ciw2BYGdYSebR0OsA==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-proto-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -2886,14 +2887,14 @@
       }
     },
     "node_modules/@opentelemetry/exporter-zipkin": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.22.0.tgz",
-      "integrity": "sha512-XcFs6rGvcTz0qW5uY7JZDYD0yNEXdekXAb6sFtnZgY/cHY6BQ09HMzOjv9SX+iaXplRDcHr1Gta7VQKM1XXM6g==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.23.0.tgz",
+      "integrity": "sha512-2LOGvNUGONuIcWhynFaJorVyqv03uZkURScciLmOxvBf2lWTNPEj77br1dCpShIWBM+YlrH7Tc+JXAs+GC7DqA==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -2903,11 +2904,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.49.1.tgz",
-      "integrity": "sha512-0DLtWtaIppuNNRRllSD4bjU8ZIiLp1cDXvJEbp752/Zf+y3gaLNaoGRGIlX4UHhcsrmtL+P2qxi3Hodi8VuKiQ==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.50.0.tgz",
+      "integrity": "sha512-bhGhbJiZKpuu7wTaSak4hyZcFPlnDeuSF/2vglze8B4w2LubcSbbOnkVTzTs5SXtzh4Xz8eRjaNnAm+u2GYufQ==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.49.1",
+        "@opentelemetry/api-logs": "0.50.0",
         "@types/shimmer": "^1.0.2",
         "import-in-the-middle": "1.7.1",
         "require-in-the-middle": "^7.1.1",
@@ -2922,11 +2923,11 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.49.1.tgz",
-      "integrity": "sha512-z6sHliPqDgJU45kQatAettY9/eVF58qVPaTuejw9YWfSRqid9pXPYeegDCSdyS47KAUgAtm+nC28K3pfF27HWg==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.50.0.tgz",
+      "integrity": "sha512-JUmjmrCmE1/fc4LjCQMqLfudgSl5OpUkzx7iA94b4jgeODM7zWxUoVXL7/CT7fWf47Cn+pmKjMvTCSESqZZ3mA==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0"
+        "@opentelemetry/core": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -2936,13 +2937,13 @@
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.49.1.tgz",
-      "integrity": "sha512-DNDNUWmOqtKTFJAyOyHHKotVox0NQ/09ETX8fUOeEtyNVHoGekAVtBbvIA3AtK+JflP7LC0PTjlLfruPM3Wy6w==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.50.0.tgz",
+      "integrity": "sha512-J500AczSD7xEsjXpwNzSh5HQqxW73PT3CCNsi1VEWCE+8UPgVfkHYIGRHGoch35DV+CMe1svbi7gAk3e5eCSVA==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
         "protobufjs": "^7.2.3"
       },
       "engines": {
@@ -2953,12 +2954,12 @@
       }
     },
     "node_modules/@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.49.1.tgz",
-      "integrity": "sha512-x1qB4EUC7KikUl2iNuxCkV8yRzrSXSyj4itfpIO674H7dhI7Zv37SFaOJTDN+8Z/F50gF2ISFH9CWQ4KCtGm2A==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.50.0.tgz",
+      "integrity": "sha512-hlbn3eZbhxoK79Sq1ddj1f7qcx+PzsPQC/SFpJvaWgTaqacCbqJmpzWDKfRRCAC7iGX2Hj/sgpf8vysazqyMOw==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
         "protobufjs": "^7.2.3"
       },
       "engines": {
@@ -2969,16 +2970,16 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.49.1.tgz",
-      "integrity": "sha512-Z+koA4wp9L9e3jkFacyXTGphSWTbOKjwwXMpb0CxNb0kjTHGUxhYRN8GnkLFsFo5NbZPjP07hwAqeEG/uCratQ==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.50.0.tgz",
+      "integrity": "sha512-s0sl1Yfqd5q1Kjrf6DqXPWzErL+XHhrXOfejh4Vc/SMTNqC902xDsC8JQxbjuramWt/+hibfguIvi7Ns8VLolA==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.49.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-logs": "0.49.1",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0"
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-logs": "0.50.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -2988,11 +2989,11 @@
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.22.0.tgz",
-      "integrity": "sha512-qBItJm9ygg/jCB5rmivyGz1qmKZPsL/sX715JqPMFgq++Idm0x+N9sLQvWFHFt2+ZINnCSojw7FVBgFW6izcXA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.23.0.tgz",
+      "integrity": "sha512-cZ6rl8y2bdxYQ4e+zP2CQ+QmuPebaLBLO1skjFpj3eEu7zar+6hBzUP3llMOUupkQeQSwXz+4c8dZ26OhYfG/g==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0"
+        "@opentelemetry/core": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -3002,11 +3003,11 @@
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.22.0.tgz",
-      "integrity": "sha512-pMLgst3QIwrUfepraH5WG7xfpJ8J3CrPKrtINK0t7kBkuu96rn+HDYQ8kt3+0FXvrZI8YJE77MCQwnJWXIrgpA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.23.0.tgz",
+      "integrity": "sha512-6iArixfgIl3ZgzeltQ5jyiKbjZygM+MbM84pXi1HL0Qs4x4Ck5rM6wEtjhZffFnlDMWEkEqrnM0xF6bTfbiMAQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0"
+        "@opentelemetry/core": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -3016,12 +3017,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
-      "integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.23.0.tgz",
+      "integrity": "sha512-iPRLfVfcEQynYGo7e4Di+ti+YQTAY0h5mQEUJcHlU9JOqpb4x965O6PZ+wMcwYVY63G96KtdS86YCM1BF1vQZg==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -3031,12 +3032,12 @@
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.49.1.tgz",
-      "integrity": "sha512-gCzYWsJE0h+3cuh3/cK+9UwlVFyHvj3PReIOCDOmdeXOp90ZjKRoDOJBc3mvk1LL6wyl1RWIivR8Rg9OToyesw==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.50.0.tgz",
+      "integrity": "sha512-PeUEupBB29p9nlPNqXoa1PUWNLsZnxG0DCDj3sHqzae+8y76B/A5hvZjg03ulWdnvBLYpnJslqzylG9E0IL87g==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -3047,12 +3048,12 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.22.0.tgz",
-      "integrity": "sha512-k6iIx6H3TZ+BVMr2z8M16ri2OxWaljg5h8ihGJxi/KQWcjign6FEaEzuigXt5bK9wVEhqAcWLCfarSftaNWkkg==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.23.0.tgz",
+      "integrity": "sha512-4OkvW6+wST4h6LFG23rXSTf6nmTf201h9dzq7bE0z5R9ESEVLERZz6WXwE7PSgg1gdjlaznm1jLJf8GttypFDg==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
         "lodash.merge": "^4.6.2"
       },
       "engines": {
@@ -3063,23 +3064,23 @@
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.49.1.tgz",
-      "integrity": "sha512-feBIT85ndiSHXsQ2gfGpXC/sNeX4GCHLksC4A9s/bfpUbbgbCSl0RvzZlmEpCHarNrkZMwFRi4H0xFfgvJEjrg==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.50.0.tgz",
+      "integrity": "sha512-LhIXHnvcnhRYcPwG9VG4G6lJ7x4ElYF6UYHHmXA7e4ZWzSUEFmAPfR1IBWv358aD1KwffcEBu7J6zeAR7lPZag==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.49.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.49.1",
-        "@opentelemetry/exporter-zipkin": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-logs": "0.49.1",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/sdk-trace-node": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.50.0",
+        "@opentelemetry/exporter-zipkin": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-logs": "0.50.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/sdk-trace-node": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -3089,13 +3090,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.22.0.tgz",
-      "integrity": "sha512-pfTuSIpCKONC6vkTpv6VmACxD+P1woZf4q0K46nSUvXFvOFqjBYKFaAMkKD3M1mlKUUh0Oajwj35qNjMl80m1Q==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.23.0.tgz",
+      "integrity": "sha512-PzBmZM8hBomUqvCddF/5Olyyviayka44O5nDWq673np3ctnvwMOvNrsUORZjKja1zJbwEuD9niAGbnVrz3jwRQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -3105,15 +3106,15 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.22.0.tgz",
-      "integrity": "sha512-gTGquNz7ue8uMeiWPwp3CU321OstQ84r7PCDtOaCicjbJxzvO8RZMlEC4geOipTeiF88kss5n6w+//A0MhP1lQ==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.23.0.tgz",
+      "integrity": "sha512-dwnin5Go2r6VzJZkVc9JBPupssWp7j2EFto+S7qRkwQ00WDykWeq3x2Skk7I1Jr448FeBSvGCQVPgV5e6s6O3w==",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.22.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/propagator-b3": "1.22.0",
-        "@opentelemetry/propagator-jaeger": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/context-async-hooks": "1.23.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/propagator-b3": "1.23.0",
+        "@opentelemetry/propagator-jaeger": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -3124,9 +3125,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.22.0.tgz",
-      "integrity": "sha512-CAOgFOKLybd02uj/GhCdEeeBjOS0yeoDeo/CA7ASBSmenpZHAKGB3iDm/rv3BQLcabb/OprDEsSQ1y0P8A7Siw==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.23.0.tgz",
+      "integrity": "sha512-MiqFvfOzfR31t8cc74CTP1OZfz7MbqpAnLCra8NqQoaHJX6ncIRTdYOQYBDQ2uFISDq0WY8Y9dDTWvsgzzBYRg==",
       "engines": {
         "node": ">=14"
       }
@@ -7791,8 +7792,6 @@
       "version": "16.8.1",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
       "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
-      "dev": true,
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -10634,9 +10633,9 @@
       }
     },
     "node_modules/require-in-the-middle": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz",
-      "integrity": "sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.3.0.tgz",
+      "integrity": "sha512-nQFEv9gRw6SJAwWD2LrL0NmQvAcO7FBwJbwmr2ttPAacfy0xuiOjE5zt+zM4xDyuyvUaxBi/9gb2SoCyNEVJcw==",
       "dependencies": {
         "debug": "^4.1.1",
         "module-details-from-path": "^1.0.3",

--- a/runner/tests/testcontainers/hasura.ts
+++ b/runner/tests/testcontainers/hasura.ts
@@ -11,7 +11,7 @@ export class HasuraGraphQLContainer {
 
   private constructor (private readonly container: GenericContainer) {
     container.withExposedPorts(this.PORT)
-      .withWaitStrategy(Wait.forLogMessage(/.*starting API server*/, 2))
+      .withWaitStrategy(Wait.forLogMessage(/.*Starting API server.*/, 2))
       .withLogConsumer(logConsumer)
       .withStartupTimeout(120_000);
   }


### PR DESCRIPTION
Runner's Hasura Client test container was exceeding its 120s timeout for the "starting API Server" log message. It turns out the start message now uses a capital S, which was the cause of the error. Changing this allowed the integ tests to work again.