### PR TITLE
fix: removed overwritting of indexername in obj

### DIFF
--- a/frontend/widgets/src/QueryApi.IndexerExplorer.jsx
+++ b/frontend/widgets/src/QueryApi.IndexerExplorer.jsx
@@ -158,7 +158,6 @@ const fetchIndexerMetadata = () => {
           original_deployment_date
         }) => {
           const indexer = {
-            indexerName: indexer_name,
             lastDeploymentDate: last_deployment_date,
             numDeployements: num_deployements,
             numQueries: num_queries,

--- a/frontend/widgets/src/QueryApi.IndexerExplorer.jsx
+++ b/frontend/widgets/src/QueryApi.IndexerExplorer.jsx
@@ -74,9 +74,9 @@ const fetchIndexerData = () => {
           const sanitizedAccountID = author_account_id.replace(/\./g, '_');
           const key = `${sanitizedAccountID}/${indexer_name}`;
           return ({
+            ...(indexerMetaData.has(key) && indexerMetaData.get(key)),
             accountId: author_account_id,
             indexerName: indexer_name,
-            ...(indexerMetaData.has(key) && indexerMetaData.get(key))
           })
         });
         // sort by numQueries
@@ -158,7 +158,6 @@ const fetchIndexerMetadata = () => {
           original_deployment_date
         }) => {
           const indexer = {
-            accountId: indexer_account_id,
             indexerName: indexer_name,
             lastDeploymentDate: last_deployment_date,
             numDeployements: num_deployements,


### PR DESCRIPTION
Databricks stores account and function names in their sanitized form (Only alphanumerics and underscores) as this is how they are stored in Hasura. However, the actual indexer and accounts are stored in both RPC and the queryapi_indexer under their original names. 

This PR prevents the metadata from databricks overwriting the original names with the sanitized ones. 