### PR TITLE
feat: Add script to suspend Indexers

### DIFF
--- a/runner/package.json
+++ b/runner/package.json
@@ -14,7 +14,8 @@
     "start:dev": "tsc -p ./tsconfig.build.json && node ./dist",
     "start:docker": "node dist/index.js",
     "test": "npm run codegen && node --experimental-vm-modules ./node_modules/.bin/jest --silent",
-    "lint": "eslint -c .eslintrc.js"
+    "lint": "eslint -c .eslintrc.js",
+    "script:suspend-indexer": "tsc -p ./tsconfig.json && node ./dist/scripts/suspend-indexer.js"
   },
   "keywords": [],
   "author": "",

--- a/runner/scripts/suspend-indexer.ts
+++ b/runner/scripts/suspend-indexer.ts
@@ -18,23 +18,46 @@ import * as fs from 'fs'
 import * as grpc from '@grpc/grpc-js'
 import * as protoLoader from '@grpc/proto-loader'
 
+import Provisioner from '../src/provisioner'
+import IndexerConfig from '../src/indexer-config'
+import IndexerMeta, { LogEntry } from '../src/indexer-meta';
+
 const COORDINATOR_PROTO_PATH = '../coordinator/proto/indexer_manager.proto';
 
 assert(exists(COORDINATOR_PROTO_PATH), 'Coordinator proto file not found. Make sure you run this script from the root directory.');
 assert(process.argv.length === 4, 'Usage: npm run script:suspend-indexer -- <accountId> <functionName>');
 assert(process.env.COORDINATOR_PORT, 'COORDINATOR_PORT env var is required');
+assert(process.env.HASURA_ADMIN_SECRET, 'HASURA_ADMIN_SECRET env var is required');
+assert(process.env.HASURA_ENDPOINT, 'HASURA_ENDPOINT env var is required');
+assert(process.env.PGPORT, 'PGPORT env var is required');
+assert(process.env.PGHOST, 'PGHOST env var is required');
 
 const [_binary, _file, accountId, functionName] = process.argv;
 const { COORDINATOR_PORT } = process.env;
 
+const provisioner = new Provisioner();
+
 main();
 
