### PR TITLE
feat: Expose health info from Block Stream/Executor RPC

### DIFF
--- a/block-streamer/proto/block_streamer.proto
+++ b/block-streamer/proto/block_streamer.proto
@@ -108,4 +108,18 @@ message StreamInfo {
     string function_name = 4;
     // Block height corresponding to the created/updated height of the indexer
     uint64 version = 5;
+    // Health
+    Health health = 6;
+}
+
+message Health {
+    ProcessingState processing_state = 1;
+}
+
+enum ProcessingState {
+    UNSPECIFIED = 0;
+    IDLE = 1;
+    ACTIVE = 2;
+    PAUSED = 3;
+    HALTED = 4;
 }

--- a/block-streamer/proto/block_streamer.proto
+++ b/block-streamer/proto/block_streamer.proto
@@ -114,6 +114,7 @@ message StreamInfo {
 
 message Health {
     ProcessingState processing_state = 1;
+    uint64 updated_at_timestamp_secs = 2;
 }
 
 enum ProcessingState {

--- a/block-streamer/proto/block_streamer.proto
+++ b/block-streamer/proto/block_streamer.proto
@@ -120,7 +120,7 @@ message Health {
 enum ProcessingState {
     UNSPECIFIED = 0;
     IDLE = 1;
-    ACTIVE = 2;
+    RUNNING = 2;
     PAUSED = 3;
-    HALTED = 4;
+    STALLED = 4;
 }

--- a/block-streamer/proto/block_streamer.proto
+++ b/block-streamer/proto/block_streamer.proto
@@ -108,19 +108,26 @@ message StreamInfo {
     string function_name = 4;
     // Block height corresponding to the created/updated height of the indexer
     uint64 version = 5;
-    // Health
+    // Contains health information for the Block Stream
     Health health = 6;
 }
 
+// Contains health information for the Block Stream
 message Health {
+    // The processing state of the block stream
     ProcessingState processing_state = 1;
+    // When the health info was last updated
     uint64 updated_at_timestamp_secs = 2;
 }
 
 enum ProcessingState {
     UNSPECIFIED = 0;
+    // Not started, or has been stopped
     IDLE = 1;
+    // Running as expected
     RUNNING = 2;
+    // Intentionally paused due to some internal condition
     PAUSED = 3;
+    // Stopped due to some unknown error
     STALLED = 4;
 }

--- a/block-streamer/proto/block_streamer.proto
+++ b/block-streamer/proto/block_streamer.proto
@@ -126,8 +126,8 @@ enum ProcessingState {
     IDLE = 1;
     // Running as expected
     RUNNING = 2;
-    // Intentionally paused due to some internal condition
-    PAUSED = 3;
+    // Waiting for some internal condition to be met before continuing
+    WAITING = 3;
     // Stopped due to some unknown error
     STALLED = 4;
 }

--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -139,12 +139,12 @@ impl BlockStream {
                             tracing::error!(
                                 account_id = config.account_id.as_str(),
                                 function_name = config.function_name,
-                                "Last processed block decreased"
+                                "Last processed block should not decrease"
                             );
 
                             health.lock().unwrap().processing_state = ProcessingState::Halted;
                         }
-                        Ordering::Equal if stream_size == Some(MAX_STREAM_SIZE) => {
+                        Ordering::Equal if stream_size >= Some(MAX_STREAM_SIZE) => {
                             health.lock().unwrap().processing_state = ProcessingState::Paused;
                         }
                         Ordering::Equal => {

--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -167,6 +167,7 @@ impl BlockStream {
 
 #[allow(clippy::too_many_arguments)]
 #[tracing::instrument(
+    name = "block_stream"
     skip_all,
     fields(
         account_id = indexer.account_id.as_str(),

--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -67,15 +67,15 @@ pub enum ProcessingState {
     Idle,
 
     /// Block Stream is actively processing blocks.
-    Active,
+    Running,
 
     /// Block Stream has been intentionally/internally paused due to some condition, i.e. back pressure on
     /// the Redis Stream.
     Paused,
 
-    /// Block Stream has been halted due to an error or other condition. Must be manually
+    /// Block Stream has stalled due to an error or other condition. Must be manually
     /// restarted.
-    Halted,
+    Stalled,
 }
 
 #[derive(Clone)]
@@ -177,16 +177,16 @@ impl BlockStream {
                                 "Last processed block should not decrease"
                             );
 
-                            health_lock.processing_state = ProcessingState::Halted;
+                            health_lock.processing_state = ProcessingState::Stalled;
                         }
                         Ordering::Equal if stream_size >= Some(MAX_STREAM_SIZE) => {
                             health_lock.processing_state = ProcessingState::Paused;
                         }
                         Ordering::Equal => {
-                            health_lock.processing_state = ProcessingState::Halted;
+                            health_lock.processing_state = ProcessingState::Stalled;
                         }
                         Ordering::Greater => {
-                            health_lock.processing_state = ProcessingState::Active;
+                            health_lock.processing_state = ProcessingState::Running;
                         }
                     };
 

--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -71,7 +71,7 @@ pub enum ProcessingState {
 
     /// Block Stream has been intentionally/internally paused due to some condition, i.e. back pressure on
     /// the Redis Stream.
-    Paused,
+    Waiting,
 
     /// Block Stream has stalled due to an error or other condition. Must be manually
     /// restarted.
@@ -180,7 +180,7 @@ impl BlockStream {
                             health_lock.processing_state = ProcessingState::Stalled;
                         }
                         Ordering::Equal if stream_size >= Some(MAX_STREAM_SIZE) => {
-                            health_lock.processing_state = ProcessingState::Paused;
+                            health_lock.processing_state = ProcessingState::Waiting;
                         }
                         Ordering::Equal => {
                             health_lock.processing_state = ProcessingState::Stalled;

--- a/block-streamer/src/server/block_streamer_service.rs
+++ b/block-streamer/src/server/block_streamer_service.rs
@@ -26,12 +26,12 @@ impl From<block_stream::BlockStreamHealth> for blockstreamer::Health {
     fn from(health: block_stream::BlockStreamHealth) -> Self {
         blockstreamer::Health {
             processing_state: match health.processing_state {
-                block_stream::ProcessingState::Active => {
-                    blockstreamer::ProcessingState::Active as i32
+                block_stream::ProcessingState::Running => {
+                    blockstreamer::ProcessingState::Running as i32
                 }
                 block_stream::ProcessingState::Idle => blockstreamer::ProcessingState::Idle as i32,
-                block_stream::ProcessingState::Halted => {
-                    blockstreamer::ProcessingState::Halted as i32
+                block_stream::ProcessingState::Stalled => {
+                    blockstreamer::ProcessingState::Stalled as i32
                 }
                 block_stream::ProcessingState::Paused => {
                     blockstreamer::ProcessingState::Paused as i32

--- a/block-streamer/src/server/block_streamer_service.rs
+++ b/block-streamer/src/server/block_streamer_service.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Mutex;
+use std::time::SystemTime;
 
 use near_lake_framework::near_indexer_primitives;
 use tonic::{Request, Response, Status};
@@ -36,6 +37,11 @@ impl From<block_stream::BlockStreamHealth> for blockstreamer::Health {
                     blockstreamer::ProcessingState::Paused as i32
                 }
             },
+            updated_at_timestamp_secs: health
+                .last_updated
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
         }
     }
 }

--- a/block-streamer/src/server/block_streamer_service.rs
+++ b/block-streamer/src/server/block_streamer_service.rs
@@ -33,8 +33,8 @@ impl From<block_stream::BlockStreamHealth> for blockstreamer::Health {
                 block_stream::ProcessingState::Stalled => {
                     blockstreamer::ProcessingState::Stalled as i32
                 }
-                block_stream::ProcessingState::Paused => {
-                    blockstreamer::ProcessingState::Paused as i32
+                block_stream::ProcessingState::Waiting => {
+                    blockstreamer::ProcessingState::Waiting as i32
                 }
             },
             updated_at_timestamp_secs: health

--- a/runner-client/proto/runner.proto
+++ b/runner-client/proto/runner.proto
@@ -62,7 +62,26 @@ message ExecutorInfo {
     string executor_id = 1;
     string account_id = 2;
     string function_name = 3;
-    string status = 4;
     // Block height corresponding to the created/updated height of the indexer
     uint64 version = 5;
+    Health health = 6;
+}
+
+// Contains health information for the Executor
+message Health {
+    ExecutionState execution_state = 1;
+}
+
+enum ExecutionState {
+    UNSPECIFIED = 0;
+    // Running as expected
+    RUNNING = 1;
+    // Executor is running, but the execution is erroring
+    FAILING = 2;
+    // Waiting for some internal condition to be met before proceeding
+    WAITING = 3;
+    // Intentionally stopped
+    STOPPED = 4;
+    // Unintentionally stopped
+    STALLED = 5;
 }

--- a/runner/examples/list-executors.ts
+++ b/runner/examples/list-executors.ts
@@ -1,13 +1,13 @@
 // Run with 'npx ts-node src/test-client.ts'
 
-import runnerClient from '../src/server/runner-client';
+import runnerClient from '../src/server/services/runner/runner-client';
 
 void (async function main () {
   runnerClient.ListExecutors({}, (err, response) => {
     if (err) {
       console.error('List request error: ', err);
     } else {
-      console.log('Successful ListExecutors request: ', response);
+      console.log('list response: ', JSON.stringify({ response }, null, 2));
     }
   });
 })();

--- a/runner/examples/start-executor.ts
+++ b/runner/examples/start-executor.ts
@@ -1,6 +1,6 @@
 // Run with 'npx ts-node src/test-client.ts'
 
-import runnerClient from '../src/server/runner-client';
+import runnerClient from '../src/server/services/runner/runner-client';
 
 const schema = `
 CREATE TABLE
@@ -13,7 +13,7 @@ CREATE TABLE
 `;
 
 const code = `
-console.log("hello");
+// do nothing
 `;
 
 const indexer = {
@@ -35,7 +35,7 @@ void (async function main () {
     if (err) {
       console.error('error: ', err);
     } else {
-      console.log('start request: ', response);
+      console.log('start response: ', JSON.stringify({ response }, null, 2));
     }
   });
 })();

--- a/runner/examples/stop-executor.ts
+++ b/runner/examples/stop-executor.ts
@@ -1,13 +1,13 @@
 // Run with 'npx ts-node src/test-client.ts'
 
-import runnerClient from '../src/server/runner-client';
+import runnerClient from '../src/server/services/runner/runner-client';
 
 runnerClient.StopExecutor({
-  executorId: 'SOME_EXECUTOR_ID'
+  executorId: '0293a6b1dcd2259a8be6b59a8cd3e7b4285e540a64a7cbe99639947f7b7e2f9a'
 }, (err, response) => {
   if (err) {
     console.error('error: ', err);
   } else {
-    console.log('stop request: ', response);
+    console.log('stop request: ', JSON.stringify({ response }, null, 2));
   }
 });

--- a/runner/protos/runner.proto
+++ b/runner/protos/runner.proto
@@ -62,7 +62,26 @@ message ExecutorInfo {
     string executor_id = 1;
     string account_id = 2;
     string function_name = 3;
-    string status = 4;
     // Block height corresponding to the created/updated height of the indexer
     uint64 version = 5;
+    Health health = 6;
+}
+
+// Contains health information for the Executor
+message Health {
+    ExecutionState execution_state = 1;
+}
+
+enum ExecutionState {
+    UNSPECIFIED = 0;
+    // Running as expected
+    RUNNING = 1;
+    // Executor is running, but the execution is erroring
+    FAILING = 2;
+    // Waiting for some internal condition to be met before proceeding
+    WAITING = 3;
+    // Intentionally stopped
+    STOPPED = 4;
+    // Unintentionally stopped
+    STALLED = 5;
 }

--- a/runner/src/server/services/runner/runner-service.test.ts
+++ b/runner/src/server/services/runner/runner-service.test.ts
@@ -1,10 +1,10 @@
 import * as grpc from '@grpc/grpc-js';
 
 import type StreamHandler from '../../../stream-handler/stream-handler';
-import { IndexerStatus } from '../../../indexer-meta/indexer-meta';
 import { LogLevel } from '../../../indexer-meta/log-entry';
 import getRunnerService from './runner-service';
 import IndexerConfig from '../../../indexer-config/indexer-config';
+import { ExecutionState } from '../../../generated/runner/ExecutionState';
 
 const BASIC_REDIS_STREAM = 'test-redis-stream';
 const BASIC_ACCOUNT_ID = 'test-account-id';
@@ -15,7 +15,7 @@ const BASIC_CODE = 'test-code';
 const BASIC_SCHEMA = 'test-schema';
 const BASIC_VERSION = 1;
 const BASIC_EXECUTOR_CONTEXT = {
-  status: IndexerStatus.RUNNING,
+  executionState: ExecutionState.RUNNING,
 };
 
 describe('Runner gRPC Service', () => {
@@ -77,8 +77,10 @@ describe('Runner gRPC Service', () => {
           executorId: BASIC_EXECUTOR_ID,
           accountId: genericIndexerConfig.accountId,
           functionName: genericIndexerConfig.functionName,
-          status: IndexerStatus.RUNNING,
-          version: '1'
+          version: '1',
+          health: {
+            executionState: 'RUNNING'
+          }
         });
         resolve(null);
       });
@@ -288,8 +290,10 @@ describe('Runner gRPC Service', () => {
             executorId: BASIC_EXECUTOR_ID,
             accountId: genericIndexerConfig.accountId,
             functionName: genericIndexerConfig.functionName,
-            status: IndexerStatus.RUNNING,
-            version: '1'
+            version: '1',
+            health: {
+              executionState: 'RUNNING'
+            }
           }]
         });
         resolve(null);

--- a/runner/src/server/services/runner/runner-service.ts
+++ b/runner/src/server/services/runner/runner-service.ts
@@ -32,7 +32,9 @@ export function getRunnerService (
           accountId: executor.indexerConfig.accountId,
           functionName: executor.indexerConfig.functionName,
           version: executor.indexerConfig.version.toString(),
-          status: executor.executorContext.status
+          health: {
+            executionState: executor.executorContext.executionState,
+          }
         });
       } else {
         const notFoundError = {
@@ -150,7 +152,9 @@ export function getRunnerService (
             accountId: indexerConfig.accountId,
             functionName: indexerConfig.functionName,
             version: indexerConfig.version.toString(),
-            status: indexerContext.status
+            health: {
+              executionState: indexerContext.executionState,
+            }
           });
         });
         callback(null, {


### PR DESCRIPTION
This PR exposes a `health` field on the Block Stream/Executor info, which can be accessed via RPC. The intent of this field is for Coordinator to monitor it, and then act accordingly. I wanted to raise this work first, so that the overall result is not too large.

Essentially, `health` contains only a single `enum` describing the "state" of the process, but this can be expanded over time as needed.