### PR TITLE
refactor: Fetch Database Connection Parameters in Stream Handler

### DIFF
--- a/runner-client/examples/start_executor.rs
+++ b/runner-client/examples/start_executor.rs
@@ -9,15 +9,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = client
         .start_executor(Request::new(StartExecutorRequest {
-            account_id: "test_account".to_string(),
-            function_name: "test_indexer".to_string(),
-            code: "console.log('hi');".to_string(),
+            account_id: "account_near".to_string(),
+            function_name: "sample_indexer".to_string(),
+            code: " 
+                console.log('Hello, world!');
+                await context.db.IndexerStorage.insert({
+                    \"function_name\": \"sample_indexer\",
+                    \"key_name\": block.blockHeight.toString(),
+                    \"value\": \"Hello, world!\"
+                });
+            "
+            .to_string(),
             schema: "CREATE TABLE \"indexer_storage\" (
                         \"function_name\" TEXT NOT NULL,
                         \"key_name\" TEXT NOT NULL,
                         \"value\" TEXT NOT NULL,
                         PRIMARY KEY (\"function_name\", \"key_name\")
-                    );".to_string(),
+                    );"
+            .to_string(),
             redis_stream: "test:stream".to_string(),
             version: 123,
         }))

--- a/runner/src/server/services/runner/runner-service.test.ts
+++ b/runner/src/server/services/runner/runner-service.test.ts
@@ -26,6 +26,7 @@ describe('Runner gRPC Service', () => {
     genericStreamHandlerType = jest.fn().mockImplementation((indexerConfig) => {
       return {
         indexerConfig,
+        start: jest.fn().mockResolvedValue(null),
         stop: jest.fn(),
       };
     });
@@ -168,11 +169,14 @@ describe('Runner gRPC Service', () => {
   });
 
   it('stops a executor with correct settings', (done) => {
+    const start = jest.fn().mockImplementation(async () => {
+      await Promise.resolve();
+    });
     const stop = jest.fn().mockImplementation(async () => {
       await Promise.resolve();
     });
     const streamHandlerType = jest.fn().mockImplementation((indexerConfig) => {
-      return { stop, indexerConfig };
+      return { start, stop, indexerConfig };
     });
     const service = getRunnerService(new Map(), streamHandlerType);
     const mockCallback = jest.fn() as unknown as any;
@@ -195,11 +199,14 @@ describe('Runner gRPC Service', () => {
   });
 
   it('Invalid stop executor request with empty executor Id', () => {
+    const start = jest.fn().mockImplementation(async () => {
+      await Promise.resolve();
+    });
     const stop = jest.fn().mockImplementation(async () => {
       await Promise.resolve();
     });
     const streamHandlerType = jest.fn().mockImplementation(() => {
-      return { stop };
+      return { start, stop };
     });
     const service = getRunnerService(new Map(), streamHandlerType);
     const mockCallback = jest.fn() as unknown as any;
@@ -215,11 +222,14 @@ describe('Runner gRPC Service', () => {
   });
 
   it('Invalid stop executor request with non-existent executor', (done) => {
+    const start = jest.fn().mockImplementation(async () => {
+      await Promise.resolve();
+    });
     const stop = jest.fn().mockImplementation(async () => {
       await Promise.resolve();
     });
     const streamHandlerType = jest.fn().mockImplementation(() => {
-      return { stop };
+      return { start, stop };
     });
     const service = getRunnerService(new Map(), streamHandlerType);
 
@@ -235,11 +245,14 @@ describe('Runner gRPC Service', () => {
   });
 
   it('Invalid stop executor request with somehow failing stop', (done) => {
+    const start = jest.fn().mockImplementation(async () => {
+      await Promise.resolve();
+    });
     const stop = jest.fn().mockImplementation(async () => {
       await Promise.reject(new Error('somehow fails'));
     });
     const streamHandlerType = jest.fn().mockImplementation((indexerConfig) => {
-      return { stop, indexerConfig };
+      return { start, stop, indexerConfig };
     });
     const service = getRunnerService(new Map(), streamHandlerType);
     const mockCallback = jest.fn() as unknown as any;
@@ -262,11 +275,15 @@ describe('Runner gRPC Service', () => {
   });
 
   it('valid list executor request lists executors correctly, with stopped indexer', async () => {
+    const start = jest.fn().mockImplementation(async () => {
+      await Promise.resolve();
+    });
     const stop = jest.fn().mockImplementation(async () => {
       await Promise.resolve();
     });
     const streamHandlerType = jest.fn().mockImplementation((indexerConfig) => {
       return {
+        start,
         stop,
         indexerConfig,
         executorContext: BASIC_EXECUTOR_CONTEXT

--- a/runner/src/server/services/runner/runner-service.ts
+++ b/runner/src/server/services/runner/runner-service.ts
@@ -14,6 +14,7 @@ import { type StopExecutorResponse__Output, type StopExecutorResponse } from '..
 import { type ListExecutorsRequest__Output } from '../../../generated/runner/ListExecutorsRequest';
 import { type ListExecutorsResponse__Output, type ListExecutorsResponse } from '../../../generated/runner/ListExecutorsResponse';
 import { type ExecutorInfo__Output } from '../../../generated/runner/ExecutorInfo';
+import { type ExecutionState__Output } from '../../../generated/runner/ExecutionState';
 
 export function getRunnerService (
   executors: Map<string, StreamHandler> = new Map<string, StreamHandler>(),
@@ -33,7 +34,7 @@ export function getRunnerService (
           functionName: executor.indexerConfig.functionName,
           version: executor.indexerConfig.version.toString(),
           health: {
-            executionState: executor.executorContext.executionState,
+            executionState: executor.executorContext.executionState as ExecutionState__Output
           }
         });
       } else {
@@ -156,7 +157,7 @@ export function getRunnerService (
             functionName: indexerConfig.functionName,
             version: indexerConfig.version.toString(),
             health: {
-              executionState: indexerContext.executionState,
+              executionState: indexerContext.executionState as ExecutionState__Output
             }
           });
         });

--- a/runner/src/server/services/runner/runner-service.ts
+++ b/runner/src/server/services/runner/runner-service.ts
@@ -79,6 +79,9 @@ export function getRunnerService (
         const streamHandler = new StreamHandlerType(indexerConfig);
         executors.set(indexerConfig.executorId, streamHandler);
         callback(null, { executorId: indexerConfig.executorId });
+        streamHandler.start().catch((error: Error) => {
+          logger.error('Failed to start executor', error);
+        });
       } catch (e) {
         const error = e as Error;
 

--- a/runner/src/stream-handler/stream-handler.ts
+++ b/runner/src/stream-handler/stream-handler.ts
@@ -23,12 +23,13 @@ export interface WorkerMessage {
 }
 
 export enum ExecutionState {
-  IDLE = 'IDLE',
+  UNSPECIFIED = 'UNSPECIFIED',
   RUNNING = 'RUNNING',
   FAILING = 'FAILING',
   WAITING = 'WAITING',
   STOPPED = 'STOPPED',
   STALLED = 'STALLED',
+  IDLE = 'IDLE',
 }
 
 interface ExecutorContext {

--- a/runner/src/stream-handler/stream-handler.ts
+++ b/runner/src/stream-handler/stream-handler.ts
@@ -7,11 +7,13 @@ import LogEntry from '../indexer-meta/log-entry';
 import logger from '../logger';
 
 import type IndexerConfig from '../indexer-config';
+import { PostgresConnectionParams } from '../pg-client';
 
 export enum WorkerMessageType {
-  METRICS = 'METRICS',
-  BLOCK_HEIGHT = 'BLOCK_HEIGHT',
-  EXECUTION_STATE = 'STATUS',
+  METRICS,
+  BLOCK_HEIGHT,
+  STATUS,
+  DATABASE_CONNECTION_PARAMS,
 }
 
 export interface WorkerMessage {
@@ -36,8 +38,9 @@ export default class StreamHandler {
   private readonly logger: typeof logger;
   private readonly worker: Worker;
   public readonly executorContext: ExecutorContext;
+  private database_connection_parameters: PostgresConnectionParams | undefined;
 
-  constructor (
+  constructor(
     public readonly indexerConfig: IndexerConfig,
   ) {
     if (isMainThread) {
@@ -60,7 +63,7 @@ export default class StreamHandler {
     }
   }
 
-  async stop (): Promise<void> {
+  async stop(): Promise<void> {
     deregisterWorkerMetrics(this.worker.threadId);
 
     this.executorContext.executionState = ExecutionState.STOPPED;
@@ -68,28 +71,32 @@ export default class StreamHandler {
     await this.worker.terminate();
   }
 
-  private handleError (error: Error): void {
+  private handleError(error: Error): void {
     this.logger.error('Terminating thread', error);
     this.executorContext.executionState = ExecutionState.STALLED;
 
-    const indexer = new Indexer(this.indexerConfig);
-    indexer.setStoppedStatus().catch((e) => {
-      this.logger.error('Failed to set stopped status for indexer', e);
-    });
-    const errorContent = error instanceof Error ? error.toString() : JSON.stringify(error);
-    const streamErrorLogEntry = LogEntry.systemError(`Encountered error processing stream: ${this.indexerConfig.redisStreamKey}, terminating thread\n${errorContent}`, this.executorContext.block_height);
-
-    indexer.writeCrashedWorkerLog(streamErrorLogEntry)
-      .catch((e) => {
-        this.logger.error('Failed to write failure log for stream', e);
+    if (this.database_connection_parameters) {
+      const indexerMeta = new IndexerMeta(this.indexerConfig, this.database_connection_parameters);
+      indexerMeta.setStatus(IndexerStatus.STOPPED).catch((e) => {
+        this.logger.error('Failed to set stopped status for indexer', e);
       });
+      const errorContent = error instanceof Error ? error.toString() : JSON.stringify(error);
+      const streamErrorLogEntry = LogEntry.systemError(`Encountered error processing stream: ${this.indexerConfig.redisStreamKey}, terminating thread\n${errorContent}`, this.executorContext.block_height);
+
+      indexerMeta.writeLogs([streamErrorLogEntry])
+        .catch((e) => {
+          this.logger.error('Failed to write failure log for stream', e);
+        });
+    } else {
+      this.logger.error('Worker crashed but was unable to write crash log to Indexer logs due to failure to acquire DB Connection Parameters');
+    }
 
     this.worker.terminate().catch(() => {
       this.logger.error('Failed to terminate thread for stream');
     });
   }
 
-  private handleMessage (message: WorkerMessage): void {
+  private handleMessage(message: WorkerMessage): void {
     switch (message.type) {
       case WorkerMessageType.EXECUTION_STATE:
         this.executorContext.executionState = message.data.state;
@@ -97,6 +104,8 @@ export default class StreamHandler {
       case WorkerMessageType.BLOCK_HEIGHT:
         this.executorContext.block_height = message.data;
         break;
+      case WorkerMessageType.DATABASE_CONNECTION_PARAMS:
+        this.database_connection_parameters = message.data;
       case WorkerMessageType.METRICS:
         registerWorkerMetrics(this.worker.threadId, message.data);
         break;

--- a/runner/src/stream-handler/stream-handler.ts
+++ b/runner/src/stream-handler/stream-handler.ts
@@ -23,6 +23,7 @@ export interface WorkerMessage {
 }
 
 export enum ExecutionState {
+  IDLE = 'IDLE',
   RUNNING = 'RUNNING',
   FAILING = 'FAILING',
   WAITING = 'WAITING',
@@ -47,7 +48,7 @@ export default class StreamHandler {
     this.logger = logger.child({ accountId: indexerConfig.accountId, functionName: indexerConfig.functionName, service: this.constructor.name });
 
     this.executorContext = {
-      executionState: ExecutionState.WAITING,
+      executionState: ExecutionState.IDLE,
       block_height: indexerConfig.version,
     };
   }
@@ -77,7 +78,7 @@ export default class StreamHandler {
         throw new Error(`Failed to start Indexer: ${errorContent}`);
       }
     } else {
-      throw new Error('StreamHandler should not be instantiated in a worker thread');
+      throw new Error('StreamHandler should not be started in a worker thread');
     }
   }
 

--- a/runner/src/stream-handler/stream-handler.ts
+++ b/runner/src/stream-handler/stream-handler.ts
@@ -6,8 +6,7 @@ import LogEntry from '../indexer-meta/log-entry';
 import logger from '../logger';
 
 import type IndexerConfig from '../indexer-config';
-import type IndexerMeta from '../indexer-meta';
-import { IndexerStatus } from '../indexer-meta';
+import IndexerMeta, { IndexerStatus } from '../indexer-meta';
 import assert from 'assert';
 import Provisioner from '../provisioner';
 import { type PostgresConnectionParams } from '../pg-client';
@@ -40,7 +39,7 @@ export default class StreamHandler {
   private readonly logger: typeof logger;
   private worker: Worker | undefined;
   public readonly executorContext: ExecutorContext;
-  private readonly indexerMeta: IndexerMeta | undefined;
+  private indexerMeta: IndexerMeta | undefined;
 
   constructor (
     public readonly indexerConfig: IndexerConfig,
@@ -58,6 +57,8 @@ export default class StreamHandler {
       try {
         const provisioner = new Provisioner();
         const databaseConnectionParams: PostgresConnectionParams = await provisioner.getPgBouncerConnectionParameters(this.indexerConfig.hasuraRoleName());
+
+        this.indexerMeta = new IndexerMeta(this.indexerConfig, databaseConnectionParams);
         this.worker = new Worker(path.join(__dirname, 'worker.js'), {
           workerData: {
             indexerConfigData: this.indexerConfig.toObject(),

--- a/runner/src/stream-handler/worker.ts
+++ b/runner/src/stream-handler/worker.ts
@@ -9,9 +9,13 @@ import { METRICS } from '../metrics';
 import LakeClient from '../lake-client';
 import { WorkerMessageType, type WorkerMessage, ExecutionState } from './stream-handler';
 import setUpTracerExport from '../instrumentation';
+import IndexerMeta, { IndexerStatus } from '../indexer-meta/indexer-meta';
 import IndexerConfig from '../indexer-config';
 import parentLogger from '../logger';
 import { wrapSpan } from '../utility';
+import Provisioner from '../provisioner';
+import { PostgresConnectionParams } from '../pg-client';
+import DmlHandler from '../dml-handler/dml-handler';
 
 if (isMainThread) {
   throw new Error('Worker should not be run on main thread');
@@ -36,7 +40,7 @@ const sleep = async (ms: number): Promise<void> => { await new Promise((resolve)
 setUpTracerExport();
 const tracer = trace.getTracer('queryapi-runner-worker');
 
-void (async function main () {
+void (async function main() {
   const indexerConfig: IndexerConfig = IndexerConfig.fromObject(workerData.indexerConfigData);
   const logger = parentLogger.child({
     service: 'StreamHandler/worker',
@@ -57,12 +61,12 @@ void (async function main () {
   await handleStream(workerContext);
 })();
 
-async function handleStream (workerContext: WorkerContext): Promise<void> {
+async function handleStream(workerContext: WorkerContext): Promise<void> {
   void blockQueueProducer(workerContext);
   void blockQueueConsumer(workerContext);
 }
 
-async function blockQueueProducer (workerContext: WorkerContext): Promise<void> {
+async function blockQueueProducer(workerContext: WorkerContext): Promise<void> {
   const HISTORICAL_BATCH_SIZE = parseInt(process.env.PREFETCH_QUEUE_LIMIT ?? '10');
   let streamMessageStartId = '0';
 
@@ -92,10 +96,23 @@ async function blockQueueProducer (workerContext: WorkerContext): Promise<void> 
   }
 }
 
-async function blockQueueConsumer (workerContext: WorkerContext): Promise<void> {
+async function blockQueueConsumer(workerContext: WorkerContext): Promise<void> {
   let previousError: string = '';
   const indexerConfig: IndexerConfig = workerContext.indexerConfig;
-  const indexer = new Indexer(indexerConfig);
+  let database_connection_parameters: PostgresConnectionParams;
+  try {
+    const provisioner = new Provisioner();
+    database_connection_parameters = await provisioner.getPgBouncerConnectionParameters(this.indexerConfig.hasuraRoleName());
+    parentPort?.postMessage({ type: WorkerMessageType.DATABASE_CONNECTION_PARAMS, data: database_connection_parameters });
+  } catch (e) {
+    const error = e as Error;
+    workerContext.logger.error(`Failed to get database connection parameters: ${error.message}`);
+    throw error;
+  }
+
+  const dmlHandler: DmlHandler = new DmlHandler(database_connection_parameters, indexerConfig);
+  const indexerMeta: IndexerMeta = new IndexerMeta(indexerConfig, database_connection_parameters);
+  const indexer = new Indexer(indexerConfig, { dmlHandler, indexerMeta });
   let streamMessageId = '';
   let currBlockHeight = 0;
 
@@ -190,7 +207,7 @@ async function blockQueueConsumer (workerContext: WorkerContext): Promise<void> 
   }
 }
 
-async function generateQueuePromise (workerContext: WorkerContext, blockHeight: number, streamMessageId: string): Promise<QueueMessage> {
+async function generateQueuePromise(workerContext: WorkerContext, blockHeight: number, streamMessageId: string): Promise<QueueMessage> {
   const block = await workerContext.lakeClient.fetchBlock(blockHeight).catch((err) => {
     workerContext.logger.error(`Error fetching block ${blockHeight}`, err);
     return undefined;

--- a/runner/src/stream-handler/worker.ts
+++ b/runner/src/stream-handler/worker.ts
@@ -102,7 +102,7 @@ async function blockQueueConsumer(workerContext: WorkerContext): Promise<void> {
   let database_connection_parameters: PostgresConnectionParams;
   try {
     const provisioner = new Provisioner();
-    database_connection_parameters = await provisioner.getPgBouncerConnectionParameters(this.indexerConfig.hasuraRoleName());
+    database_connection_parameters = await provisioner.getPgBouncerConnectionParameters(indexerConfig.hasuraRoleName());
     parentPort?.postMessage({ type: WorkerMessageType.DATABASE_CONNECTION_PARAMS, data: database_connection_parameters });
   } catch (e) {
     const error = e as Error;


### PR DESCRIPTION
Due to our migration of Provisioning logic to a separate API in Runner, we can expect that an Indexers resources will be initialized before we reach the point of executing blocks. So, it is no longer necessary to lazy init DmlHandler or IndexerMeta due to not having the connection parameters at the time of class initialization. Worker can poll for these params before even beginning to execute any blocks. This also continues to simplify both the code and behavior of the execute function. 