### PR TITLE
fix: Allow re-provisioning of recently de-provisioned resources

### DIFF
--- a/runner/src/provisioner/provisioner.test.ts
+++ b/runner/src/provisioner/provisioner.test.ts
@@ -173,24 +173,21 @@ describe('Provisioner', () => {
     it('returns false if datasource doesnt exists', async () => {
       hasuraClient.doesSourceExist = jest.fn().mockReturnValueOnce(false);
 
-      await expect(provisioner.fetchUserApiProvisioningStatus(indexerConfig)).resolves.toBe(false);
-      expect(provisioner.isUserApiProvisioned(indexerConfig.accountId, indexerConfig.functionName)).toBe(false);
+      await expect(provisioner.isProvisioned(indexerConfig)).resolves.toBe(false);
     });
 
     it('returns false if datasource and schema dont exists', async () => {
       hasuraClient.doesSourceExist = jest.fn().mockReturnValueOnce(false);
       hasuraClient.doesSchemaExist = jest.fn().mockReturnValueOnce(false);
 
-      await expect(provisioner.fetchUserApiProvisioningStatus(indexerConfig)).resolves.toBe(false);
-      expect(provisioner.isUserApiProvisioned(indexerConfig.accountId, indexerConfig.functionName)).toBe(false);
+      await expect(provisioner.isProvisioned(indexerConfig)).resolves.toBe(false);
     });
 
     it('returns true if datasource and schema exists', async () => {
       hasuraClient.doesSourceExist = jest.fn().mockReturnValueOnce(true);
       hasuraClient.doesSchemaExist = jest.fn().mockReturnValueOnce(true);
 
-      await expect(provisioner.fetchUserApiProvisioningStatus(indexerConfig)).resolves.toBe(true);
-      expect(provisioner.isUserApiProvisioned(indexerConfig.accountId, indexerConfig.functionName)).toBe(true);
+      await expect(provisioner.isProvisioned(indexerConfig)).resolves.toBe(true);
     });
   });
 
@@ -233,7 +230,6 @@ describe('Provisioner', () => {
           'delete'
         ]
       );
-      expect(provisioner.isUserApiProvisioned(accountId, functionName)).toBe(true);
     });
 
     it('skips provisioning the datasource if it already exists', async () => {


### PR DESCRIPTION
Provisioning a recently de-provisioned Data Layer would silently fail. This is due to the fact that de/provisioning tasks are stored in-memory, keyed by a hash of the config. So if a provisioning task was recently completed, attempting to re-provision would return that same task.

This PR keys by random UUIDs, instead of hashes, so we can trigger multiple provisioning jobs for a given Indexer/Data Layer, allowing for the Provision > De-provision > Provision flow. To protect against re-provisioning an _existing_ Data Layer, we only start the task after verifying it doesn't already exist. Also removed cache from `Provisioner` to ensure we are getting accurate results.