### PR TITLE
fix: fetch BOS indexerdata from near RPC call and conditionally render metadata if available in databricks

### DIFF
--- a/frontend/widgets/src/QueryApi.IndexerCard.jsx
+++ b/frontend/widgets/src/QueryApi.IndexerCard.jsx
@@ -1,9 +1,7 @@
 const { accountId, indexerName, lastDeploymentDate, numDeployements, numQueries, originalDeploymentDate } = props;
-const editUrl = `https://dev.near.org/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}`;
-const statusUrl = `https://dev.near.org/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}&view=indexer&activeIndexerView=status`;
+const editUrl = `https://dev.near.org/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId.replaceAll("_", ".")}/${indexerName}`;
 const playgroundLink = `https://cloud.hasura.io/public/graphiql?endpoint=${REPL_GRAPHQL_ENDPOINT}/v1/graphql&header=x-hasura-role%3A${accountId.replace(/\./g, '_')}`;
 const formatNumberWithCommas = (number) => number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-
 const Card = styled.div`
   position: relative;
   width: 100%;
@@ -183,6 +181,7 @@ return (
       >
         View Indexer
       </ButtonLink>
+      {editUrl}
     </CardFooter>
   </Card>
 );

--- a/frontend/widgets/src/QueryApi.IndexerCard.jsx
+++ b/frontend/widgets/src/QueryApi.IndexerCard.jsx
@@ -88,11 +88,11 @@ const Text = styled.p`
   margin: 0;
   font-size: 14px;
   line-height: 20px;
