### PR TITLE
fix: display issue in explorer indexers

### DIFF
--- a/frontend/replacement.dev.json
+++ b/frontend/replacement.dev.json
@@ -1,7 +1,7 @@
 {
     "REPL_ACCOUNT_ID": "dev-queryapi.dataplatform.near",
     "REPL_GRAPHQL_ENDPOINT": "https://near-queryapi.dev.api.pagoda.co",
-    "REPL_EXTERNAL_APP_URL": "http://localhost:3000",
+    "REPL_EXTERNAL_APP_URL": "https://queryapi-frontend-vcqilefdcq-ew.a.run.app",
     "REPL_REGISTRY_CONTRACT_ID": "dev-queryapi.dataplatform.near",
     "REPL_QUERY_API_USAGE_URL": "https://storage.googleapis.com/databricks-near-query-runner/output/query-api-usage/indexers_dev.json"
 }

--- a/frontend/replacement.dev.json
+++ b/frontend/replacement.dev.json
@@ -1,7 +1,7 @@
 {
     "REPL_ACCOUNT_ID": "dev-queryapi.dataplatform.near",
     "REPL_GRAPHQL_ENDPOINT": "https://near-queryapi.dev.api.pagoda.co",
-    "REPL_EXTERNAL_APP_URL": "https://queryapi-frontend-vcqilefdcq-ew.a.run.app",
+    "REPL_EXTERNAL_APP_URL": "http://localhost:3000",
     "REPL_REGISTRY_CONTRACT_ID": "dev-queryapi.dataplatform.near",
     "REPL_QUERY_API_USAGE_URL": "https://storage.googleapis.com/databricks-near-query-runner/output/query-api-usage/indexers_dev.json"
 }

--- a/frontend/widgets/src/QueryApi.Editor.jsx
+++ b/frontend/widgets/src/QueryApi.Editor.jsx
@@ -83,18 +83,16 @@ const requestHandler = (request, response) => {
   }
 };
 
-const props = {
-  externalAppUrl,
-  path,
-  initialViewHeight,
-  initialPayload,
-  requestHandler,
-};
-
 // NearSocialBridgeCore widget is the core that makes all the "magic" happens
 return (
   <Widget
     src={"wendersonpires.near/widget/NearSocialBridgeCore"}
-    props={props}
+    props={{
+      externalAppUrl,
+      path,
+      initialViewHeight,
+      initialPayload,
+      requestHandler,
+    }}
   />
 );

--- a/frontend/widgets/src/QueryApi.IndexerExplorer.jsx
+++ b/frontend/widgets/src/QueryApi.IndexerExplorer.jsx
@@ -40,7 +40,7 @@ const [hasMetadataRendered, setHasMetadataRendered] = useState(false);
 const [indexers, setIndexers] = useState([]);
 const [total, setTotal] = useState(0);
 const [currentPageIndexer, setCurrentPageIndexer] = useState([]);
-const [page, setPage] = useState(1);
+const [page, setPage] = useState(0);
 
 const [myIndexers, setMyIndexers] = useState([]);
 
@@ -188,11 +188,12 @@ useEffect(() => {
 }, [selectedTab, hasMetadataRendered]);
 
 const handleLoadMore = () => {
-  const start = page * PAGE_SIZE;
+  const nextPage = page + 1;
+  const start = nextPage * PAGE_SIZE;
   const end = start + PAGE_SIZE;
   const newIndexers = indexers.slice(start, end);
   setCurrentPageIndexer([...currentPageIndexer, ...newIndexers]);
-  setPage(page + 1);
+  setPage(nextPage);
 };
 
 const backupNearRPCRequest = () => {

--- a/frontend/widgets/src/QueryApi.IndexerExplorer.jsx
+++ b/frontend/widgets/src/QueryApi.IndexerExplorer.jsx
@@ -40,7 +40,7 @@ const [hasMetadataRendered, setHasMetadataRendered] = useState(false);
 const [indexers, setIndexers] = useState([]);
 const [total, setTotal] = useState(0);
 const [currentPageIndexer, setCurrentPageIndexer] = useState([]);
-const [page, setPage] = useState(0);
+const [page, setPage] = useState(1);
 
 const [myIndexers, setMyIndexers] = useState([]);
 


### PR DESCRIPTION
explore seems to be missing a few indexers and the reason was due to pagination starting from 0. so on load it would grab the intial 50 and then onclick for loadmore it would still grab the 0-50 already on display.

fix: changes page to intialize to 1. 

Initial Load (0-49) Indexers Loaded
First Click (page = 1): Loads indexers from 50 to 99.
Second Click (page = 2): Loads indexers from 100 to 149.
```
const handleLoadMore = () => {
  const start = page * PAGE_SIZE; // FIRST: 1*50 = 50 -> SECOND: 2*50 = 100
  const end = start + PAGE_SIZE; //  FIRST: 50+50 = 100 -> SECOND: 100+50 = 150
  const newIndexers = indexers.slice(start, end); // FIRST CLICK: 50-99 -> SECOND CLICK: 100-149
  setCurrentPageIndexer([...currentPageIndexer, ...newIndexers]); 
  // FIRST: 0-49 + 50-99, SECOND: 0-99 + 100 - 149
  setPage(page + 1); 
};
```