### PR TITLE
refactor: Unify logic for generating Redis keys

### DIFF
--- a/coordinator/src/handlers/block_streams.rs
+++ b/coordinator/src/handlers/block_streams.rs
@@ -12,6 +12,7 @@ use tonic::transport::channel::Channel;
 use tonic::Request;
 
 use crate::indexer_config::IndexerConfig;
+use crate::redis::KeyProvider;
 use crate::utils::exponential_retry;
 
 #[cfg(not(test))]

--- a/coordinator/src/handlers/executors.rs
+++ b/coordinator/src/handlers/executors.rs
@@ -9,6 +9,7 @@ use tonic::transport::channel::Channel;
 use tonic::Request;
 
 use crate::indexer_config::IndexerConfig;
+use crate::redis::KeyProvider;
 use crate::utils::exponential_retry;
 
 #[cfg(not(test))]

--- a/coordinator/src/indexer_config.rs
+++ b/coordinator/src/indexer_config.rs
@@ -1,6 +1,8 @@
 use near_primitives::types::AccountId;
 use registry_types::{Rule, StartBlock};
 
+use crate::redis::KeyProvider;
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct IndexerConfig {
     pub account_id: AccountId,
@@ -11,6 +13,16 @@ pub struct IndexerConfig {
     pub rule: Rule,
     pub updated_at_block_height: Option<u64>,
     pub created_at_block_height: u64,
+}
+
+impl KeyProvider for IndexerConfig {
+    fn account_id(&self) -> String {
+        self.account_id.to_string()
+    }
+
+    fn function_name(&self) -> String {
+        self.function_name.clone()
+    }
 }
 
 #[cfg(test)]
@@ -35,18 +47,6 @@ impl Default for IndexerConfig {
 impl IndexerConfig {
     pub fn get_full_name(&self) -> String {
         format!("{}/{}", self.account_id, self.function_name)
-    }
-
-    pub fn get_redis_stream_key(&self) -> String {
-        format!("{}:block_stream", self.get_full_name())
-    }
-
-    pub fn get_last_published_block_key(&self) -> String {
-        format!("{}:last_published_block", self.get_full_name())
-    }
-
-    pub fn get_state_key(&self) -> String {
-        format!("{}:state", self.get_full_name())
     }
 
     pub fn get_registry_version(&self) -> u64 {

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -77,8 +77,6 @@ async fn main() -> anyhow::Result<()> {
         async move { server::init(grpc_port, indexer_state_manager, registry).await }
     });
 
-    indexer_state_manager.migrate().await?;
-
     loop {
         tokio::try_join!(synchroniser.sync(), sleep(CONTROL_LOOP_THROTTLE_SECONDS))?;
     }

--- a/coordinator/src/redis.rs
+++ b/coordinator/src/redis.rs
@@ -5,7 +5,26 @@ use std::fmt::Debug;
 use anyhow::Context;
 use redis::{aio::ConnectionManager, FromRedisValue, ToRedisArgs};
 
-use crate::{indexer_config::IndexerConfig, indexer_state::IndexerState};
+pub trait KeyProvider {
+    fn account_id(&self) -> String;
+    fn function_name(&self) -> String;
+
+    fn prefix(&self) -> String {
+        format!("{}/{}", self.account_id(), self.function_name())
+    }
+
+    fn get_redis_stream_key(&self) -> String {
+        format!("{}:block_stream", self.prefix())
+    }
+
+    fn get_last_published_block_key(&self) -> String {
+        format!("{}:last_published_block", self.prefix())
+    }
+
+    fn get_state_key(&self) -> String {
+        format!("{}:state", self.prefix())
+    }
+}
 
 #[cfg(test)]
 pub use MockRedisClientImpl as RedisClient;
@@ -136,43 +155,48 @@ impl RedisClientImpl {
         self.exists(Self::INDEXER_STATES_SET).await
     }
 
-    pub async fn get_last_published_block(
-        &self,
-        indexer_config: &IndexerConfig,
-    ) -> anyhow::Result<Option<u64>> {
-        self.get::<_, u64>(indexer_config.get_last_published_block_key())
+    pub async fn get_last_published_block<P>(&self, key_provider: &P) -> anyhow::Result<Option<u64>>
+    where
+        P: KeyProvider + 'static,
+    {
+        self.get::<_, u64>(key_provider.get_last_published_block_key())
             .await
     }
 
-    pub async fn clear_block_stream(&self, indexer_config: &IndexerConfig) -> anyhow::Result<()> {
-        let stream_key = indexer_config.get_redis_stream_key();
+    pub async fn clear_block_stream<P>(&self, key_provider: &P) -> anyhow::Result<()>
+    where
+        P: KeyProvider + 'static,
+    {
+        let stream_key = key_provider.get_redis_stream_key();
         self.del(stream_key.clone())
             .await
             .context(format!("Failed to clear Redis Stream: {}", stream_key))
     }
 
-    pub async fn get_indexer_state(
-        &self,
-        indexer_config: &IndexerConfig,
-    ) -> anyhow::Result<Option<String>> {
-        self.get(indexer_config.get_state_key()).await
+    pub async fn get_indexer_state<P>(&self, key_provider: &P) -> anyhow::Result<Option<String>>
+    where
+        P: KeyProvider + 'static,
+    {
+        self.get(key_provider.get_state_key()).await
     }
 
-    pub async fn set_indexer_state(
-        &self,
-        indexer_config: &IndexerConfig,
-        state: String,
-    ) -> anyhow::Result<()> {
-        self.set(indexer_config.get_state_key(), state).await?;
+    pub async fn set_indexer_state<P>(&self, key_provider: &P, state: String) -> anyhow::Result<()>
+    where
+        P: KeyProvider + 'static,
+    {
+        self.set(key_provider.get_state_key(), state).await?;
 
-        self.sadd(Self::INDEXER_STATES_SET, indexer_config.get_state_key())
+        self.sadd(Self::INDEXER_STATES_SET, key_provider.get_state_key())
             .await
     }
 
-    pub async fn delete_indexer_state(&self, state: &IndexerState) -> anyhow::Result<()> {
-        self.del(state.get_state_key()).await?;
+    pub async fn delete_indexer_state<P>(&self, key_provider: &P) -> anyhow::Result<()>
+    where
+        P: KeyProvider + 'static,
+    {
+        self.del(key_provider.get_state_key()).await?;
 
-        self.srem(Self::INDEXER_STATES_SET, state.get_state_key())
+        self.srem(Self::INDEXER_STATES_SET, key_provider.get_state_key())
             .await
     }
 
@@ -202,30 +226,34 @@ mockall::mock! {
     pub RedisClientImpl {
         pub async fn connect(redis_url: &str) -> anyhow::Result<Self>;
 
-        pub async fn get_indexer_state(&self, indexer_config: &IndexerConfig) -> anyhow::Result<Option<String>>;
+        pub async fn get_indexer_state<P>(&self, key_provider: &P) -> anyhow::Result<Option<String>>
+            where P: KeyProvider + 'static;
 
-        pub async fn set_indexer_state(
+        pub async fn set_indexer_state<P>(
             &self,
-            indexer_config: &IndexerConfig,
+            key_provider: &P,
             state: String,
-        ) -> anyhow::Result<()>;
+        ) -> anyhow::Result<()>
+            where P: KeyProvider + 'static;
 
-        pub async fn get_last_published_block(
+        pub async fn get_last_published_block<P>(
             &self,
-            indexer_config: &IndexerConfig,
-        ) -> anyhow::Result<Option<u64>>;
+            key_provider: &P,
+        ) -> anyhow::Result<Option<u64>>
+            where P: KeyProvider + 'static;
 
-        pub async fn clear_block_stream(&self, indexer_config: &IndexerConfig) -> anyhow::Result<()>;
+        pub async fn clear_block_stream<P>(&self, key_provider: &P) -> anyhow::Result<()>
+            where P: KeyProvider + 'static;
 
         pub async fn get<T, U>(&self, key: T) -> anyhow::Result<Option<U>>
-        where
-            T: ToRedisArgs + Debug + Send + Sync + 'static,
-            U: FromRedisValue + Debug + 'static;
+            where
+                T: ToRedisArgs + Debug + Send + Sync + 'static,
+                U: FromRedisValue + Debug + 'static;
 
         pub async fn set<K, V>(&self, key: K, value: V) -> anyhow::Result<()>
-        where
-            K: ToRedisArgs + Debug + Send + Sync + 'static,
-            V: ToRedisArgs + Debug + Send + Sync + 'static;
+            where
+                K: ToRedisArgs + Debug + Send + Sync + 'static,
+                V: ToRedisArgs + Debug + Send + Sync + 'static;
 
         pub async fn del<K>(&self, key: K) -> anyhow::Result<()>
         where
@@ -234,13 +262,14 @@ mockall::mock! {
         pub async fn indexer_states_set_exists(&self) -> anyhow::Result<bool>;
 
         pub async fn sadd<S, V>(&self, set: S, value: V) -> anyhow::Result<()>
-        where
-            S: ToRedisArgs + Debug + Send + Sync + 'static,
-            V: ToRedisArgs + Debug + Send + Sync + 'static;
+            where
+                S: ToRedisArgs + Debug + Send + Sync + 'static,
+                V: ToRedisArgs + Debug + Send + Sync + 'static;
 
         pub async fn list_indexer_states(&self) -> anyhow::Result<Vec<String>>;
 
-        pub async fn delete_indexer_state(&self, state: &IndexerState) -> anyhow::Result<()>;
+        pub async fn delete_indexer_state<P>(&self, key_provider: &P) -> anyhow::Result<()>
+            where P: KeyProvider + 'static;
     }
 
     impl Clone for RedisClientImpl {

--- a/coordinator/src/redis.rs
+++ b/coordinator/src/redis.rs
@@ -138,23 +138,6 @@ impl RedisClientImpl {
             .context(format!("SADD {set:?} {member:?}"))
     }
 
-    pub async fn exists<K>(&self, key: K) -> anyhow::Result<bool>
-    where
-        K: ToRedisArgs + Debug + Send + Sync + 'static,
-    {
-        tracing::debug!("EXISTS {key:?}");
-
-        redis::cmd("EXISTS")
-            .arg(&key)
-            .query_async(&mut self.connection.clone())
-            .await
-            .context(format!("EXISTS {key:?}"))
-    }
-
-    pub async fn indexer_states_set_exists(&self) -> anyhow::Result<bool> {
-        self.exists(Self::INDEXER_STATES_SET).await
-    }
-
     pub async fn get_last_published_block<P>(&self, key_provider: &P) -> anyhow::Result<Option<u64>>
     where
         P: KeyProvider + 'static,

--- a/coordinator/src/registry.rs
+++ b/coordinator/src/registry.rs
@@ -23,6 +23,7 @@ impl IndexerRegistry {
         Self(slice.iter().cloned().collect())
     }
 
+    #[cfg(test)]
     pub fn new() -> Self {
         Self(HashMap::new())
     }
@@ -34,6 +35,7 @@ impl IndexerRegistry {
         }
     }
 
+    #[cfg(test)]
     pub fn get(&self, account_id: &AccountId, function_name: &str) -> Option<&IndexerConfig> {
         self.0.get(account_id)?.get(function_name)
     }

--- a/coordinator/src/synchroniser.rs
+++ b/coordinator/src/synchroniser.rs
@@ -1,17 +1,13 @@
 use registry_types::StartBlock;
 use tracing::instrument;
 
-use crate::{
-    handlers::{
-        block_streams::{BlockStreamsHandler, StreamInfo},
-        data_layer::{DataLayerHandler, TaskStatus},
-        executors::{ExecutorInfo, ExecutorsHandler},
-    },
-    indexer_config::IndexerConfig,
-    indexer_state::{IndexerState, IndexerStateManager, ProvisionedState},
-    redis::RedisClient,
-    registry::Registry,
-};
+use crate::handlers::block_streams::{BlockStreamsHandler, StreamInfo};
+use crate::handlers::data_layer::{DataLayerHandler, TaskStatus};
+use crate::handlers::executors::{ExecutorInfo, ExecutorsHandler};
+use crate::indexer_config::IndexerConfig;
+use crate::indexer_state::{IndexerState, IndexerStateManager, ProvisionedState};
+use crate::redis::{KeyProvider, RedisClient};
+use crate::registry::Registry;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
@@ -1050,7 +1046,9 @@ mod test {
             let last_published_block = 1;
 
             let mut redis_client = RedisClient::default();
-            redis_client.expect_clear_block_stream().never();
+            redis_client
+                .expect_clear_block_stream::<IndexerConfig>()
+                .never();
             redis_client
                 .expect_get_last_published_block()
                 .with(eq(config.clone()))


### PR DESCRIPTION
Both the `IndexerState` and `IndexerConfig` structs are used individually to access Redis, and therefore have duplicate code for generating the required keys. This is problematic for the following reasons:
1. Redis access is limited to these structs, anything else requiring access needs to duplicate the logic again
2. Updates need to be reflected across both structs, creating more room for error

This PR creates a common Redis `KeyProvider` interface/trait for accessing Indexer Redis data/keys. Now the required structs, i.e. `IndexerState` and `IndexerConfig`, can implement this trait, and automatically get access to the methods which generate the keys.

Also did some minor clean up, removing the old Coordinator migration code.