### PR TITLE
doc: Document `bitmap` implementation

### DIFF
--- a/block-streamer/src/receiver_blocks/bitmap.rs
+++ b/block-streamer/src/receiver_blocks/bitmap.rs
@@ -47,7 +47,7 @@ struct EliasGammaDecoded {
     /// length of the run of bits (0s or 1s) in the decompressed bitmap.
     pub value: u64,
     /// The index of the last bit in the compressed bitmap that was part of the
-    /// Elias Gamma encoded value. Used to determine the starting point for the next encoded value.
+    /// Elias Gamma sequence. Used to determine the starting point for the next sequence.
     pub last_bit_index: usize,
 }
 

--- a/block-streamer/src/receiver_blocks/bitmap.rs
+++ b/block-streamer/src/receiver_blocks/bitmap.rs
@@ -51,7 +51,7 @@ struct EliasGammaDecoded {
     pub last_bit_index: usize,
 }
 
-/// A struct representing a compressed bitmap using Elias Gamma encoding.
+/// A struct representing a bitmap compressed using Elias Gamma encoding.
 ///
 /// The `CompressedBitmap` is used to efficiently store sequences of bits where
 /// runs of 1s and 0s are encoded to save space, using Elias Gamma encoding which consists of two


### PR DESCRIPTION
In an effort to understand the bitmap implementation, I've added documentation comments. Let me know if it's incorrect!