-  // color: ${(p) => (p.bold ? "#11181C" : "#687076")};
-  // font-weight: ${(p) => (p.bold ? "600" : "400")};
-  // font-size: ${(p) => (p.small ? "12px" : "14px")};
-  // overflow: ${(p) => (p.ellipsis ? "hidden" : "")};
-  // text-overflow: ${(p) => (p.ellipsis ? "ellipsis" : "")};
+  color: ${(p) => (p.bold ? "#11181C" : "#687076")};
+  font-weight: ${(p) => (p.bold ? "600" : "400")};
+  font-size: ${(p) => (p.small ? "12px" : "14px")};
+  overflow: ${(p) => (p.ellipsis ? "hidden" : "")};
+  text-overflow: ${(p) => (p.ellipsis ? "ellipsis" : "")};
   white-space: nowrap;
 
   i {

--- a/frontend/widgets/src/QueryApi.IndexerCard.jsx
+++ b/frontend/widgets/src/QueryApi.IndexerCard.jsx
@@ -2,6 +2,7 @@ const { accountId, indexerName, lastDeploymentDate, numDeployements, numQueries,
 const editUrl = `https://dev.near.org/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId.replaceAll("_", ".")}/${indexerName}`;
 const playgroundLink = `https://cloud.hasura.io/public/graphiql?endpoint=${REPL_GRAPHQL_ENDPOINT}/v1/graphql&header=x-hasura-role%3A${accountId.replace(/\./g, '_')}`;
 const formatNumberWithCommas = (number) => number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+
 const Card = styled.div`
   position: relative;
   width: 100%;
@@ -181,7 +182,6 @@ return (
       >
         View Indexer
       </ButtonLink>
-      {editUrl}
     </CardFooter>
   </Card>
 );

--- a/frontend/widgets/src/QueryApi.IndexerCard.jsx
+++ b/frontend/widgets/src/QueryApi.IndexerCard.jsx
@@ -1,5 +1,6 @@
 const { accountId, indexerName, lastDeploymentDate, numDeployements, numQueries, originalDeploymentDate } = props;
-const editUrl = `https://dev.near.org/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId.replaceAll("_", ".")}/${indexerName}`;
+const accountIdName = accountId.replaceAll("_", ".");
+const editUrl = `https://dev.near.org/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountIdName}/${indexerName}`;
 const playgroundLink = `https://cloud.hasura.io/public/graphiql?endpoint=${REPL_GRAPHQL_ENDPOINT}/v1/graphql&header=x-hasura-role%3A${accountId.replace(/\./g, '_')}`;
 const formatNumberWithCommas = (number) => number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 
@@ -161,7 +162,7 @@ return (
           {indexerName}
         </TextLink>
         <TextLink as="a" ellipsis>
-          @{accountId}
+          @{accountIdName}
         </TextLink>
         <Text>{formatNumberWithCommas(numQueries)} Queries in the past 7 days</Text>
       </div>

--- a/frontend/widgets/src/QueryApi.IndexerCard.jsx
+++ b/frontend/widgets/src/QueryApi.IndexerCard.jsx
@@ -1,6 +1,14 @@
-const { accountId, indexerName, lastDeploymentDate, numDeployements, numQueries, originalDeploymentDate } = props;
-const accountIdName = accountId.replaceAll("_", ".");
-const editUrl = `https://dev.near.org/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountIdName}/${indexerName}`;
+const { accountId, indexerName, indexerMetadata } = props;
+const sanitizedAccountID = accountId.replace(/\./g, '_');
+const key = `${sanitizedAccountID}/${indexerName}`;
+
+const indexer = {
+  accountId,
+  indexerName,
+  ...(indexerMetadata.has(key) && indexerMetadata.get(key))
+};
+
+const editUrl = `https://dev.near.org/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}`;
 const playgroundLink = `https://cloud.hasura.io/public/graphiql?endpoint=${REPL_GRAPHQL_ENDPOINT}/v1/graphql&header=x-hasura-role%3A${accountId.replace(/\./g, '_')}`;
 const formatNumberWithCommas = (number) => number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 
@@ -80,11 +88,11 @@ const Text = styled.p`
   margin: 0;
   font-size: 14px;
   line-height: 20px;
-  color: ${(p) => (p.bold ? "#11181C" : "#687076")};
-  font-weight: ${(p) => (p.bold ? "600" : "400")};
-  font-size: ${(p) => (p.small ? "12px" : "14px")};
-  overflow: ${(p) => (p.ellipsis ? "hidden" : "")};
-  text-overflow: ${(p) => (p.ellipsis ? "ellipsis" : "")};
+  // color: ${(p) => (p.bold ? "#11181C" : "#687076")};
+  // font-weight: ${(p) => (p.bold ? "600" : "400")};
+  // font-size: ${(p) => (p.small ? "12px" : "14px")};
+  // overflow: ${(p) => (p.ellipsis ? "hidden" : "")};
+  // text-overflow: ${(p) => (p.ellipsis ? "ellipsis" : "")};
   white-space: nowrap;
 
   i {
@@ -162,9 +170,15 @@ return (
           {indexerName}
         </TextLink>
         <TextLink as="a" ellipsis>
-          @{accountIdName}
+          @{accountId}
         </TextLink>
-        <Text>{formatNumberWithCommas(numQueries)} Queries in the past 7 days</Text>
+        {indexer.numQueries >= 0 && (
+          <Text>
+            {indexer.numQueries > 999
+              ? `${formatNumberWithCommas(indexer.numQueries)} Queries in the past 7 days`
+              : `${indexer.numQueries} Queries in the past 7 days`}
+          </Text>
+        )}
       </div>
     </CardBody>
 
@@ -175,11 +189,6 @@ return (
       <ButtonLink
         primary
         href={editUrl}
-        onClick={() =>
-          State.update({
-            activeTab: "editor",
-          })
-        }
       >
         View Indexer
       </ButtonLink>

--- a/frontend/widgets/src/QueryApi.IndexerExplorer.jsx
+++ b/frontend/widgets/src/QueryApi.IndexerExplorer.jsx
@@ -37,7 +37,7 @@ const fetchIndexerData = () => {
         });
       });
 
-      setMyIndexers([myIndexers]);
+      setMyIndexers(myIndexers);
       setAllIndexers(allIndexers);
       setError(null);
     })

--- a/frontend/widgets/src/QueryApi.IndexerExplorer.jsx
+++ b/frontend/widgets/src/QueryApi.IndexerExplorer.jsx
@@ -1,12 +1,31 @@
-const accountId = context.accountId;
-const santizedAccountId = accountId.replaceAll(".", "_");
+const myAccountId = context.accountId;
 
 const [selectedTab, setSelectedTab] = useState(props.tab && props.tab !== "all" ? props.tab : "all");
 const [myIndexers, setMyIndexers] = useState([]);
 const [allIndexers, setAllIndexers] = useState([]);
 const [error, setError] = useState(null);
+const [indexerMetadata, setIndexerMetaData] = useState(new Map());
 
 const fetchIndexerData = () => {
+  Near.asyncView(`${REPL_REGISTRY_CONTRACT_ID}`, "list_all").then((data) => {
+    const allIndexers = [];
+    const myIndexers = [];
+    Object.keys(data).forEach((accId) => {
+      Object.keys(data[accId]).forEach((functionName) => {
+        const indexer = {
+          accountId: accId,
+          indexerName: functionName,
+        };
+        if (accId === myAccountId) myIndexers.push(indexer);
+        allIndexers.push(indexer);
+      });
+    });
+    setMyIndexers(myIndexers);
+    setAllIndexers(allIndexers);
+  });
+}
+
+const storeIndexerMetaData = () => {
   const url = `${REPL_QUERY_API_USAGE_URL}`;
 
   asyncFetch(url)
@@ -16,12 +35,10 @@ const fetchIndexerData = () => {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
       const { data } = JSON.parse(response.body);
-      const allIndexers = [];
-      const myIndexers = [];
+      const map = new Map();
 
       data.forEach(entry => {
         const { indexer_account_id, indexers } = entry;
-
         indexers.forEach(({ indexer_name, last_deployment_date, num_deployements, num_queries, original_deployment_date }) => {
           const indexer = {
             accountId: indexer_account_id,
@@ -31,21 +48,17 @@ const fetchIndexerData = () => {
             numQueries: num_queries,
             originalDeploymentDate: original_deployment_date
           };
-
-          if (indexer_account_id === santizedAccountId) myIndexers.push(indexer);
-          allIndexers.push(indexer);
+          map.set(`${indexer_account_id}/${indexer_name}`, indexer);
         });
       });
-
-      setMyIndexers(myIndexers);
-      setAllIndexers(allIndexers);
+      setIndexerMetaData(map);
       setError(null);
     })
 }
 
-
 useEffect(() => {
   fetchIndexerData();
+  storeIndexerMetaData();
 }, []);
 
 const Wrapper = styled.div`
@@ -243,7 +256,7 @@ return (
             <Item key={i}>
               <Widget
                 src={`${REPL_ACCOUNT_ID}/widget/QueryApi.IndexerCard`}
-                props={{ ...indexer }}
+                props={{ ...indexer, indexerMetadata }}
               />
             </Item>
           ))}
@@ -271,7 +284,7 @@ return (
             <Item key={i}>
               <Widget
                 src={`${REPL_ACCOUNT_ID}/widget/QueryApi.IndexerCard`}
-                props={{ ...indexer }}
+                props={{ ...indexer, indexerMetadata }}
               />
             </Item>
           ))}


### PR DESCRIPTION
BOS component data is fetched from NEAR RPC call 'list_all'. We use a map to set a k/v pair for indexer metadata recieved on databricks. When we render each card we check the map to see if the indexer to be rendered from NEAR RPC exist in the map. If it does exist we conditionally render metadata.