### PR TITLE
test: Test fetching indexer config from registry

### DIFF
--- a/.github/workflows/coordinator-ci.yml
+++ b/.github/workflows/coordinator-ci.yml
@@ -21,6 +21,13 @@ jobs:
       uses: arduino/setup-protoc@v2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.75.0
+        override: true
+        profile: minimal
+        components: rustfmt
     - name: Check
       working-directory: ./coordinator
       run: cargo check
@@ -33,6 +40,13 @@ jobs:
       uses: arduino/setup-protoc@v2
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.75.0
+        override: true
+        profile: minimal
+        components: rustfmt
     - name: Test
       working-directory: ./coordinator
       run: cargo test


### PR DESCRIPTION
Added tests for fetching individual indexer config from registry contract. This was mostly an exercise to understand the behaviour of parsing registry contract responses, as well as understanding the changes that were made recently. A thin wrapper (`JsonRpcClientWrapper`) has been created to allow mocking of the JSON RPC Client responses. 