### PR TITLE
fix: Support array values for queries and string type for inserts

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -12,20 +12,20 @@ First, download the bos-loader cli by following this guide [here](https://docs.n
 From the root of QueryAPI Frontend repo, run the following command
 
 ```bash
-yarn serve:widgets:local // for running local enviornment 
-yarn serve:widgets:dev // for running dev enviornment 
-yarn serve:widgets:prod // for running prod enviornment 
+npm run serve:widgets:local // for running local enviornment 
+npm run serve:widgets:dev // for running dev enviornment 
+npm run serve:widgets:prod // for running prod enviornment 
 ```
 > Near.org or any other BOS gateway queries the blockchain state to pull the latest widgets code and renders it. If we would like to test our BOS widgets, we need to override the path at which the gateway (near.org) queries for the widget code. We do this using the Bos-loader tool (the underlying CLI tool used in the `yarn serve:widgets:dev` command) which allows us to serve out widgets locally (http://127.0.0.1:3030 by default). ** This command replaces all keys found in `replacement.dev.json` object with the their values in the widgets directory when serving the widgets **.  At this point, we have served our widgets locally but have not yet told the BOS gateway (near.org) where to load our local widgets from. 
 
 
-**Then, Head to `near.org/flags` and enter `http://127.0.0.1:3030`**
+**Then, Head to `dev.near.org/flags` and enter `http://127.0.0.1:3030`**
 
 > In order to tell our BOS gateway (near.org), where to load the local widgets from, we head to `near.org/flags` and enter the local path we got from running the previous command. If you have not changed any configurations then the default should be `http://127.0.0.1:3030`
 
 **Finally**, run the following to serve the local NextJS frontend
 ```bash
-yarn dev
+npm dev
 ```
 
 **Now, head to the path where the widgets are served on the BOS.**

--- a/frontend/replacement.dev.json
+++ b/frontend/replacement.dev.json
@@ -1,6 +1,6 @@
 {
     "REPL_ACCOUNT_ID": "dev-queryapi.dataplatform.near",
     "REPL_GRAPHQL_ENDPOINT": "https://near-queryapi.dev.api.pagoda.co",
-    "REPL_EXTERNAL_APP_URL": "http://localhost:3000",
+    "REPL_EXTERNAL_APP_URL": "https://queryapi-frontend-vcqilefdcq-ew.a.run.app",
     "REPL_REGISTRY_CONTRACT_ID": "dev-queryapi.dataplatform.near"
 }

--- a/frontend/replacement.dev.json
+++ b/frontend/replacement.dev.json
@@ -1,6 +1,6 @@
 {
     "REPL_ACCOUNT_ID": "dev-queryapi.dataplatform.near",
     "REPL_GRAPHQL_ENDPOINT": "https://near-queryapi.dev.api.pagoda.co",
-    "REPL_EXTERNAL_APP_URL": "https://queryapi-frontend-vcqilefdcq-ew.a.run.app",
+    "REPL_EXTERNAL_APP_URL": "http://localhost:3000",
     "REPL_REGISTRY_CONTRACT_ID": "dev-queryapi.dataplatform.near"
 }

--- a/frontend/src/utils/pgSchemaTypeGen.js
+++ b/frontend/src/utils/pgSchemaTypeGen.js
@@ -273,8 +273,8 @@ export class PgSchemaTypeGen {
       // UUID type
       uuid: 'string',
       // JSON types
-      json: 'any',
-      jsonb: 'any',
+      json: 'string | any',
+      jsonb: 'string | any',
       // Arrays
       'integer[]': 'number[]',
       'text[]': 'string[]',

--- a/frontend/src/utils/pgSchemaTypeGen.js
+++ b/frontend/src/utils/pgSchemaTypeGen.js
@@ -204,6 +204,7 @@ export class PgSchemaTypeGen {
 
       tableList.add(sanitizedTableName);
 
+      let queryDefinition = `declare interface ${sanitizedTableName}Query {\n`;
       let itemDefinition = `declare interface ${sanitizedTableName}Item {\n`;
       let inputDefinition = `declare interface ${sanitizedTableName}Input {\n`;
 
@@ -211,23 +212,25 @@ export class PgSchemaTypeGen {
         const tsType = columnDetails.nullable ? columnDetails.type + ' | null' : columnDetails.type;
         const optional = columnDetails.required ? '' : '?';
 
+        queryDefinition += `  ${columnName}?: ${tsType} | ${tsType}[];\n`
         itemDefinition += `  ${columnName}?: ${tsType};\n`;
         inputDefinition += `  ${columnName}${optional}: ${tsType};\n`;
       }
 
+      queryDefinition += '}\n\n';
       itemDefinition += '}\n\n';
       inputDefinition += '}\n\n';
       const columnNamesDef = `type ${sanitizedTableName}Columns = "${Object.keys(columns).join('" | "')}";\n\n`;
 
-      tsDefinitions += itemDefinition + inputDefinition + columnNamesDef;
+      tsDefinitions += queryDefinition + itemDefinition + inputDefinition + columnNamesDef;
 
       contextObject += `
                 ${sanitizedTableName}: {
                     insert: (objectsToInsert: ${sanitizedTableName}Input | ${sanitizedTableName}Input[]) => Promise<${sanitizedTableName}Item[]>;
-                    select: (filterObj: ${sanitizedTableName}Item, limit = null) => Promise<${sanitizedTableName}Item[]>;
-                    update: (filterObj: ${sanitizedTableName}Item, updateObj: ${sanitizedTableName}Item) => Promise<${sanitizedTableName}Item[]>;
+                    select: (filterObj: ${sanitizedTableName}Query, limit = null) => Promise<${sanitizedTableName}Item[]>;
+                    update: (filterObj: ${sanitizedTableName}Query, updateObj: ${sanitizedTableName}Item) => Promise<${sanitizedTableName}Item[]>;
                     upsert: (objectsToInsert: ${sanitizedTableName}Input | ${sanitizedTableName}Input[], conflictColumns: ${sanitizedTableName}Columns[], updateColumns: ${sanitizedTableName}Columns[]) => Promise<${sanitizedTableName}Item[]>;
-                    delete: (filterObj: ${sanitizedTableName}Item) => Promise<${sanitizedTableName}Item[]>;
+                    delete: (filterObj: ${sanitizedTableName}Query) => Promise<${sanitizedTableName}Item[]>;
                 },`;
     }
 
@@ -255,18 +258,18 @@ export class PgSchemaTypeGen {
       char: 'string',
       text: 'string',
       // Binary data types
-      bytea: 'Buffer',
+      bytea: 'Buffer | string',
       // Boolean type
-      boolean: 'boolean',
+      boolean: 'boolean | string',
       // Date/Time types
-      timestamp: 'Date',
-      'timestamp without time zone': 'Date',
-      'timestamp with time zone': 'Date',
-      date: 'Date',
-      time: 'Date',
-      'time without time zone': 'Date',
-      'time with time zone': 'Date',
-      interval: 'Date',
+      timestamp: 'Date | string',
+      'timestamp without time zone': 'Date | string',
+      'timestamp with time zone': 'Date | string',
+      date: 'Date | string',
+      time: 'Date | string',
+      'time without time zone': 'Date | string',
+      'time with time zone': 'Date | string',
+      interval: 'Date | string',
       // UUID type
       uuid: 'string',
       // JSON types


### PR DESCRIPTION
Context DB in the frontend was showing an error for inserts and select. For inserts, some types such as `date` would expect `Date` type when string type also works. I updated the type gen to allow string type input for these options. This ensures string or number input is acceptable for essentially all types. 
<img width="955" alt="image" src="https://github.com/near/queryapi/assets/22734869/3dd9ae4b-fa95-44de-824e-b026c525c5d1">


In addition, selection queries allow for array input to match muliple values for a certain column. However, the frontend was not updated to accept this input. I've added a new interface called Query which allows for array values in input objects. 
![Uploading image.png…]()
