### PR TITLE
fix: Add metrics for reliably measuring Block Stream/Executor health

### DIFF
--- a/block-streamer/Cargo.lock
+++ b/block-streamer/Cargo.lock
@@ -980,6 +980,7 @@ dependencies = [
  "lazy_static",
  "mockall",
  "near-lake-framework",
+ "pin-project",
  "prometheus",
  "prost 0.12.4",
  "redis",

--- a/block-streamer/Cargo.toml
+++ b/block-streamer/Cargo.toml
@@ -19,6 +19,7 @@ graphql_client = { version = "0.14.0", features = ["reqwest"] }
 lazy_static = "1.4.0"
 mockall = "0.11.4"
 near-lake-framework = "0.7.8"
+pin-project = "1.1.5"
 prometheus = "0.13.3"
 prost = "0.12.3"
 redis = { version = "0.21.5", features = ["tokio-comp", "connection-manager"] }

--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -18,7 +18,9 @@ const MAX_STREAM_SIZE_WITH_CACHE: u64 = 100;
 const DELTA_LAKE_SKIP_ACCOUNTS: [&str; 4] = ["*", "*.near", "*.kaiching", "*.tg"];
 const MAX_STREAM_SIZE: u64 = 100;
 
+#[pin_project::pin_project]
 pub struct PollCounter<F> {
+    #[pin]
     inner: F,
     indexer_name: String,
 }
@@ -40,8 +42,8 @@ impl<F: Future> Future for PollCounter<F> {
             .with_label_values(&[&self.indexer_name])
             .inc();
 
-        let future = unsafe { self.map_unchecked_mut(|s| &mut s.inner) };
-        future.poll(cx)
+        let this = self.project();
+        this.inner.poll(cx)
     }
 }
 

--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -148,8 +148,9 @@ impl BlockStream {
             task.cancellation_token.cancel();
             let _ = task.handle.await?;
 
-            metrics::BLOCK_STREAM_UP
-                .remove_label_values(&[&self.indexer_config.get_full_name()])?;
+            // Fails if metric doesn't exist, i.e. task was never polled
+            let _ = metrics::BLOCK_STREAM_UP
+                .remove_label_values(&[&self.indexer_config.get_full_name()]);
 
             return Ok(());
         }

--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -148,6 +148,9 @@ impl BlockStream {
             task.cancellation_token.cancel();
             let _ = task.handle.await?;
 
+            metrics::BLOCK_STREAM_UP
+                .remove_label_values(&[&self.indexer_config.get_full_name()])?;
+
             return Ok(());
         }
 

--- a/block-streamer/src/metrics.rs
+++ b/block-streamer/src/metrics.rs
@@ -57,6 +57,12 @@ lazy_static! {
         &["level"]
     )
     .unwrap();
+    pub static ref BLOCK_STREAM_UP: IntCounterVec = register_int_counter_vec!(
+        "queryapi_block_streamer_block_stream_up",
+        "A continuously increasing counter to indicate the block stream is up",
+        &["indexer"]
+    )
+    .unwrap();
 }
 
 pub struct LogCounter;

