### PR TITLE
feat: Add metric for receiver block backfill failures

### DIFF
--- a/block-streamer/src/graphql/client.rs
+++ b/block-streamer/src/graphql/client.rs
@@ -57,6 +57,12 @@ impl GraphQLClientImpl {
             .json(&body)
             .send()
             .await?;
+        if reqwest_response.status() != 200 {
+            tracing::error!(
+                "GraphQL query failed with status code: {}",
+                reqwest_response.status()
+            );
+        }
 
         reqwest_response.json().await
     }

--- a/block-streamer/src/metrics.rs
+++ b/block-streamer/src/metrics.rs
@@ -63,6 +63,12 @@ lazy_static! {
         &["indexer"]
     )
     .unwrap();
+    pub static ref RECEIVER_BLOCKS_FAILURE: IntGaugeVec = register_int_gauge_vec!(
+        "queryapi_block_streamer_receiver_blocks_failure",
+        "Gauge which only has a nonzero value if an error occurs during receiver block backfill",
+        &["indexer"]
+    )
+    .unwrap();
 }
 
 pub struct LogCounter;


### PR DESCRIPTION
Adds a metric for tracking receiver block backfill status. Since the backfill has an end state, I can't rely on constantly incrementing a counter. Instead, I use a gauge and check for non zero values. If the backfill starts and completes without issue, the value will be 0. But, if the backfill fails, it will increment the gauge and then skip to Lake backfill, leaving the gauge at a nonzero value. We can alert on this. If the stream is restarted, then a successful attempt at the backfill will reset the gauge to 0. 