-function main() {
-  console.log(`Disabling indexer: ${accountId}/${functionName}\n`);
+async function main() {
+  const config = new IndexerConfig('redis stream', accountId, functionName, 0, 'code', 'schema', 2);
+
+  console.log(`Suspending indexer: ${accountId}/${functionName}\n`);
 
   const indexerManager = createIndexerManagerClient();
 
-  indexerManager.disable({ accountId: 'morgs.near', functionName: 'sqs' }, console.log);
+  indexerManager.disable({ accountId, functionName }, console.log);
+
+  console.log('Logging suspension notification');
+
+  const pgCredentials = await provisioner.getPostgresConnectionParameters(config.userName());
+  const meta = new IndexerMeta(config, pgCredentials);
+
+  await meta.writeLogs([
+    LogEntry.systemInfo('Suspending Indexer due to inactivity'),
+  ]);
+
+  console.log('Done')
 }
 
 function exists(path: string): boolean {

--- a/runner/scripts/suspend-indexer.ts
+++ b/runner/scripts/suspend-indexer.ts
@@ -8,7 +8,7 @@
   * 1. Call Coordinator to disable the indexer
   * 2. Write to the Indexers logs table to notify of suspension
   *
-  * Usage: node toggle-indexer.js <accountId> <functionName>
+  * Usage: node suspend-indexer.ts <accountId> <functionName>
   * 
 */
 
@@ -21,7 +21,7 @@ const protoLoader = require( '@grpc/proto-loader');
 const COORDINATOR_PROTO_PATH = '../../coordinator/proto/indexer_manager.proto';
 
 assert(exists(COORDINATOR_PROTO_PATH), 'Coordinator proto file not found. Make sure you run this script from the `./scripts` directory.');
-assert(process.argv.length === 4, 'Usage: node toggle-indexer.js <accountId> <functionName>');
+assert(process.argv.length === 4, 'Usage: node suspend-indexer.ts <accountId> <functionName>');
 assert(process.env.COORDINATOR_PORT, 'COORDINATOR_PORT env var is required');
 
 const [_binary, _file, accountId, functionName] = process.argv;

--- a/runner/scripts/suspend-indexer.ts
+++ b/runner/scripts/suspend-indexer.ts
@@ -12,11 +12,11 @@
   * 
 */
 
-const assert = require('assert');
-const fs = require('fs');
+import assert from 'assert'
+import * as fs from 'fs'
 
-const grpc = require('@grpc/grpc-js');
-const protoLoader = require( '@grpc/proto-loader');
+import * as grpc from '@grpc/grpc-js'
+import * as protoLoader from '@grpc/proto-loader'
 
 const COORDINATOR_PROTO_PATH = '../../coordinator/proto/indexer_manager.proto';
 
@@ -34,10 +34,10 @@ function main() {
 
   const indexerManager = createIndexerManagerClient();
 
-  indexerManager.diable({ accountId: 'morgs.near', functionName: 'sqs' }, console.log);
+  indexerManager.disable({ accountId: 'morgs.near', functionName: 'sqs' }, console.log);
 }
 
-function exists(path) {
+function exists(path: string): boolean {
   try {
     fs.statSync(path);
     return true;
@@ -48,6 +48,6 @@ function exists(path) {
 
 function createIndexerManagerClient() {
   const packageDefinition = protoLoader.loadSync(COORDINATOR_PROTO_PATH);
-  const protoDescriptor = grpc.loadPackageDefinition(packageDefinition);
+  const protoDescriptor: any = grpc.loadPackageDefinition(packageDefinition);
   return new protoDescriptor.indexer.IndexerManager(`localhost:${COORDINATOR_PORT}`, grpc.credentials.createInsecure());
 }

--- a/runner/scripts/suspend-indexer.ts
+++ b/runner/scripts/suspend-indexer.ts
@@ -8,7 +8,7 @@
   * 1. Call Coordinator to disable the indexer
   * 2. Write to the Indexers logs table to notify of suspension
   *
-  * Usage: node suspend-indexer.ts <accountId> <functionName>
+  * Usage: npm run script:suspend-indexer -- <accountId> <functionName>
   * 
 */
 
@@ -18,10 +18,10 @@ import * as fs from 'fs'
 import * as grpc from '@grpc/grpc-js'
 import * as protoLoader from '@grpc/proto-loader'
 
-const COORDINATOR_PROTO_PATH = '../../coordinator/proto/indexer_manager.proto';
+const COORDINATOR_PROTO_PATH = '../coordinator/proto/indexer_manager.proto';
 
-assert(exists(COORDINATOR_PROTO_PATH), 'Coordinator proto file not found. Make sure you run this script from the `./scripts` directory.');
-assert(process.argv.length === 4, 'Usage: node suspend-indexer.ts <accountId> <functionName>');
+assert(exists(COORDINATOR_PROTO_PATH), 'Coordinator proto file not found. Make sure you run this script from the root directory.');
+assert(process.argv.length === 4, 'Usage: npm run script:suspend-indexer -- <accountId> <functionName>');
 assert(process.env.COORDINATOR_PORT, 'COORDINATOR_PORT env var is required');
 
 const [_binary, _file, accountId, functionName] = process.argv;

--- a/runner/scripts/suspend-indexer.ts
+++ b/runner/scripts/suspend-indexer.ts
@@ -64,7 +64,7 @@ async function logSuspension() {
   const pgCredentials = await new Provisioner().getPostgresConnectionParameters(config.userName());
 
   await new IndexerMeta(config, pgCredentials).writeLogs([
-    LogEntry.systemInfo('Suspending Indexer due to inactivity'),
+    LogEntry.systemInfo('The indexer is suspended due to inactivity.'),
   ]);
 }
 

--- a/runner/scripts/toggle-indexer.ts
+++ b/runner/scripts/toggle-indexer.ts
@@ -1,0 +1,14 @@
+// 1. Assert env vars
+// 2. connect to coordinator
+// 3. disable
+// 4. log and set status?
+
+const grpc = require('@grpc/grpc-js');
+const protoLoader = require( '@grpc/proto-loader');
+
+const packageDefinition = protoLoader.loadSync('../../coordinator/proto/indexer_manager.proto');
+const protoDescriptor = grpc.loadPackageDefinition(packageDefinition);
+
+const indexerManager = new protoDescriptor.indexer.IndexerManager('localhost:8002', grpc.credentials.createInsecure());
+
+indexerManager.disable({ accountId: 'morgs.near', functionName: 'sqs' }, console.log);

--- a/runner/scripts/toggle-indexer.ts
+++ b/runner/scripts/toggle-indexer.ts
@@ -3,12 +3,51 @@
 // 3. disable
 // 4. log and set status?
 
+/*
+  * This script is used to suspend an indexer for a given account. It will:
+  * 1. Call Coordinator to disable the indexer
+  * 2. Write to the Indexers logs table to notify of suspension
+  *
+  * Usage: node toggle-indexer.js <accountId> <functionName>
+  * 
+*/
+
+const assert = require('assert');
+const fs = require('fs');
+
 const grpc = require('@grpc/grpc-js');
 const protoLoader = require( '@grpc/proto-loader');
 
-const packageDefinition = protoLoader.loadSync('../../coordinator/proto/indexer_manager.proto');
-const protoDescriptor = grpc.loadPackageDefinition(packageDefinition);
+const COORDINATOR_PROTO_PATH = '../../coordinator/proto/indexer_manager.proto';
 
-const indexerManager = new protoDescriptor.indexer.IndexerManager('localhost:8002', grpc.credentials.createInsecure());
+assert(exists(COORDINATOR_PROTO_PATH), 'Coordinator proto file not found. Make sure you run this script from the `./scripts` directory.');
+assert(process.argv.length === 4, 'Usage: node toggle-indexer.js <accountId> <functionName>');
+assert(process.env.COORDINATOR_PORT, 'COORDINATOR_PORT env var is required');
 
-indexerManager.disable({ accountId: 'morgs.near', functionName: 'sqs' }, console.log);
+const [_binary, _file, accountId, functionName] = process.argv;
+const { COORDINATOR_PORT } = process.env;
+
+main();
+
+function main() {
+  console.log(`Disabling indexer: ${accountId}/${functionName}\n`);
+
+  const indexerManager = createIndexerManagerClient();
+
+  indexerManager.diable({ accountId: 'morgs.near', functionName: 'sqs' }, console.log);
+}
+
+function exists(path) {
+  try {
+    fs.statSync(path);
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+function createIndexerManagerClient() {
+  const packageDefinition = protoLoader.loadSync(COORDINATOR_PROTO_PATH);
+  const protoDescriptor = grpc.loadPackageDefinition(packageDefinition);
+  return new protoDescriptor.indexer.IndexerManager(`localhost:${COORDINATOR_PORT}`, grpc.credentials.createInsecure());
+}

--- a/runner/src/indexer-meta/index.ts
+++ b/runner/src/indexer-meta/index.ts
@@ -1,2 +1,3 @@
 export { default } from './indexer-meta';
 export { IndexerStatus, METADATA_TABLE_UPSERT, MetadataFields } from './indexer-meta';
+export { default as LogEntry } from './log-entry';

--- a/runner/tsconfig.build.json
+++ b/runner/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
   "include": ["./src"],
-  "exclude": ["node_modules", "dist", "**/*.test.*"]
+  "exclude": ["node_modules", "dist", "**/*.test.*", "scripts"]
 }

--- a/runner/tsconfig.json
+++ b/runner/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2018",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     "lib": ["es2021"],                                      /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     "module": "commonjs",                                /* Specify what module code is generated. */
-    "rootDirs": ["./src", "./tests"],    
+    "rootDirs": ["./src", "./tests", "./scripts"],    
     "moduleResolution": "node",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     "resolveJsonModule": true,                           /* Enable importing .json files. */
     "allowJs": true,                                     /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
@@ -20,6 +20,6 @@
     "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
-  "include": ["./src", "./tests"],
+  "include": ["./src", "./tests", "./scripts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
This PR adds a Node script to Runner to suspend Indexers due to inactivity. The script will:
1. Call Coordinator to disable the indexer
2. Write to the Indexers logs table to notify of suspension

Note that as Coordinator is in a private network, you must tunnel to the machine to expose the gRPC server. This can be achieved via running the following in a separate terminal:
```sh
gcloud compute ssh ubuntu@queryapi-coordinator-mainnet -- -L 9003:0.0.0.0:9003
```

The following environment variables are required:
- `HASURA_ADMIN_SECRET`
- `HASURA_ENDPOINT`
- `PGPORT`
- `PGHOST`

All of which can be found in the Runner compute instance metadata:
```sh
gcloud compute instances describe queryapi-runner-mainnet
```


Usage: `npm run script:suspend-indexer -- <accountId> <functionName>`