--- a/coordinator/Cargo.lock
+++ b/coordinator/Cargo.lock
@@ -939,6 +939,7 @@ dependencies = [
  "lazy_static",
  "mockall",
  "near-lake-framework",
+ "pin-project",
  "prometheus",
  "prost 0.12.3",
  "redis 0.21.7",
@@ -3133,18 +3134,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/runner/src/metrics.ts
+++ b/runner/src/metrics.ts
@@ -63,6 +63,24 @@ const LOGS_COUNT = new Counter({
   labelNames: ['level'],
 });
 
+const EXECUTOR_UP = new Counter({
+  name: 'queryapi_runner_executor_up',
+  help: 'Incremented each time the executor loop runs to indicate whether the job is functional',
+  labelNames: ['indexer'],
+});
+
+const SUCCESSFUL_EXECUTIONS = new Counter({
+  name: 'queryapi_runner_successful_executions',
+  help: 'Count of successful executions of an indexer function',
+  labelNames: ['indexer'],
+});
+
+const FAILED_EXECUTIONS = new Counter({
+  name: 'queryapi_runner_failed_executions',
+  help: 'Count of failed executions of an indexer function',
+  labelNames: ['indexer'],
+});
+
 export const METRICS = {
   HEAP_TOTAL_ALLOCATION,
   HEAP_USED,
@@ -73,7 +91,10 @@ export const METRICS = {
   UNPROCESSED_STREAM_MESSAGES,
   LAST_PROCESSED_BLOCK_HEIGHT,
   EXECUTION_DURATION,
-  LOGS_COUNT
+  LOGS_COUNT,
+  EXECUTOR_UP,
+  SUCCESSFUL_EXECUTIONS,
+  FAILED_EXECUTIONS,
 };
 
 const aggregatorRegistry = new AggregatorRegistry();

--- a/runner/src/metrics.ts
+++ b/runner/src/metrics.ts
@@ -63,24 +63,18 @@ const LOGS_COUNT = new Counter({
   labelNames: ['level'],
 });
 
-// We need this because the current metric formula uses "successful" executions, so genuinely broken
-// indexers will be considered "failed". This should always be at 100%
-// if there is no data then the executor is not running - and we should alert
 const EXECUTOR_UP = new Counter({
   name: 'queryapi_runner_executor_up',
   help: 'Incremented each time the executor loop runs to indicate whether the job is functional',
   labelNames: ['indexer'],
 });
 
-// not necessarily needed but useful to see?
 const SUCCESSFUL_EXECUTIONS = new Counter({
   name: 'queryapi_runner_successful_executions',
   help: 'Count of successful executions of an indexer function',
   labelNames: ['indexer'],
 });
 
-// This will allow us to determine whether a specific indexer is broken, so wont work across the board
-// but for critial indexers it should be 0
 const FAILED_EXECUTIONS = new Counter({
   name: 'queryapi_runner_failed_executions',
   help: 'Count of failed executions of an indexer function',

--- a/runner/src/metrics.ts
+++ b/runner/src/metrics.ts
@@ -63,18 +63,24 @@ const LOGS_COUNT = new Counter({
   labelNames: ['level'],
 });
 
+// We need this because the current metric formula uses "successful" executions, so genuinely broken
+// indexers will be considered "failed". This should always be at 100%
+// if there is no data then the executor is not running - and we should alert
 const EXECUTOR_UP = new Counter({
   name: 'queryapi_runner_executor_up',
   help: 'Incremented each time the executor loop runs to indicate whether the job is functional',
   labelNames: ['indexer'],
 });
 
+// not necessarily needed but useful to see?
 const SUCCESSFUL_EXECUTIONS = new Counter({
   name: 'queryapi_runner_successful_executions',
   help: 'Count of successful executions of an indexer function',
   labelNames: ['indexer'],
 });
 
+// This will allow us to determine whether a specific indexer is broken, so wont work across the board
+// but for critial indexers it should be 0
 const FAILED_EXECUTIONS = new Counter({
   name: 'queryapi_runner_failed_executions',
   help: 'Count of failed executions of an indexer function',


### PR DESCRIPTION
The current methods for determining both Block Stream and Executor health is flawed. This PR addresses these flaws by adding new, more reliable, metrics for use within Grafana.

### Block Streams

A Block Stream is considered healthy if `LAST_PROCESSED_BLOCK` is continuously incremented, i.e. we are continuously downloading blocks from S3. This is flawed for the following reasons:
1. When the Redis Stream if full, we halt the Block Stream, preventing it from processing more blocks
2. When a Block Stream is intentionally stopped, we no longer process blocks

To address these flaws, I've introduced a new dedicated metric: `BLOCK_STREAM_UP`, which:
- is incremented every time the Block Stream future is polled, i.e. the task is doing work. A static value means unhealthy.
- is removed when the Block Stream is stopped, so that it doesn't trigger the false positive described above

### Executors

An Executor is considered unhealthy if: it has messages in the Redis Stream, and no reported execution durations. The latter only being recorded on success. The inverse of this is used to determine "healthy". This is flawed for the following reasons:
1. We distinguish the difference between a genuinely broken Indexer, and one broken due to system failures
2. "health" is only determined when there are messages in Redis, meaning we catch the issue later than possible

To address these I have added the following metrics:
1. `EXECUTOR_UP` which is incremented on every Executor loop, like above, a static value means unhealthy.
2. `SUCCESSFUL_EXECUTIONS`/`FAILED_EXECUTIONS` which track successful/failed executions directly, rather than tracking using durations. This will be useful for tracking health of specific Indexers, e.g. the `staking` indexer should never have failed executions.
