### PR TITLE
test: Coodinator handlers

### DIFF
--- a/coordinator/src/handlers/block_streams.rs
+++ b/coordinator/src/handlers/block_streams.rs
@@ -186,7 +186,7 @@ impl BlockStreamsHandler {
         Ok(())
     }
 
-    async fn reconfigure_block_stream(&self, config: &IndexerConfig) -> anyhow::Result<()> {
+    async fn reconfigure(&self, config: &IndexerConfig) -> anyhow::Result<()> {
         if matches!(
             config.start_block,
             StartBlock::Latest | StartBlock::Height(..)
@@ -249,7 +249,7 @@ impl BlockStreamsHandler {
         Ok(height)
     }
 
-    async fn resume_block_stream(&self, config: &IndexerConfig) -> anyhow::Result<()> {
+    async fn resume(&self, config: &IndexerConfig) -> anyhow::Result<()> {
         let height = self.get_continuation_block_height(config).await?;
 
         tracing::info!(height, "Resuming block stream");
@@ -297,7 +297,7 @@ impl BlockStreamsHandler {
         Ok(())
     }
 
-    pub async fn synchronise_block_stream(
+    pub async fn synchronise(
         &self,
         config: &IndexerConfig,
         previous_sync_version: Option<u64>,
@@ -319,7 +319,7 @@ impl BlockStreamsHandler {
 
             self.stop(block_stream.stream_id.clone()).await?;
 
-            self.reconfigure_block_stream(config).await?;
+            self.reconfigure(config).await?;
 
             return Ok(());
         }
@@ -331,12 +331,12 @@ impl BlockStreamsHandler {
         }
 
         if previous_sync_version.unwrap() != config.get_registry_version() {
-            self.reconfigure_block_stream(config).await?;
+            self.reconfigure(config).await?;
 
             return Ok(());
         }
 
-        self.resume_block_stream(config).await?;
+        self.resume(config).await?;
 
         Ok(())
     }

--- a/coordinator/src/handlers/block_streams.rs
+++ b/coordinator/src/handlers/block_streams.rs
@@ -8,7 +8,7 @@ use anyhow::Context;
 use block_streamer::block_streamer_client::BlockStreamerClient;
 use block_streamer::{
     start_stream_request::Rule, ActionAnyRule, ActionFunctionCallRule, GetStreamRequest,
-    ListStreamsRequest, ProcessingState, StartStreamRequest, Status, StopStreamRequest,
+    ProcessingState, StartStreamRequest, Status, StopStreamRequest,
 };
 use near_primitives::types::AccountId;
 use registry_types::StartBlock;
@@ -39,24 +39,6 @@ impl BlockStreamsHandler {
             client,
             redis_client,
         })
-    }
-
-    pub async fn list(&self) -> anyhow::Result<Vec<StreamInfo>> {
-        exponential_retry(|| async {
-            let response = self
-                .client
-                .clone()
-                .list_streams(Request::new(ListStreamsRequest {}))
-                .await
-                .context("Failed to list streams")?;
-
-            let streams = response.into_inner().streams;
-
-            tracing::debug!("List streams response: {:#?}", streams);
-
-            Ok(streams)
-        })
-        .await
     }
 
     pub async fn stop(&self, stream_id: String) -> anyhow::Result<()> {

--- a/coordinator/src/handlers/executors.rs
+++ b/coordinator/src/handlers/executors.rs
@@ -177,7 +177,7 @@ impl ExecutorsHandler {
         Ok(())
     }
 
-    pub async fn synchronise_executor(&self, config: &IndexerConfig) -> anyhow::Result<()> {
+    pub async fn synchronise(&self, config: &IndexerConfig) -> anyhow::Result<()> {
         let executor = self
             .get(config.account_id.clone(), config.function_name.clone())
             .await?;

--- a/coordinator/src/lifecycle.rs
+++ b/coordinator/src/lifecycle.rs
@@ -135,7 +135,7 @@ impl<'a> LifecycleManager<'a> {
 
         state.block_stream_synced_at = Some(config.get_registry_version());
 
-        if let Err(error) = self.executors_handler.synchronise_executor(config).await {
+        if let Err(error) = self.executors_handler.synchronise(config).await {
             warn!(?error, "Failed to synchronise executor, retrying...");
 
             return LifecycleState::Running;

--- a/coordinator/src/lifecycle.rs
+++ b/coordinator/src/lifecycle.rs
@@ -125,7 +125,7 @@ impl<'a> LifecycleManager<'a> {
 
         if let Err(error) = self
             .block_streams_handler
-            .synchronise_block_stream(config, state.block_stream_synced_at)
+            .synchronise(config, state.block_stream_synced_at)
             .await
         {
             warn!(?error, "Failed to synchronise block stream, retrying...");


### PR DESCRIPTION
Adds tests for: `DataLayerHandler`, `BlockStreamsHandler`, and `ExecutorsHandler`. No functional changes, but I did need to extract/create internal client wrappers so that the RPC requests can be mocked.