### PR TITLE
feat: Restart worker thread on uncaught exception

### DIFF
--- a/runner/src/server/services/runner/runner-service.test.ts
+++ b/runner/src/server/services/runner/runner-service.test.ts
@@ -27,6 +27,7 @@ describe('Runner gRPC Service', () => {
       return {
         indexerConfig,
         stop: jest.fn(),
+        start: jest.fn()
       };
     });
     genericIndexerConfig = new IndexerConfig(BASIC_REDIS_STREAM, BASIC_ACCOUNT_ID, BASIC_FUNCTION_NAME, BASIC_VERSION, BASIC_CODE, BASIC_SCHEMA, LogLevel.INFO);
@@ -117,7 +118,7 @@ describe('Runner gRPC Service', () => {
       await Promise.resolve();
     });
     const streamHandlerType = jest.fn().mockImplementation((indexerConfig) => {
-      return { stop, indexerConfig };
+      return { start: jest.fn(), stop, indexerConfig };
     });
     const service = getRunnerService(new Map(), streamHandlerType);
     const mockCallback = jest.fn() as unknown as any;
@@ -184,7 +185,7 @@ describe('Runner gRPC Service', () => {
       await Promise.reject(new Error('somehow fails'));
     });
     const streamHandlerType = jest.fn().mockImplementation((indexerConfig) => {
-      return { stop, indexerConfig };
+      return { start: jest.fn(), stop, indexerConfig };
     });
     const service = getRunnerService(new Map(), streamHandlerType);
     const mockCallback = jest.fn() as unknown as any;
@@ -212,6 +213,7 @@ describe('Runner gRPC Service', () => {
     });
     const streamHandlerType = jest.fn().mockImplementation((indexerConfig) => {
       return {
+        start: jest.fn(),
         stop,
         indexerConfig,
         executorContext: BASIC_EXECUTOR_CONTEXT

--- a/runner/src/server/services/runner/runner-service.ts
+++ b/runner/src/server/services/runner/runner-service.ts
@@ -52,6 +52,7 @@ export function getRunnerService (
       // Handle request
       try {
         const streamHandler = new StreamHandlerType(indexerConfig);
+        streamHandler.start();
         executors.set(indexerConfig.executorId, streamHandler);
         callback(null, { executorId: indexerConfig.executorId });
       } catch (e) {

--- a/runner/src/stream-handler/worker.ts
+++ b/runner/src/stream-handler/worker.ts
@@ -63,7 +63,7 @@ async function handleStream (workerContext: WorkerContext): Promise<void> {
   void blockQueueConsumer(workerContext);
 }
 
-async function blockQueueProducer (workerContext: WorkerContext): Promise<void> {
+async function blockQueueProducer (workerContext: WorkerContext): Promise<never> {
   const HISTORICAL_BATCH_SIZE = parseInt(process.env.PREFETCH_QUEUE_LIMIT ?? '10');
   let streamMessageStartId = '0';
 
@@ -93,7 +93,7 @@ async function blockQueueProducer (workerContext: WorkerContext): Promise<void> 
   }
 }
 
-async function blockQueueConsumer (workerContext: WorkerContext): Promise<void> {
+async function blockQueueConsumer (workerContext: WorkerContext): Promise<never> {
   let previousError: string = '';
   const indexerConfig: IndexerConfig = workerContext.indexerConfig;
   const indexer = new Indexer(indexerConfig);


### PR DESCRIPTION
Currently, we terminate the worker thread if there is an uncaught exception. It was previously thought that uncaught exceptions were unrecoverable, but that is not always the case, e.g. uncaught PG connection failures can and should be retried. This PR updates that behaviour so the worker is restarted, rather than terminated.