### PR TITLE
feat: explorers page indexer to find most popular indexers (desc)

### DIFF
--- a/frontend/replacement.mainnet.json
+++ b/frontend/replacement.mainnet.json
@@ -1,7 +1,7 @@
 {
     "REPL_ACCOUNT_ID": "dataplatform.near",
     "REPL_GRAPHQL_ENDPOINT": "https://near-queryapi.api.pagoda.co",
-    "REPL_EXTERNAL_APP_URL": "https://queryapi-frontend-24ktefolwq-ew.a.run.app",
+    "REPL_EXTERNAL_APP_URL": "http://localhost:3000",
     "REPL_REGISTRY_CONTRACT_ID": "queryapi.dataplatform.near",
     "REPL_QUERY_API_USAGE_URL": "https://storage.googleapis.com/databricks-near-query-runner/output/query-api-usage/indexers.json"
 }

--- a/frontend/replacement.mainnet.json
+++ b/frontend/replacement.mainnet.json
@@ -1,7 +1,7 @@
 {
     "REPL_ACCOUNT_ID": "dataplatform.near",
     "REPL_GRAPHQL_ENDPOINT": "https://near-queryapi.api.pagoda.co",
-    "REPL_EXTERNAL_APP_URL": "http://localhost:3000",
+    "REPL_EXTERNAL_APP_URL": "https://queryapi-frontend-24ktefolwq-ew.a.run.app",
     "REPL_REGISTRY_CONTRACT_ID": "queryapi.dataplatform.near",
     "REPL_QUERY_API_USAGE_URL": "https://storage.googleapis.com/databricks-near-query-runner/output/query-api-usage/indexers.json"
 }

--- a/frontend/widgets/src/QueryApi.IndexerCard.jsx
+++ b/frontend/widgets/src/QueryApi.IndexerCard.jsx
@@ -1,15 +1,12 @@
-const { accountId, indexerName, indexerMetadata } = props;
-const sanitizedAccountID = accountId.replace(/\./g, '_');
-const key = `${sanitizedAccountID}/${indexerName}`;
+const { accountId, indexerName, numQueries } = props;
 
 const indexer = {
   accountId,
   indexerName,
-  ...(indexerMetadata.has(key) && indexerMetadata.get(key))
+  numQueries,
 };
 
 const editUrl = `https://dev.near.org/${REPL_ACCOUNT_ID}/widget/QueryApi.App?selectedIndexerPath=${accountId}/${indexerName}`;
-
 const playgroundLink = `https://cloud.hasura.io/public/graphiql?endpoint=${REPL_GRAPHQL_ENDPOINT}/v1/graphql&header=x-hasura-role%3A${accountId.replace(/\./g, '_')}`;
 const formatNumberWithCommas = (number) => number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 

--- a/frontend/widgets/src/QueryApi.IndexerExplorer.jsx
+++ b/frontend/widgets/src/QueryApi.IndexerExplorer.jsx
@@ -34,18 +34,17 @@ query getMyActiveIndexers($authorAccountId: String!) {
 `;
 
 const [selectedTab, setSelectedTab] = useState(props.tab && props.tab !== "all" ? props.tab : "all");
+const [indexerMetaData, setIndexerMetaData] = useState(new Map());
+const [hasMetadataRendered, setHasMetadataRendered] = useState(false);
 
 const [indexers, setIndexers] = useState([]);
 const [total, setTotal] = useState(0);
 const [currentPageIndexer, setCurrentPageIndexer] = useState([]);
+const [page, setPage] = useState(0);
 
 const [myIndexers, setMyIndexers] = useState([]);
-const [indexerMetaData, setIndexerMetaData] = useState(new Map());
-const [page, setPage] = useState(0);
-const [hasMetadataRendered, setHasMetadataRendered] = useState(false);
 
 const [loading, setLoading] = useState(false);
-const [isLoadingMore, setIsLoadingMore] = useState(false);
 const [error, setError] = useState(null);
 
 const fetchGraphQL = (operationsDoc, operationName, variables) => {
@@ -84,6 +83,7 @@ const fetchIndexerData = () => {
         const sortedIndexers = newIndexers.sort((a, b) => (b.numQueries ?? 0) - (a.numQueries ?? 0));
         setTotal(totalCount);
         setIndexers(sortedIndexers);
+        setCurrentPageIndexer(sortedIndexers.slice(0, PAGE_SIZE));
       } else {
         throw new Error('Data is not an array:', data);
       }
@@ -620,10 +620,9 @@ return (
                 </Item>
               ))}
             </Items>
-            {isLoadingMore && <LoadingSpinner />}
             <LoadMoreContainer>
-              <Button onClick={handleLoadMore}>
-                Load More
+              <Button onClick={handleLoadMore} disabled={indexers.length <= currentPageIndexer.length}>
+                {indexers.length <= currentPageIndexer.length ? "No more indexers" : "Load More"}
               </Button>
             </LoadMoreContainer>
           </>


### PR DESCRIPTION
display indexers by numQueries Desc. 

**High level Approach:**
onLoad set metadata from databricks to local state. 
immediately after QueryAPI indexer grabs all results and any matching metadata there is from the above state and sets all data new state that has all indexer data.

pagination loads 50 and loads locally from all indexer data leading to an instant interaction and loading