### PR TITLE
feat: Limit Redis Stream length

### DIFF
--- a/block-streamer/Cargo.toml
+++ b/block-streamer/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0.55"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracing-stackdriver = "0.10.0"
-tokio = { version = "1.28.0", features = ["full"]}
+tokio = { version = "1.28.0", features = ["full", "test-util"]}
 tokio-util = "0.7.10"
 tokio-stream = "0.1.14"
 tonic = "0.10.2"

--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -45,7 +45,7 @@ impl BlockStream {
     pub fn start(
         &mut self,
         start_block_height: near_indexer_primitives::types::BlockHeight,
-        redis_client: std::sync::Arc<crate::redis::RedisClient>,
+        redis: std::sync::Arc<crate::redis::RedisWrapper>,
         delta_lake_client: std::sync::Arc<crate::delta_lake_client::DeltaLakeClient>,
         lake_s3_client: crate::lake_s3_client::SharedLakeS3Client,
     ) -> anyhow::Result<()> {
@@ -74,7 +74,7 @@ impl BlockStream {
                 result = start_block_stream(
                     start_block_height,
                     &indexer_config,
-                    redis_client,
+                    redis,
                     delta_lake_client,
                     lake_s3_client,
                     &chain_id,
@@ -129,7 +129,7 @@ impl BlockStream {
 pub(crate) async fn start_block_stream(
     start_block_height: near_indexer_primitives::types::BlockHeight,
     indexer: &IndexerConfig,
-    redis_client: std::sync::Arc<crate::redis::RedisClient>,
+    redis: std::sync::Arc<crate::redis::RedisWrapper>,
     delta_lake_client: std::sync::Arc<crate::delta_lake_client::DeltaLakeClient>,
     lake_s3_client: crate::lake_s3_client::SharedLakeS3Client,
     chain_id: &ChainId,
@@ -145,7 +145,7 @@ pub(crate) async fn start_block_stream(
     let last_indexed_delta_lake_block = process_delta_lake_blocks(
         start_block_height,
         delta_lake_client,
-        redis_client.clone(),
+        redis.clone(),
         indexer,
         redis_stream.clone(),
     )
@@ -156,7 +156,7 @@ pub(crate) async fn start_block_stream(
         last_indexed_delta_lake_block,
         lake_s3_client,
         lake_prefetch_size,
-        redis_client,
+        redis,
         indexer,
         redis_stream,
         chain_id,
@@ -175,7 +175,7 @@ pub(crate) async fn start_block_stream(
 async fn process_delta_lake_blocks(
     start_block_height: near_indexer_primitives::types::BlockHeight,
     delta_lake_client: std::sync::Arc<crate::delta_lake_client::DeltaLakeClient>,
-    redis_client: std::sync::Arc<crate::redis::RedisClient>,
+    redis: std::sync::Arc<crate::redis::RedisWrapper>,
     indexer: &IndexerConfig,
     redis_stream: String,
 ) -> anyhow::Result<u64> {
@@ -230,10 +230,10 @@ async fn process_delta_lake_blocks(
 
     for block_height in &blocks_from_index {
         let block_height = block_height.to_owned();
-        redis_client
             .publish_block(indexer, redis_stream.clone(), block_height)
+        redis
             .await?;
-        redis_client
+        redis
             .set_last_processed_block(indexer, block_height)
             .await?;
     }
@@ -253,7 +253,7 @@ async fn process_near_lake_blocks(
     start_block_height: near_indexer_primitives::types::BlockHeight,
     lake_s3_client: crate::lake_s3_client::SharedLakeS3Client,
     lake_prefetch_size: usize,
-    redis_client: std::sync::Arc<crate::redis::RedisClient>,
+    redis: std::sync::Arc<crate::redis::RedisWrapper>,
     indexer: &IndexerConfig,
     redis_stream: String,
     chain_id: &ChainId,
@@ -278,7 +278,7 @@ async fn process_near_lake_blocks(
         let block_height = streamer_message.block.header.height;
         last_indexed_block = block_height;
 
-        redis_client
+        redis
             .set_last_processed_block(indexer, block_height)
             .await?;
 
@@ -289,18 +289,14 @@ async fn process_near_lake_blocks(
         );
 
         if !matches.is_empty() {
-            if let Ok(Some(stream_length)) =
-                redis_client.get_stream_length(redis_stream.clone()).await
-            {
+            if let Ok(Some(stream_length)) = redis.get_stream_length(redis_stream.clone()).await {
                 if stream_length <= MAX_STREAM_SIZE_WITH_CACHE {
-                    redis_client
-                        .cache_streamer_message(&streamer_message)
-                        .await?;
+                    redis.cache_streamer_message(&streamer_message).await?;
                 }
             }
 
-            redis_client
                 .publish_block(indexer, redis_stream.clone(), block_height)
+            redis
                 .await?;
         }
     }
@@ -355,17 +351,18 @@ mod tests {
             .expect_list_matching_block_heights()
             .returning(|_, _| Ok(vec![107503702, 107503703]));
 
-        let mut mock_redis_client = crate::redis::RedisClient::default();
-        mock_redis_client
+        let mut mock_redis_wrapper = crate::redis::RedisWrapper::default();
+        mock_redis_wrapper
             .expect_publish_block()
             .with(
                 predicate::always(),
                 predicate::eq("stream key".to_string()),
                 predicate::in_iter([107503702, 107503703, 107503705]),
+                predicate::always(),
             )
-            .returning(|_, _, _| Ok(()))
+            .returning(|_, _, _, _| Ok(()))
             .times(3);
-        mock_redis_client
+        mock_redis_wrapper
             .expect_set_last_processed_block()
             .with(
                 predicate::always(),
@@ -373,11 +370,11 @@ mod tests {
             )
             .returning(|_, _| Ok(()))
             .times(4);
-        mock_redis_client
+        mock_redis_wrapper
             .expect_cache_streamer_message()
             .with(predicate::always())
             .returning(|_| Ok(()));
-        mock_redis_client
+        mock_redis_wrapper
             .expect_get_stream_length()
             .with(predicate::eq("stream key".to_string()))
             .returning(|_| Ok(Some(10)));
@@ -397,7 +394,7 @@ mod tests {
         start_block_stream(
             91940840,
             &indexer_config,
-            std::sync::Arc::new(mock_redis_client),
+            std::sync::Arc::new(mock_redis_wrapper),
             std::sync::Arc::new(mock_delta_lake_client),
             mock_lake_s3_client,
             &ChainId::Mainnet,
@@ -428,15 +425,16 @@ mod tests {
                 })
             });
 
-        let mut mock_redis_client = crate::redis::RedisClient::default();
+        let mut mock_redis_client = crate::redis::RedisWrapper::default();
         mock_redis_client
             .expect_publish_block()
             .with(
                 predicate::always(),
                 predicate::eq("stream key".to_string()),
                 predicate::in_iter([107503705]),
+                predicate::always(),
             )
-            .returning(|_, _, _| Ok(()))
+            .returning(|_, _, _, _| Ok(()))
             .times(1);
         mock_redis_client
             .expect_set_last_processed_block()
@@ -499,7 +497,7 @@ mod tests {
             .expect_list_matching_block_heights()
             .never();
 
-        let mut mock_redis_client = crate::redis::RedisClient::default();
+        let mut mock_redis_client = crate::redis::RedisWrapper::default();
         mock_redis_client.expect_publish_block().never();
         mock_redis_client.expect_set_last_processed_block().never();
 
@@ -544,7 +542,7 @@ mod tests {
             .expect_list_matching_block_heights()
             .never();
 
-        let mut mock_redis_client = crate::redis::RedisClient::default();
+        let mut mock_redis_client = crate::redis::RedisWrapper::default();
         mock_redis_client.expect_publish_block().never();
         mock_redis_client.expect_set_last_processed_block().never();
 
@@ -589,7 +587,7 @@ mod tests {
             .expect_list_matching_block_heights()
             .never();
 
-        let mut mock_redis_client = crate::redis::RedisClient::default();
+        let mut mock_redis_client = crate::redis::RedisWrapper::default();
         mock_redis_client.expect_publish_block().never();
         mock_redis_client.expect_set_last_processed_block().never();
 

--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -46,7 +46,7 @@ impl BlockStream {
     pub fn start(
         &mut self,
         start_block_height: near_indexer_primitives::types::BlockHeight,
-        redis: std::sync::Arc<crate::redis::RedisWrapper>,
+        redis: std::sync::Arc<crate::redis::RedisClient>,
         delta_lake_client: std::sync::Arc<crate::delta_lake_client::DeltaLakeClient>,
         lake_s3_client: crate::lake_s3_client::SharedLakeS3Client,
     ) -> anyhow::Result<()> {
@@ -130,7 +130,7 @@ impl BlockStream {
 pub(crate) async fn start_block_stream(
     start_block_height: near_indexer_primitives::types::BlockHeight,
     indexer: &IndexerConfig,
-    redis: std::sync::Arc<crate::redis::RedisWrapper>,
+    redis: std::sync::Arc<crate::redis::RedisClient>,
     delta_lake_client: std::sync::Arc<crate::delta_lake_client::DeltaLakeClient>,
     lake_s3_client: crate::lake_s3_client::SharedLakeS3Client,
     chain_id: &ChainId,
@@ -176,7 +176,7 @@ pub(crate) async fn start_block_stream(
 async fn process_delta_lake_blocks(
     start_block_height: near_indexer_primitives::types::BlockHeight,
     delta_lake_client: std::sync::Arc<crate::delta_lake_client::DeltaLakeClient>,
-    redis: std::sync::Arc<crate::redis::RedisWrapper>,
+    redis: std::sync::Arc<crate::redis::RedisClient>,
     indexer: &IndexerConfig,
     redis_stream: String,
 ) -> anyhow::Result<u64> {
@@ -254,7 +254,7 @@ async fn process_near_lake_blocks(
     start_block_height: near_indexer_primitives::types::BlockHeight,
     lake_s3_client: crate::lake_s3_client::SharedLakeS3Client,
     lake_prefetch_size: usize,
-    redis: std::sync::Arc<crate::redis::RedisWrapper>,
+    redis: std::sync::Arc<crate::redis::RedisClient>,
     indexer: &IndexerConfig,
     redis_stream: String,
     chain_id: &ChainId,
@@ -352,7 +352,7 @@ mod tests {
             .expect_list_matching_block_heights()
             .returning(|_, _| Ok(vec![107503702, 107503703]));
 
-        let mut mock_redis_wrapper = crate::redis::RedisWrapper::default();
+        let mut mock_redis_wrapper = crate::redis::RedisClient::default();
         mock_redis_wrapper
             .expect_publish_block()
             .with(
@@ -426,7 +426,7 @@ mod tests {
                 })
             });
 
-        let mut mock_redis_client = crate::redis::RedisWrapper::default();
+        let mut mock_redis_client = crate::redis::RedisClient::default();
         mock_redis_client
             .expect_publish_block()
             .with(
@@ -498,7 +498,7 @@ mod tests {
             .expect_list_matching_block_heights()
             .never();
 
-        let mut mock_redis_client = crate::redis::RedisWrapper::default();
+        let mut mock_redis_client = crate::redis::RedisClient::default();
         mock_redis_client.expect_publish_block().never();
         mock_redis_client.expect_set_last_processed_block().never();
 
@@ -543,7 +543,7 @@ mod tests {
             .expect_list_matching_block_heights()
             .never();
 
-        let mut mock_redis_client = crate::redis::RedisWrapper::default();
+        let mut mock_redis_client = crate::redis::RedisClient::default();
         mock_redis_client.expect_publish_block().never();
         mock_redis_client.expect_set_last_processed_block().never();
 
@@ -588,7 +588,7 @@ mod tests {
             .expect_list_matching_block_heights()
             .never();
 
-        let mut mock_redis_client = crate::redis::RedisWrapper::default();
+        let mut mock_redis_client = crate::redis::RedisClient::default();
         mock_redis_client.expect_publish_block().never();
         mock_redis_client.expect_set_last_processed_block().never();
 

--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -352,8 +352,8 @@ mod tests {
             .expect_list_matching_block_heights()
             .returning(|_, _| Ok(vec![107503702, 107503703]));
 
-        let mut mock_redis_wrapper = crate::redis::RedisClient::default();
-        mock_redis_wrapper
+        let mut mock_redis = crate::redis::RedisClient::default();
+        mock_redis
             .expect_publish_block()
             .with(
                 predicate::always(),
@@ -363,7 +363,7 @@ mod tests {
             )
             .returning(|_, _, _, _| Ok(()))
             .times(3);
-        mock_redis_wrapper
+        mock_redis
             .expect_set_last_processed_block()
             .with(
                 predicate::always(),
@@ -371,11 +371,11 @@ mod tests {
             )
             .returning(|_, _| Ok(()))
             .times(4);
-        mock_redis_wrapper
+        mock_redis
             .expect_cache_streamer_message()
             .with(predicate::always())
             .returning(|_| Ok(()));
-        mock_redis_wrapper
+        mock_redis
             .expect_get_stream_length()
             .with(predicate::eq("stream key".to_string()))
             .returning(|_| Ok(Some(10)));
@@ -395,7 +395,7 @@ mod tests {
         start_block_stream(
             91940840,
             &indexer_config,
-            std::sync::Arc::new(mock_redis_wrapper),
+            std::sync::Arc::new(mock_redis),
             std::sync::Arc::new(mock_delta_lake_client),
             mock_lake_s3_client,
             &ChainId::Mainnet,

--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -12,6 +12,7 @@ use registry_types::Rule;
 const LAKE_PREFETCH_SIZE: usize = 100;
 const MAX_STREAM_SIZE_WITH_CACHE: u64 = 100;
 const DELTA_LAKE_SKIP_ACCOUNTS: [&str; 4] = ["*", "*.near", "*.kaiching", "*.tg"];
+const MAX_STREAM_SIZE: u64 = 100;
 
 pub struct Task {
     handle: JoinHandle<anyhow::Result<()>>,
@@ -230,8 +231,8 @@ async fn process_delta_lake_blocks(
 
     for block_height in &blocks_from_index {
         let block_height = block_height.to_owned();
-            .publish_block(indexer, redis_stream.clone(), block_height)
         redis
+            .publish_block(indexer, redis_stream.clone(), block_height, MAX_STREAM_SIZE)
             .await?;
         redis
             .set_last_processed_block(indexer, block_height)
@@ -295,8 +296,8 @@ async fn process_near_lake_blocks(
                 }
             }
 
-                .publish_block(indexer, redis_stream.clone(), block_height)
             redis
+                .publish_block(indexer, redis_stream.clone(), block_height, MAX_STREAM_SIZE)
                 .await?;
         }
     }

--- a/block-streamer/src/main.rs
+++ b/block-streamer/src/main.rs
@@ -45,7 +45,7 @@ async fn main() -> anyhow::Result<()> {
         "Starting Block Streamer"
     );
 
-    let redis = std::sync::Arc::new(redis::RedisWrapper::connect(&redis_url).await?);
+    let redis = std::sync::Arc::new(redis::RedisClient::connect(&redis_url).await?);
 
     let aws_config = aws_config::from_env().load().await;
     let s3_config = aws_sdk_s3::Config::from(&aws_config);

--- a/block-streamer/src/main.rs
+++ b/block-streamer/src/main.rs
@@ -45,7 +45,7 @@ async fn main() -> anyhow::Result<()> {
         "Starting Block Streamer"
     );
 
-    let redis_client = std::sync::Arc::new(redis::RedisClient::connect(&redis_url).await?);
+    let redis = std::sync::Arc::new(redis::RedisWrapper::connect(&redis_url).await?);
 
     let aws_config = aws_config::from_env().load().await;
     let s3_config = aws_sdk_s3::Config::from(&aws_config);
@@ -58,7 +58,7 @@ async fn main() -> anyhow::Result<()> {
 
     tokio::spawn(metrics::init_server(metrics_port).expect("Failed to start metrics server"));
 
-    server::init(&grpc_port, redis_client, delta_lake_client, lake_s3_client).await?;
+    server::init(&grpc_port, redis, delta_lake_client, lake_s3_client).await?;
 
     Ok(())
 }

--- a/block-streamer/src/server/block_streamer_service.rs
+++ b/block-streamer/src/server/block_streamer_service.rs
@@ -206,7 +206,7 @@ mod tests {
             .expect_list_matching_block_heights()
             .returning(|_, _| Ok(vec![]));
 
-        let mock_redis_wrapper = crate::redis::RedisClient::default();
+        let mock_redis = crate::redis::RedisClient::default();
 
         let mut mock_lake_s3_client = crate::lake_s3_client::SharedLakeS3Client::default();
         mock_lake_s3_client
@@ -214,7 +214,7 @@ mod tests {
             .returning(crate::lake_s3_client::SharedLakeS3Client::default);
 
         BlockStreamerService::new(
-            std::sync::Arc::new(mock_redis_wrapper),
+            std::sync::Arc::new(mock_redis),
             std::sync::Arc::new(mock_delta_lake_client),
             mock_lake_s3_client,
         )

--- a/block-streamer/src/server/block_streamer_service.rs
+++ b/block-streamer/src/server/block_streamer_service.rs
@@ -13,7 +13,7 @@ use crate::server::blockstreamer;
 use blockstreamer::*;
 
 pub struct BlockStreamerService {
-    redis: std::sync::Arc<crate::redis::RedisWrapper>,
+    redis: std::sync::Arc<crate::redis::RedisClient>,
     delta_lake_client: std::sync::Arc<crate::delta_lake_client::DeltaLakeClient>,
     lake_s3_client: crate::lake_s3_client::SharedLakeS3Client,
     chain_id: ChainId,
@@ -22,7 +22,7 @@ pub struct BlockStreamerService {
 
 impl BlockStreamerService {
     pub fn new(
-        redis: std::sync::Arc<crate::redis::RedisWrapper>,
+        redis: std::sync::Arc<crate::redis::RedisClient>,
         delta_lake_client: std::sync::Arc<crate::delta_lake_client::DeltaLakeClient>,
         lake_s3_client: crate::lake_s3_client::SharedLakeS3Client,
     ) -> Self {
@@ -206,7 +206,7 @@ mod tests {
             .expect_list_matching_block_heights()
             .returning(|_, _| Ok(vec![]));
 
-        let mock_redis_wrapper = crate::redis::RedisWrapper::default();
+        let mock_redis_wrapper = crate::redis::RedisClient::default();
 
         let mut mock_lake_s3_client = crate::lake_s3_client::SharedLakeS3Client::default();
         mock_lake_s3_client

--- a/block-streamer/src/server/block_streamer_service.rs
+++ b/block-streamer/src/server/block_streamer_service.rs
@@ -13,7 +13,7 @@ use crate::server::blockstreamer;
 use blockstreamer::*;
 
 pub struct BlockStreamerService {
-    redis_client: std::sync::Arc<crate::redis::RedisClient>,
+    redis: std::sync::Arc<crate::redis::RedisWrapper>,
     delta_lake_client: std::sync::Arc<crate::delta_lake_client::DeltaLakeClient>,
     lake_s3_client: crate::lake_s3_client::SharedLakeS3Client,
     chain_id: ChainId,
@@ -22,12 +22,12 @@ pub struct BlockStreamerService {
 
 impl BlockStreamerService {
     pub fn new(
-        redis_client: std::sync::Arc<crate::redis::RedisClient>,
+        redis: std::sync::Arc<crate::redis::RedisWrapper>,
         delta_lake_client: std::sync::Arc<crate::delta_lake_client::DeltaLakeClient>,
         lake_s3_client: crate::lake_s3_client::SharedLakeS3Client,
     ) -> Self {
         Self {
-            redis_client,
+            redis,
             delta_lake_client,
             lake_s3_client,
             chain_id: ChainId::Mainnet,
@@ -113,7 +113,7 @@ impl blockstreamer::block_streamer_server::BlockStreamer for BlockStreamerServic
         block_stream
             .start(
                 request.start_block_height,
-                self.redis_client.clone(),
+                self.redis.clone(),
                 self.delta_lake_client.clone(),
                 self.lake_s3_client.clone(),
             )
@@ -206,10 +206,7 @@ mod tests {
             .expect_list_matching_block_heights()
             .returning(|_, _| Ok(vec![]));
 
-        let mut mock_redis_client = crate::redis::RedisClient::default();
-        mock_redis_client
-            .expect_xadd::<String, u64>()
-            .returning(|_, _| Ok(()));
+        let mock_redis_wrapper = crate::redis::RedisWrapper::default();
 
         let mut mock_lake_s3_client = crate::lake_s3_client::SharedLakeS3Client::default();
         mock_lake_s3_client
@@ -217,7 +214,7 @@ mod tests {
             .returning(crate::lake_s3_client::SharedLakeS3Client::default);
 
         BlockStreamerService::new(
-            std::sync::Arc::new(mock_redis_client),
+            std::sync::Arc::new(mock_redis_wrapper),
             std::sync::Arc::new(mock_delta_lake_client),
             mock_lake_s3_client,
         )

--- a/block-streamer/src/server/mod.rs
+++ b/block-streamer/src/server/mod.rs
@@ -6,7 +6,7 @@ pub mod blockstreamer {
 
 pub async fn init(
     port: &str,
-    redis: std::sync::Arc<crate::redis::RedisWrapper>,
+    redis: std::sync::Arc<crate::redis::RedisClient>,
     delta_lake_client: std::sync::Arc<crate::delta_lake_client::DeltaLakeClient>,
     lake_s3_client: crate::lake_s3_client::SharedLakeS3Client,
 ) -> anyhow::Result<()> {

--- a/block-streamer/src/server/mod.rs
+++ b/block-streamer/src/server/mod.rs
@@ -6,7 +6,7 @@ pub mod blockstreamer {
 
 pub async fn init(
     port: &str,
-    redis_client: std::sync::Arc<crate::redis::RedisClient>,
+    redis: std::sync::Arc<crate::redis::RedisWrapper>,
     delta_lake_client: std::sync::Arc<crate::delta_lake_client::DeltaLakeClient>,
     lake_s3_client: crate::lake_s3_client::SharedLakeS3Client,
 ) -> anyhow::Result<()> {
@@ -14,11 +14,8 @@ pub async fn init(
 
     tracing::info!("Starting gRPC server on {}", addr);
 
-    let block_streamer_service = block_streamer_service::BlockStreamerService::new(
-        redis_client,
-        delta_lake_client,
-        lake_s3_client,
-    );
+    let block_streamer_service =
+        block_streamer_service::BlockStreamerService::new(redis, delta_lake_client, lake_s3_client);
 
     let block_streamer_server =
         blockstreamer::block_streamer_server::BlockStreamerServer::new(block_streamer_service);


### PR DESCRIPTION
This PR introduces back pressure to the Redis Stream in Block Streamer, ensuring that the stream does not exceed a specified maximum length. This is achieved by blocking the `redis.publish_block()` call, intermittently polling the Stream length, and publishing once it falls below the configured limit.

To aid testing, the current `RedisClient` struct has been split in to two:
- `RedisCommands` - thin wrapper around redis commands to make mocking possible.
- `RedisClient` - provides higher-level redis functionality, e.g. "publishing blocks", utilising the above.

In most cases, `RedisClient` will be used. The split just allows us to test `RedisWrapper` itself.