### PR TITLE
feat: Deprovision Data Layer on delete

### DIFF
--- a/coordinator/src/handlers/data_layer.rs
+++ b/coordinator/src/handlers/data_layer.rs
@@ -1,12 +1,12 @@
 #![cfg_attr(test, allow(dead_code))]
 
-pub use runner::data_layer::ProvisioningStatus;
+pub use runner::data_layer::TaskStatus;
 
 use anyhow::Context;
 use runner::data_layer::data_layer_client::DataLayerClient;
-use runner::data_layer::{CheckProvisioningTaskStatusRequest, ProvisionRequest};
+use runner::data_layer::{GetTaskStatusRequest, ProvisionRequest};
 use tonic::transport::channel::Channel;
-use tonic::{Request, Status};
+use tonic::Request;
 
 use crate::indexer_config::IndexerConfig;
 
@@ -15,17 +15,14 @@ pub use DataLayerHandlerImpl as DataLayerHandler;
 #[cfg(test)]
 pub use MockDataLayerHandlerImpl as DataLayerHandler;
 
+type TaskId = String;
+
 pub struct DataLayerHandlerImpl {
     client: DataLayerClient<Channel>,
 }
 
 #[cfg_attr(test, mockall::automock)]
 impl DataLayerHandlerImpl {
-    pub fn from_env() -> anyhow::Result<Self> {
-        let runner_url = std::env::var("RUNNER_URL").context("RUNNER_URL is not set")?;
-        Self::connect(&runner_url)
-    }
-
     pub fn connect(runner_url: &str) -> anyhow::Result<Self> {
         let channel = Channel::from_shared(runner_url.to_string())
             .context("Runner URL is invalid")?
@@ -38,7 +35,7 @@ impl DataLayerHandlerImpl {
     pub async fn start_provisioning_task(
         &self,
         indexer_config: &IndexerConfig,
-    ) -> anyhow::Result<ProvisioningStatus> {
+    ) -> anyhow::Result<TaskId> {
         let request = ProvisionRequest {
             account_id: indexer_config.account_id.to_string(),
             function_name: indexer_config.function_name.clone(),
@@ -49,46 +46,33 @@ impl DataLayerHandlerImpl {
             .client
             .clone()
             .start_provisioning_task(Request::new(request))
+            .await?;
+
+        Ok(response.into_inner().task_id)
+    }
+
+    pub async fn get_task_status(&self, task_id: TaskId) -> anyhow::Result<TaskStatus> {
+        let request = GetTaskStatusRequest { task_id };
+
+        let response = self
+            .client
+            .clone()
+            .get_task_status(Request::new(request))
             .await;
 
         if let Err(error) = response {
-            if error.code() == tonic::Code::AlreadyExists {
-                return Ok(ProvisioningStatus::Pending);
+            if error.code() == tonic::Code::NotFound {
+                return Ok(TaskStatus::Failed);
             }
 
             return Err(error.into());
         }
 
         let status = match response.unwrap().into_inner().status {
-            1 => ProvisioningStatus::Pending,
-            2 => ProvisioningStatus::Complete,
-            3 => ProvisioningStatus::Failed,
-            _ => ProvisioningStatus::Unspecified,
-        };
-
-        Ok(status)
-    }
-
-    pub async fn check_provisioning_task_status(
-        &self,
-        indexer_config: &IndexerConfig,
-    ) -> anyhow::Result<ProvisioningStatus> {
-        let request = CheckProvisioningTaskStatusRequest {
-            account_id: indexer_config.account_id.to_string(),
-            function_name: indexer_config.function_name.clone(),
-        };
-
-        let response = self
-            .client
-            .clone()
-            .check_provisioning_task_status(Request::new(request))
-            .await?;
-
-        let status = match response.into_inner().status {
-            1 => ProvisioningStatus::Pending,
-            2 => ProvisioningStatus::Complete,
-            3 => ProvisioningStatus::Failed,
-            _ => ProvisioningStatus::Unspecified,
+            1 => TaskStatus::Pending,
+            2 => TaskStatus::Complete,
+            3 => TaskStatus::Failed,
+            _ => anyhow::bail!("Received invalid task status"),
         };
 
         Ok(status)

--- a/coordinator/src/handlers/data_layer.rs
+++ b/coordinator/src/handlers/data_layer.rs
@@ -1,10 +1,12 @@
 #![cfg_attr(test, allow(dead_code))]
 
+use near_primitives::types::AccountId;
+
 pub use runner::data_layer::TaskStatus;
 
 use anyhow::Context;
 use runner::data_layer::data_layer_client::DataLayerClient;
-use runner::data_layer::{GetTaskStatusRequest, ProvisionRequest};
+use runner::data_layer::{DeprovisionRequest, GetTaskStatusRequest, ProvisionRequest};
 use tonic::transport::channel::Channel;
 use tonic::Request;
 
@@ -46,6 +48,25 @@ impl DataLayerHandlerImpl {
             .client
             .clone()
             .start_provisioning_task(Request::new(request))
+            .await?;
+
+        Ok(response.into_inner().task_id)
+    }
+
+    pub async fn start_deprovisioning_task(
+        &self,
+        account_id: AccountId,
+        function_name: String,
+    ) -> anyhow::Result<TaskId> {
+        let request = DeprovisionRequest {
+            account_id: account_id.to_string(),
+            function_name,
+        };
+
+        let response = self
+            .client
+            .clone()
+            .start_deprovisioning_task(Request::new(request))
             .await?;
 
         Ok(response.into_inner().task_id)

--- a/coordinator/src/indexer_state.rs
+++ b/coordinator/src/indexer_state.rs
@@ -32,12 +32,16 @@ pub struct IndexerState {
     pub provisioned_state: ProvisionedState,
 }
 
+// FIX `IndexerConfig` does not exist after an Indexer is deleted, and we need a way to
+// construct the state key without it. But, this isn't ideal as we now have two places which
+// define this key - we need to consolidate these somehow.
 impl IndexerState {
-    // FIX `IndexerConfig` does not exist after an Indexer is deleted, and we need a way to
-    // construct the state key without it. But, this isn't ideal as we now have two places which
-    // define this key - we need to consolidate these somehow.
     pub fn get_state_key(&self) -> String {
         format!("{}/{}:state", self.account_id, self.function_name)
+    }
+
+    pub fn get_redis_stream_key(&self) -> String {
+        format!("{}/{}:block_stream", self.account_id, self.function_name)
     }
 }
 

--- a/coordinator/src/indexer_state.rs
+++ b/coordinator/src/indexer_state.rs
@@ -11,6 +11,7 @@ pub enum ProvisionedState {
     Unprovisioned,
     Provisioning { task_id: String },
     Provisioned,
+    Deprovisioning { task_id: String },
     Failed,
 }
 
@@ -130,6 +131,22 @@ impl IndexerStateManagerImpl {
         indexer_state.block_stream_synced_at = Some(indexer_config.get_registry_version());
 
         self.set_state(indexer_config, indexer_state).await?;
+
+        Ok(())
+    }
+
+    pub async fn set_deprovisioning(
+        &self,
+        indexer_state: &IndexerState,
+        task_id: String,
+    ) -> anyhow::Result<()> {
+        let mut state = indexer_state.clone();
+
+        state.provisioned_state = ProvisionedState::Deprovisioning { task_id };
+
+        self.redis_client
+            .set(state.get_state_key(), serde_json::to_string(&state)?)
+            .await?;
 
         Ok(())
     }

--- a/coordinator/src/indexer_state.rs
+++ b/coordinator/src/indexer_state.rs
@@ -9,7 +9,7 @@ use crate::redis::RedisClient;
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub enum ProvisionedState {
     Unprovisioned,
-    Provisioning,
+    Provisioning { task_id: String },
     Provisioned,
     Failed,
 }
@@ -134,10 +134,14 @@ impl IndexerStateManagerImpl {
         Ok(())
     }
 
-    pub async fn set_provisioning(&self, indexer_config: &IndexerConfig) -> anyhow::Result<()> {
+    pub async fn set_provisioning(
+        &self,
+        indexer_config: &IndexerConfig,
+        task_id: String,
+    ) -> anyhow::Result<()> {
         let mut indexer_state = self.get_state(indexer_config).await?;
 
-        indexer_state.provisioned_state = ProvisionedState::Provisioning;
+        indexer_state.provisioned_state = ProvisionedState::Provisioning { task_id };
 
         self.set_state(indexer_config, indexer_state).await?;
 

--- a/coordinator/src/indexer_state.rs
+++ b/coordinator/src/indexer_state.rs
@@ -110,6 +110,12 @@ impl IndexerStateManagerImpl {
             return Ok(serde_json::from_str(&raw_state)?);
         }
 
+        tracing::info!(
+            account_id = indexer_config.account_id.to_string(),
+            function_name = indexer_config.function_name.as_str(),
+            "Creating new state using default"
+        );
+
         Ok(self.get_default_state(indexer_config))
     }
 

--- a/coordinator/src/redis.rs
+++ b/coordinator/src/redis.rs
@@ -227,6 +227,10 @@ mockall::mock! {
             K: ToRedisArgs + Debug + Send + Sync + 'static,
             V: ToRedisArgs + Debug + Send + Sync + 'static;
 
+        pub async fn del<K>(&self, key: K) -> anyhow::Result<()>
+        where
+            K: ToRedisArgs + Debug + Send + Sync + 'static;
+
         pub async fn indexer_states_set_exists(&self) -> anyhow::Result<bool>;
 
         pub async fn sadd<S, V>(&self, set: S, value: V) -> anyhow::Result<()>

--- a/coordinator/src/synchroniser.rs
+++ b/coordinator/src/synchroniser.rs
@@ -635,8 +635,8 @@ mod test {
             state_manager.expect_list().returning(|| Ok(vec![]));
             state_manager
                 .expect_set_provisioning()
-                .with(eq(config.clone()))
-                .returning(|_| Ok(()))
+                .with(eq(config.clone()), eq("task_id".to_string()))
+                .returning(|_, _| Ok(()))
                 .once();
 
             let mut data_layer_handler = DataLayerHandler::default();

--- a/coordinator/src/synchroniser.rs
+++ b/coordinator/src/synchroniser.rs
@@ -257,7 +257,9 @@ impl<'a> Synchroniser<'a> {
             }
             ProvisionedState::Failed => return Ok(()),
             ProvisionedState::Provisioned => {}
-            ProvisionedState::Unprovisioned | ProvisionedState::Deprovisioning { .. } => todo!(),
+            ProvisionedState::Unprovisioned | ProvisionedState::Deprovisioning { .. } => {
+                anyhow::bail!("Provisioning task should have been started")
+            }
         }
 
         if !state.enabled {

--- a/coordinator/src/synchroniser.rs
+++ b/coordinator/src/synchroniser.rs
@@ -226,7 +226,7 @@ impl<'a> Synchroniser<'a> {
             }
             TaskStatus::Pending => Ok(()),
             _ => {
-                tracing::info!("Data layer provisioning failed");
+                tracing::warn!("Data layer provisioning failed");
                 self.state_manager.set_provisioning_failure(config).await
             }
         }

--- a/runner-client/examples/start_provisioning_task.rs
+++ b/runner-client/examples/start_provisioning_task.rs
@@ -9,8 +9,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client
         .start_provisioning_task(Request::new(ProvisionRequest {
-            account_id: "morgs.near".to_string(),
-            function_name: "test2".to_string(),
+            account_id: "test.near".to_string(),
+            function_name: "data_layer_example".to_string(),
             schema: "create table blocks();".to_string(),
         }))
         .await?;

--- a/runner-client/proto/data-layer.proto
+++ b/runner-client/proto/data-layer.proto
@@ -4,10 +4,18 @@ package data_layer;
 
 service DataLayer {
     // Starts async provisioning task
-    rpc StartProvisioningTask (ProvisionRequest) returns (ProvisionResponse);
+    rpc StartProvisioningTask (ProvisionRequest) returns (StartTaskResponse);
 
-    // Checks the provisioning status
-    rpc CheckProvisioningTaskStatus (CheckProvisioningTaskStatusRequest) returns (ProvisionResponse);
+    // Start async deprovisioning task
+    rpc StartDeprovisioningTask (DeprovisionRequest) returns (StartTaskResponse);
+
+    // Checks the status of provisioning/deprovisioning
+    rpc GetTaskStatus (GetTaskStatusRequest) returns (GetTaskStatusResponse);
+
+}
+
+message StartTaskResponse {
+    string task_id = 1;
 }
 
 message ProvisionRequest {
@@ -16,18 +24,23 @@ message ProvisionRequest {
     string schema = 3;
 }
 
-message CheckProvisioningTaskStatusRequest {
+message DeprovisionRequest {
     string account_id = 1;
     string function_name = 2;
 }
 
-enum ProvisioningStatus {
+
+message GetTaskStatusRequest {
+    string task_id = 1;
+}
+
+enum TaskStatus {
     UNSPECIFIED = 0;
     PENDING = 1;
     COMPLETE = 2;
     FAILED = 3;
 }
 
-message ProvisionResponse {
-    ProvisioningStatus status = 1;
+message GetTaskStatusResponse {
+    TaskStatus status = 1;
 }

--- a/runner/protos/data-layer.proto
+++ b/runner/protos/data-layer.proto
@@ -4,10 +4,18 @@ package data_layer;
 
 service DataLayer {
     // Starts async provisioning task
-    rpc StartProvisioningTask (ProvisionRequest) returns (ProvisionResponse);
+    rpc StartProvisioningTask (ProvisionRequest) returns (StartTaskResponse);
 
-    // Checks the provisioning status
-    rpc CheckProvisioningTaskStatus (CheckProvisioningTaskStatusRequest) returns (ProvisionResponse);
+    // Start async deprovisioning task
+    // rpc StartDeprovisioningTask (DeprovisionRequest) returns (StartTaskResponse);
+
+    // Checks the status of provisioning/deprovisioning
+    rpc GetTaskStatus (GetTaskStatusRequest) returns (GetTaskStatusResponse);
+
+}
+
+message StartTaskResponse {
+    string task_id = 1;
 }
 
 message ProvisionRequest {
@@ -16,18 +24,23 @@ message ProvisionRequest {
     string schema = 3;
 }
 
-message CheckProvisioningTaskStatusRequest {
+message DeprovisionRequest {
     string account_id = 1;
     string function_name = 2;
 }
 
-enum ProvisioningStatus {
+
+message GetTaskStatusRequest {
+    string task_id = 1;
+}
+
+enum TaskStatus {
     UNSPECIFIED = 0;
     PENDING = 1;
     COMPLETE = 2;
     FAILED = 3;
 }
 
-message ProvisionResponse {
-    ProvisioningStatus status = 1;
+message GetTaskStatusResponse {
+    TaskStatus status = 1;
 }

--- a/runner/protos/data-layer.proto
+++ b/runner/protos/data-layer.proto
@@ -7,7 +7,7 @@ service DataLayer {
     rpc StartProvisioningTask (ProvisionRequest) returns (StartTaskResponse);
 
     // Start async deprovisioning task
-    // rpc StartDeprovisioningTask (DeprovisionRequest) returns (StartTaskResponse);
+    rpc StartDeprovisioningTask (DeprovisionRequest) returns (StartTaskResponse);
 
     // Checks the status of provisioning/deprovisioning
     rpc GetTaskStatus (GetTaskStatusRequest) returns (GetTaskStatusResponse);

--- a/runner/src/hasura-client/__snapshots__/hasura-client.test.ts.snap
+++ b/runner/src/hasura-client/__snapshots__/hasura-client.test.ts.snap
@@ -222,6 +222,21 @@ exports[`HasuraClient drops a datasource 1`] = `
 }
 `;
 
+exports[`HasuraClient drops a schema 1`] = `
+[
+  [
+    "mock-hasura-endpoint/v2/query",
+    {
+      "body": "{"type":"run_sql","args":{"sql":"DROP schema IF EXISTS schemaName CASCADE","read_only":false,"source":"dbName"}}",
+      "headers": {
+        "X-Hasura-Admin-Secret": "mock-hasura-admin-secret",
+      },
+      "method": "POST",
+    },
+  ],
+]
+`;
+
 exports[`HasuraClient gets table names within a schema 1`] = `
 {
   "args": {

--- a/runner/src/hasura-client/__snapshots__/hasura-client.test.ts.snap
+++ b/runner/src/hasura-client/__snapshots__/hasura-client.test.ts.snap
@@ -212,6 +212,16 @@ exports[`HasuraClient creates a schema 1`] = `
 ]
 `;
 
+exports[`HasuraClient drops a datasource 1`] = `
+{
+  "args": {
+    "cascade": true,
+    "name": "morgs_near",
+  },
+  "type": "pg_drop_source",
+}
+`;
+
 exports[`HasuraClient gets table names within a schema 1`] = `
 {
   "args": {

--- a/runner/src/hasura-client/hasura-client.test.ts
+++ b/runner/src/hasura-client/hasura-client.test.ts
@@ -172,6 +172,21 @@ describe('HasuraClient', () => {
     expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toMatchSnapshot();
   });
 
+  it('drops a datasource', async () => {
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValue({
+        status: 200,
+        text: () => JSON.stringify({})
+      });
+    const client = new HasuraClient({ fetch: mockFetch as unknown as typeof fetch }, config);
+
+    await client.dropDatasource('morgs_near');
+
+    expect(mockFetch.mock.calls[0][1].headers['X-Hasura-Admin-Secret']).toBe(config.adminSecret);
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toMatchSnapshot();
+  });
+
   it('adds a datasource', async () => {
     const mockFetch = jest
       .fn()

--- a/runner/src/hasura-client/hasura-client.test.ts
+++ b/runner/src/hasura-client/hasura-client.test.ts
@@ -41,6 +41,20 @@ describe('HasuraClient', () => {
     expect(mockFetch.mock.calls).toMatchSnapshot();
   });
 
+  it('drops a schema', async () => {
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValue({
+        status: 200,
+        text: () => JSON.stringify({})
+      });
+    const client = new HasuraClient({ fetch: mockFetch as unknown as typeof fetch }, config);
+
+    await client.dropSchema('dbName', 'schemaName');
+
+    expect(mockFetch.mock.calls).toMatchSnapshot();
+  });
+
   it('checks if a schema exists within source', async () => {
     const mockFetch = jest
       .fn()

--- a/runner/src/hasura-client/hasura-client.ts
+++ b/runner/src/hasura-client/hasura-client.ts
@@ -443,4 +443,11 @@ export default class HasuraClient {
       },
     });
   }
+
+  async dropDatasource (databaseName: string): Promise<void> {
+    return await this.executeMetadataRequest('pg_drop_source', {
+      name: databaseName,
+      cascade: true,
+    });
+  }
 }

--- a/runner/src/hasura-client/hasura-client.ts
+++ b/runner/src/hasura-client/hasura-client.ts
@@ -209,6 +209,13 @@ export default class HasuraClient {
     return result.length > 1;
   }
 
+  async dropSchema (source: string, schemaName: string): Promise<any> {
+    return await this.executeSql(
+      `DROP schema IF EXISTS ${schemaName} CASCADE`,
+      { source, readOnly: false }
+    );
+  }
+
   async createSchema (source: string, schemaName: string): Promise<any> {
     return await this.executeSql(`CREATE schema ${schemaName}`, {
       source,

--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -106,7 +106,7 @@ describe('Provisioner', () => {
         ["SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'morgs_near'"],
       ]);
       expect(hasuraClient.dropDatasource).toBeCalledWith(indexerConfig.databaseName());
-      expect(adminPgClient.query).toBeCalledWith('DROP DATABASE IF EXISTS morgs_near FORCE');
+      expect(adminPgClient.query).toBeCalledWith('DROP DATABASE IF EXISTS morgs_near (FORCE)');
       expect(adminPgClient.query).toBeCalledWith('DROP ROLE IF EXISTS morgs_near');
     });
 

--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -86,7 +86,7 @@ describe('Provisioner', () => {
         ['DROP SCHEMA IF EXISTS morgs_near_test_function CASCADE'],
         ["SELECT cron.unschedule('morgs_near_test_function_sys_logs_create_partition');"],
         ["SELECT cron.unschedule('morgs_near_test_function_sys_logs_delete_partition');"],
-        ['SELECT schema_name FROM information_schema.schemata WHERE schema_name = morgs_near'],
+        ["SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'morgs_near'"],
       ]);
     });
 
@@ -103,7 +103,7 @@ describe('Provisioner', () => {
         ['DROP SCHEMA IF EXISTS morgs_near_test_function CASCADE'],
         ["SELECT cron.unschedule('morgs_near_test_function_sys_logs_create_partition');"],
         ["SELECT cron.unschedule('morgs_near_test_function_sys_logs_delete_partition');"],
-        ['SELECT schema_name FROM information_schema.schemata WHERE schema_name = morgs_near'],
+        ["SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'morgs_near'"],
       ]);
       expect(hasuraClient.dropDatasource).toBeCalledWith(indexerConfig.databaseName());
       expect(adminPgClient.query).toBeCalledWith('DROP DATABASE IF EXISTS morgs_near FORCE');

--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -86,7 +86,7 @@ describe('Provisioner', () => {
         ['DROP SCHEMA IF EXISTS morgs_near_test_function CASCADE'],
         ["SELECT cron.unschedule('morgs_near_test_function_sys_logs_create_partition');"],
         ["SELECT cron.unschedule('morgs_near_test_function_sys_logs_delete_partition');"],
-        ["SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'morgs_near'"],
+        ["SELECT schema_name FROM information_schema.schemata WHERE schema_owner = 'morgs_near'"],
       ]);
     });
 
@@ -103,7 +103,7 @@ describe('Provisioner', () => {
         ['DROP SCHEMA IF EXISTS morgs_near_test_function CASCADE'],
         ["SELECT cron.unschedule('morgs_near_test_function_sys_logs_create_partition');"],
         ["SELECT cron.unschedule('morgs_near_test_function_sys_logs_delete_partition');"],
-        ["SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'morgs_near'"],
+        ["SELECT schema_name FROM information_schema.schemata WHERE schema_owner = 'morgs_near'"],
       ]);
       expect(hasuraClient.dropDatasource).toBeCalledWith(indexerConfig.databaseName());
       expect(adminPgClient.query).toBeCalledWith('DROP DATABASE IF EXISTS morgs_near (FORCE)');

--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -71,6 +71,20 @@ describe('Provisioner', () => {
     indexerConfig = new IndexerConfig('', accountId, functionName, 0, '', databaseSchema, LogLevel.INFO);
   });
 
+  describe('deprovision', () => {
+    it('drops the schema', async () => {
+      await provisioner.deprovision(indexerConfig);
+      expect(userPgClientQuery.mock.calls).toEqual([
+        ['DROP SCHEMA IF EXISTS morgs_near_test_function CASCADE']
+      ]);
+    });
+
+    it('handles drop schema failures', async () => {
+      userPgClientQuery = jest.fn().mockRejectedValue(new Error('no'));
+      await expect(provisioner.deprovision(indexerConfig)).rejects.toThrow('Failed to deprovision: Failed to drop schema: no');
+    });
+  });
+
   describe('isUserApiProvisioned', () => {
     it('returns false if datasource doesnt exists', async () => {
       hasuraClient.doesSourceExist = jest.fn().mockReturnValueOnce(false);

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -302,6 +302,12 @@ export default class Provisioner {
     }, 'Failed to drop datasource');
   }
 
+  async dropRole (userName: string): Promise<void> {
+    await wrapError(async () => {
+      await this.adminDefaultPgClient.query(this.pgFormat('DROP ROLE IF EXISTS %I', userName));
+    }, 'Failed to drop role');
+  }
+
   public async deprovision (config: ProvisioningConfig): Promise<void> {
     await wrapError(async () => {
       await this.dropSchema(config.userName(), config.schemaName());
@@ -312,9 +318,9 @@ export default class Provisioner {
       if (schemas.length === 0) {
         await this.dropDatasource(config.databaseName());
         await this.dropDatabase(config.databaseName());
+        await this.dropRole(config.userName());
       }
     }, 'Failed to deprovision');
-    // drop role
   }
 
   async provisionUserApi (indexerConfig: ProvisioningConfig): Promise<void> { // replace any with actual type

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -290,6 +290,12 @@ export default class Provisioner {
     }, 'Failed to list schemas');
   }
 
+  async dropDatabase (databaseName: string): Promise<void> {
+    await wrapError(async () => {
+      await this.adminDefaultPgClient.query(this.pgFormat('DROP DATABASE IF EXISTS %I FORCE', databaseName));
+    }, 'Failed to drop database');
+  }
+
   async dropDatasource (databaseName: string): Promise<void> {
     await wrapError(async () => {
       await this.hasuraClient.dropDatasource(databaseName);
@@ -305,9 +311,9 @@ export default class Provisioner {
 
       if (schemas.length === 0) {
         await this.dropDatasource(config.databaseName());
+        await this.dropDatabase(config.databaseName());
       }
     }, 'Failed to deprovision');
-    // drop database
     // drop role
   }
 

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -280,7 +280,7 @@ export default class Provisioner {
       const userPgClient = new this.PgClient(userDbConnectionParameters);
 
       const result = await userPgClient.query(
-        this.pgFormat('SELECT schema_name FROM information_schema.schemata WHERE schema_name = %I', userName)
+        this.pgFormat('SELECT schema_name FROM information_schema.schemata WHERE schema_name = %L', userName)
       );
       console.log({ result });
 

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -292,7 +292,7 @@ export default class Provisioner {
 
   async dropDatabase (databaseName: string): Promise<void> {
     await wrapError(async () => {
-      await this.adminDefaultPgClient.query(this.pgFormat('DROP DATABASE IF EXISTS %I FORCE', databaseName));
+      await this.adminDefaultPgClient.query(this.pgFormat('DROP DATABASE IF EXISTS %I (FORCE)', databaseName));
     }, 'Failed to drop database');
   }
 

--- a/runner/src/provisioner/provisioner.ts
+++ b/runner/src/provisioner/provisioner.ts
@@ -274,15 +274,14 @@ export default class Provisioner {
     );
   }
 
-  async listSchemaNames (userName: string): Promise<string[]> {
+  async listUserOwnedSchemas (userName: string): Promise<string[]> {
     return await wrapError(async () => {
       const userDbConnectionParameters = await this.getPostgresConnectionParameters(userName);
       const userPgClient = new this.PgClient(userDbConnectionParameters);
 
       const result = await userPgClient.query(
-        this.pgFormat('SELECT schema_name FROM information_schema.schemata WHERE schema_name = %L', userName)
+        this.pgFormat('SELECT schema_name FROM information_schema.schemata WHERE schema_owner = %L', userName)
       );
-      console.log({ result });
 
       await userPgClient.end();
 
@@ -323,7 +322,7 @@ export default class Provisioner {
       await this.dropSchema(config.userName(), config.schemaName());
       await this.removeLogPartitionJobs(config.userName(), config.schemaName());
 
-      const schemas = await this.listSchemaNames(config.userName());
+      const schemas = await this.listUserOwnedSchemas(config.userName());
 
       if (schemas.length === 0) {
         await this.dropDatasource(config.databaseName());

--- a/runner/src/server/services/data-layer/data-layer-service.test.ts
+++ b/runner/src/server/services/data-layer/data-layer-service.test.ts
@@ -69,7 +69,7 @@ describe('DataLayerService', () => {
   describe('StartProvisioningTask', () => {
     it('should return ALREADY_EXISTS if the task exists', (done) => {
       const tasks = {
-        'testAccount:testFunction': { pending: true, completed: false, failed: false } as unknown as AsyncTask
+        '9e74d55766d685e8a47363befebaf532e56e1484e19407ec77f18130f4fc9499': { pending: true, completed: false, failed: false } as unknown as AsyncTask
       };
       const call = {
         request: { accountId: 'testAccount', functionName: 'testFunction', schema: 'schema' }

--- a/runner/src/server/services/data-layer/data-layer-service.test.ts
+++ b/runner/src/server/services/data-layer/data-layer-service.test.ts
@@ -69,7 +69,7 @@ describe('DataLayerService', () => {
   describe('StartProvisioningTask', () => {
     it('should return ALREADY_EXISTS if the task exists', (done) => {
       const tasks = {
-        '9e74d55766d685e8a47363befebaf532e56e1484e19407ec77f18130f4fc9499': { pending: true, completed: false, failed: false } as unknown as AsyncTask
+        '8291150845651941809f8f3db28eeb7fd8acdfeb422cb07c10178020070836b8': { pending: true, completed: false, failed: false } as unknown as AsyncTask
       };
       const call = {
         request: { accountId: 'testAccount', functionName: 'testFunction', schema: 'schema' }
@@ -86,7 +86,6 @@ describe('DataLayerService', () => {
     it('should start a new provisioning task', (done) => {
       const tasks: Record<any, any> = {};
       const provisioner = {
-        fetchUserApiProvisioningStatus: jest.fn().mockResolvedValue(false),
         provisionUserApi: jest.fn().mockResolvedValue(null)
       } as unknown as Provisioner;
       const call = {
@@ -99,6 +98,41 @@ describe('DataLayerService', () => {
       };
 
       createDataLayerService(provisioner, tasks).StartProvisioningTask(call, callback);
+    });
+  });
+
+  describe('StartDeprovisioningTask', () => {
+    it('should return ALREADY_EXISTS if the task exists', (done) => {
+      const tasks = {
+        f92a9f97d2609849e6837b483d8210c7b308c6f615a691449087ec00db1eef06: { pending: true, completed: false, failed: false } as unknown as AsyncTask
+      };
+      const call = {
+        request: { accountId: 'testAccount', functionName: 'testFunction', schema: 'schema' }
+      } as unknown as ServerUnaryCall<any, any>;
+      const callback = (error: any): void => {
+        expect(error.code).toBe(status.ALREADY_EXISTS);
+        expect(error.details).toBe('Deprovisioning task already exists');
+        done();
+      };
+
+      createDataLayerService(undefined, tasks).StartDeprovisioningTask(call, callback);
+    });
+
+    it('should start a new deprovisioning task', (done) => {
+      const tasks: Record<any, any> = {};
+      const provisioner = {
+        deprovision: jest.fn().mockResolvedValue(null)
+      } as unknown as Provisioner;
+      const call = {
+        request: { accountId: 'testAccount', functionName: 'testFunction', schema: 'testSchema' }
+      } as unknown as ServerUnaryCall<any, any>;
+      const callback = (_error: any, response: any): void => {
+        expect(tasks[response.taskId]).toBeDefined();
+        expect(tasks[response.taskId].pending).toBe(true);
+        done();
+      };
+
+      createDataLayerService(provisioner, tasks).StartDeprovisioningTask(call, callback);
     });
   });
 });

--- a/runner/src/server/services/data-layer/data-layer-service.test.ts
+++ b/runner/src/server/services/data-layer/data-layer-service.test.ts
@@ -1,14 +1,14 @@
 import { type ServerUnaryCall, status } from '@grpc/grpc-js';
 
-import { createDataLayerService, type ProvisioningTask } from './data-layer-service';
-import { ProvisioningStatus } from '../../../generated/data_layer/ProvisioningStatus';
+import { createDataLayerService, type AsyncTask } from './data-layer-service';
+import { TaskStatus } from '../../../generated/data_layer/TaskStatus';
 import type Provisioner from '../../../provisioner';
 
 describe('DataLayerService', () => {
-  describe('CheckProvisioningTaskStatus', () => {
+  describe('GetTaskStatus', () => {
     it('should return NOT_FOUND if the task does not exist', (done) => {
       const call = {
-        request: { accountId: 'testAccount', functionName: 'testFunction' }
+        request: { taskId: 'id' }
       } as unknown as ServerUnaryCall<any, any>;
 
       const callback = (error: any): void => {
@@ -17,59 +17,59 @@ describe('DataLayerService', () => {
         done();
       };
 
-      createDataLayerService().CheckProvisioningTaskStatus(call, callback);
+      createDataLayerService().GetTaskStatus(call, callback);
     });
 
     it('should return PENDING if the task is pending', (done) => {
       const tasks = {
-        'testAccount:testFunction': { pending: true, completed: false, failed: false } as unknown as ProvisioningTask
+        id: { pending: true, completed: false, failed: false } as unknown as AsyncTask
       };
       const call = {
-        request: { accountId: 'testAccount', functionName: 'testFunction' }
+        request: { taskId: 'id' }
       } as unknown as ServerUnaryCall<any, any>;
       const callback = (_error: any, response: any): void => {
-        expect(response.status).toBe(ProvisioningStatus.PENDING);
+        expect(response.status).toBe(TaskStatus.PENDING);
         done();
       };
 
-      createDataLayerService(undefined, tasks).CheckProvisioningTaskStatus(call, callback);
+      createDataLayerService(undefined, tasks).GetTaskStatus(call, callback);
     });
 
     it('should return COMPLETE if the task is completed', (done) => {
       const tasks = {
-        'testAccount:testFunction': { pending: false, completed: true, failed: false } as unknown as ProvisioningTask
+        id: { pending: false, completed: true, failed: false } as unknown as AsyncTask
       };
       const call = {
-        request: { accountId: 'testAccount', functionName: 'testFunction' }
+        request: { taskId: 'id' }
       } as unknown as ServerUnaryCall<any, any>;
       const callback = (_error: any, response: any): void => {
-        expect(response.status).toBe(ProvisioningStatus.COMPLETE);
+        expect(response.status).toBe(TaskStatus.COMPLETE);
         done();
       };
 
-      createDataLayerService(undefined, tasks).CheckProvisioningTaskStatus(call, callback);
+      createDataLayerService(undefined, tasks).GetTaskStatus(call, callback);
     });
 
     it('should return FAILED if the task has failed', (done) => {
       const tasks = {
-        'testAccount:testFunction': { pending: false, completed: false, failed: true } as unknown as ProvisioningTask
+        id: { pending: false, completed: false, failed: true } as unknown as AsyncTask
       };
       const call = {
-        request: { accountId: 'testAccount', functionName: 'testFunction' }
+        request: { taskId: 'id' }
       } as unknown as ServerUnaryCall<any, any>;
       const callback = (_error: any, response: any): void => {
-        expect(response.status).toBe(ProvisioningStatus.FAILED);
+        expect(response.status).toBe(TaskStatus.FAILED);
         done();
       };
 
-      createDataLayerService(undefined, tasks).CheckProvisioningTaskStatus(call, callback);
+      createDataLayerService(undefined, tasks).GetTaskStatus(call, callback);
     });
   });
 
-  describe('Provision', () => {
+  describe('StartProvisioningTask', () => {
     it('should return ALREADY_EXISTS if the task exists', (done) => {
       const tasks = {
-        'testAccount:testFunction': { pending: true, completed: false, failed: false } as unknown as ProvisioningTask
+        'testAccount:testFunction': { pending: true, completed: false, failed: false } as unknown as AsyncTask
       };
       const call = {
         request: { accountId: 'testAccount', functionName: 'testFunction', schema: 'schema' }
@@ -83,23 +83,7 @@ describe('DataLayerService', () => {
       createDataLayerService(undefined, tasks).StartProvisioningTask(call, callback);
     });
 
-    it('should return Complete if the task has already completed', (done) => {
-      const tasks: Record<any, any> = {};
-      const provisioner = {
-        fetchUserApiProvisioningStatus: jest.fn().mockResolvedValue(true)
-      } as unknown as Provisioner;
-      const call = {
-        request: { accountId: 'testAccount', functionName: 'testFunction', schema: 'testSchema' }
-      } as unknown as ServerUnaryCall<any, any>;
-      const callback = (_error: any, response: any): void => {
-        expect(response.status).toBe(ProvisioningStatus.COMPLETE);
-        done();
-      };
-
-      createDataLayerService(provisioner, tasks).StartProvisioningTask(call, callback);
-    });
-
-    it('should start a new provisioning task and return PENDING', (done) => {
+    it('should start a new provisioning task', (done) => {
       const tasks: Record<any, any> = {};
       const provisioner = {
         fetchUserApiProvisioningStatus: jest.fn().mockResolvedValue(false),
@@ -109,26 +93,8 @@ describe('DataLayerService', () => {
         request: { accountId: 'testAccount', functionName: 'testFunction', schema: 'testSchema' }
       } as unknown as ServerUnaryCall<any, any>;
       const callback = (_error: any, response: any): void => {
-        expect(response.status).toBe(ProvisioningStatus.PENDING);
-        expect(tasks['testAccount:testFunction']).toBeDefined();
-        expect(tasks['testAccount:testFunction'].pending).toBe(true);
-        done();
-      };
-
-      createDataLayerService(provisioner, tasks).StartProvisioningTask(call, callback);
-    });
-
-    it('should return INTERNAL error if checking provisioning status fails', (done) => {
-      const tasks: Record<any, any> = {};
-      const provisioner = {
-        fetchUserApiProvisioningStatus: jest.fn().mockRejectedValue(new Error('boom'))
-      } as unknown as Provisioner;
-      const call = {
-        request: { accountId: 'testAccount', functionName: 'testFunction', schema: 'testSchema' }
-      } as unknown as ServerUnaryCall<any, any>;
-      const callback = (error: any): void => {
-        expect(error.code).toBe(status.INTERNAL);
-        expect(error.details).toBe('boom');
+        expect(tasks[response.taskId]).toBeDefined();
+        expect(tasks[response.taskId].pending).toBe(true);
         done();
       };
 

--- a/runner/src/server/services/data-layer/data-layer-service.test.ts
+++ b/runner/src/server/services/data-layer/data-layer-service.test.ts
@@ -67,16 +67,16 @@ describe('DataLayerService', () => {
   });
 
   describe('StartProvisioningTask', () => {
-    it('should return ALREADY_EXISTS if the task exists', (done) => {
-      const tasks = {
-        '8291150845651941809f8f3db28eeb7fd8acdfeb422cb07c10178020070836b8': { pending: true, completed: false, failed: false } as unknown as AsyncTask
+    it('should return the current task if it exists', (done) => {
+      const tasks: Record<any, any> = {
+        '8291150845651941809f8f3db28eeb7fd8acdfeb422cb07c10178020070836b8': { pending: false, completed: true, failed: false } as unknown as AsyncTask
       };
       const call = {
         request: { accountId: 'testAccount', functionName: 'testFunction', schema: 'schema' }
       } as unknown as ServerUnaryCall<any, any>;
-      const callback = (error: any): void => {
-        expect(error.code).toBe(status.ALREADY_EXISTS);
-        expect(error.details).toBe('Provisioning task already exists');
+      const callback = (_error: any, response: any): void => {
+        expect(tasks[response.taskId]).toBeDefined();
+        expect(tasks[response.taskId].completed).toBe(true);
         done();
       };
 

--- a/runner/src/server/services/data-layer/data-layer-service.ts
+++ b/runner/src/server/services/data-layer/data-layer-service.ts
@@ -35,6 +35,16 @@ type ProvisioningTasks = Record<string, ProvisioningTask>;
 
 const generateTaskId = (accountId: string, functionName: string): string => `${accountId}:${functionName}`;
 
+const createLogger = (config: ProvisioningConfig): typeof parentLogger => {
+  const logger = parentLogger.child({
+    accountId: config.accountId,
+    functionName: config.functionName,
+    service: 'DataLayerService'
+  });
+
+  return logger;
+};
+
 export function createDataLayerService (
   provisioner: Provisioner = new Provisioner(),
   tasks: ProvisioningTasks = {}
@@ -73,11 +83,7 @@ export function createDataLayerService (
 
       const provisioningConfig = new ProvisioningConfig(accountId, functionName, schema);
 
-      const logger = parentLogger.child({
-        service: 'DataLayerService',
-        accountId: provisioningConfig.accountId,
-        functionName: provisioningConfig.functionName,
-      });
+      const logger = createLogger(provisioningConfig);
 
       const task = tasks[generateTaskId(accountId, functionName)];
 
@@ -90,6 +96,8 @@ export function createDataLayerService (
 
         return;
       };
+
+      logger.info('Starting provisioning task');
 
       provisioner.fetchUserApiProvisioningStatus(provisioningConfig).then((isProvisioned) => {
         if (isProvisioned) {

--- a/runner/src/server/services/data-layer/data-layer-service.ts
+++ b/runner/src/server/services/data-layer/data-layer-service.ts
@@ -1,3 +1,5 @@
+import crypto from 'crypto';
+
 import { type ServerUnaryCall, type sendUnaryData, status, StatusBuilder } from '@grpc/grpc-js';
 
 import Provisioner from '../../../provisioner';
@@ -35,6 +37,12 @@ export class AsyncTask {
 }
 
 type AsyncTasks = Record<string, AsyncTask | undefined>;
+
+const hash = (...args: string[]): string => {
+  const hash = crypto.createHash('sha256');
+  hash.update(args.join(':'));
+  return hash.digest('hex');
+};
 
 const createLogger = (config: ProvisioningConfig): typeof parentLogger => {
   const logger = parentLogger.child({
@@ -84,7 +92,7 @@ export function createDataLayerService (
 
       const logger = createLogger(provisioningConfig);
 
-      const taskId = `${accountId}:${functionName}`;
+      const taskId = hash(accountId, functionName, schema);
 
       const task = tasks[taskId];
 

--- a/runner/src/server/services/data-layer/data-layer-service.ts
+++ b/runner/src/server/services/data-layer/data-layer-service.ts
@@ -103,11 +103,7 @@ export function createDataLayerService (
       const task = tasks[taskId];
 
       if (task) {
-        const exists = new StatusBuilder()
-          .withCode(status.ALREADY_EXISTS)
-          .withDetails('Provisioning task already exists')
-          .build();
-        callback(exists);
+        callback(null, { taskId });
 
         return;
       };

--- a/runner/tests/integration.test.ts
+++ b/runner/tests/integration.test.ts
@@ -245,6 +245,21 @@ describe('Indexer integration', () => {
     const { morgs_near_test_context_db_indexer_storage: totalRows }: any = await graphqlClient.request(queryAllRows);
     expect(totalRows.length).toEqual(3); // Two inserts, and the overwritten upsert
   });
+
+  it('deprovisions', async () => {
+    const indexerConfig = new IndexerConfig(
+      'test:stream',
+      'morgs.near',
+      'test-provisioning',
+      0,
+      '',
+      'CREATE TABLE blocks (height numeric)',
+      LogLevel.INFO
+    );
+
+    await provisioner.provisionUserApi(indexerConfig);
+    await provisioner.deprovision(indexerConfig);
+  });
 });
 
 async function indexerLogsQuery (indexerSchemaName: string, graphqlClient: GraphQLClient): Promise<any> {


### PR DESCRIPTION
This PR removes Data Layer resources on Indexer Delete. To achieve this, the following has been added:
- `Provisioner.deprovision()` method which removes: schema, cron jobs, and if necessary, Hasura source, database, and role
- `DataLayerService.StartDeprovisioningTask` gRPC method
- Calling the above from Coordinator within the delete lifecycle hook

In addition to the above, I've slightly refactored DataLayerService to make the addition of de-provisioning more accomodating:
- `StartDeprovisioningTask` and `StartProvisioningTask` now return opaque IDs rather than using `accountId`/`functionName` - to avoid conflicts with eachother
- There is a single `GetTaskStatus` method which is used for both, before it was specific to provisioning

As mentioned in #805, the Coordinator implementation is a little awkward due to the shared/non-blocking Control Loop. I'll look to refactor this later and hopefully improve on this.