### PR TITLE
fix: Do not eat bitmap backfill errors

### DIFF
--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -286,6 +286,7 @@ async fn process_bitmap_indexer_blocks(
                     "Backfill using bitmap indexer failed unexpectedly: {:?}",
                     err
                 );
+                break;
             }
         }
     }

--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -269,7 +269,7 @@ async fn process_bitmap_indexer_blocks(
 
     let mut last_published_block_height: u64 = start_block_height;
 
-    while let Some(Ok(block_height)) = matching_block_heights.next().await {
+    while let Some(block_height) = matching_block_heights.next().await.transpose()? {
         redis
             .publish_block(indexer, redis_stream.clone(), block_height, MAX_STREAM_SIZE)
             .await?;


### PR DESCRIPTION
If the stream yielding block heights from the bitmap indexer fails, its error will be eaten by the while loop as the loop will simply end if any error takes place. This PR ensures that if the result from the stream is an error, it logs the error before proceeding with Lake. 