### PR TITLE
chore: Log non existant indexer responses

### DIFF
--- a/coordinator/src/registry.rs
+++ b/coordinator/src/registry.rs
@@ -250,6 +250,13 @@ impl RegistryImpl {
                     deleted_at_block_height: config.deleted_at_block_height,
                 }))
             } else {
+                tracing::info!(
+                    account_id = account_id.as_str(),
+                    function_name,
+                    "Received null config from registry: {:?}",
+                    String::from_utf8_lossy(&call_result.result)
+                );
+
                 Ok(None)
             };
         }


### PR DESCRIPTION
Recently, we erroneously encountered "Delete" lifecycle transitions. One suspect is RPC responses from the registry contract incorrectly being parsed as `None`. This PR logs any RPC response interpreted as `None` so we can confirm if this is the culprit.