### PR TITLE
fix: Decreasing Processed Block Error

### DIFF
--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -187,7 +187,7 @@ impl BlockStream {
                             health_lock.processing_state = ProcessingState::Waiting;
                         }
                         Ordering::Equal => {
-                            tracing::error!(
+                            tracing::warn!(
                                 account_id = config.account_id.as_str(),
                                 function_name = config.function_name,
                                 "No block has been processed for {stalled_timeout_seconds} seconds"
@@ -352,7 +352,7 @@ pub(crate) async fn start_block_stream(
     .context("Failed while fetching and streaming bitmap indexer blocks")?;
 
     let last_indexed_near_lake_block = process_near_lake_blocks(
-        last_bitmap_indexer_block + 1,
+        last_bitmap_indexer_block,
         lake_s3_client,
         lake_prefetch_size,
         redis,

--- a/block-streamer/src/block_stream.rs
+++ b/block-streamer/src/block_stream.rs
@@ -132,7 +132,7 @@ impl BlockStream {
             let stalled_timeout_seconds = 120;
 
             async move {
-                let mut last_processed_block = Some(start_block_height);
+                let mut last_processed_block = Some(start_block_height - 1);
                 loop {
                     tokio::time::sleep(std::time::Duration::from_secs(stalled_timeout_seconds))
                         .await;
@@ -352,7 +352,7 @@ pub(crate) async fn start_block_stream(
     .context("Failed while fetching and streaming bitmap indexer blocks")?;
 
     let last_indexed_near_lake_block = process_near_lake_blocks(
-        last_bitmap_indexer_block,
+        last_bitmap_indexer_block + 1,
         lake_s3_client,
         lake_prefetch_size,
         redis,


### PR DESCRIPTION
Block streams are failing due to their start block being lower than the current. This PR fixes this issue by seeding the health task with the input start block. This should fix the issue in most cases. I've also ensured that the handoff between receiver_blocks and lake also do not repeat a block. 