### PR TITLE
fix: Prevent conflicting provisioning requests

### DIFF
--- a/coordinator/src/handlers/data_layer.rs
+++ b/coordinator/src/handlers/data_layer.rs
@@ -88,6 +88,7 @@ impl DataLayerHandlerImpl {
     pub fn connect(runner_url: &str) -> anyhow::Result<Self> {
         let channel = Channel::from_shared(runner_url.to_string())
             .context("Runner URL is invalid")?
+            .rate_limit(1, std::time::Duration::from_secs(5))
             .connect_lazy();
         let client = DataLayerClient::new(channel);
 

--- a/coordinator/src/lifecycle.rs
+++ b/coordinator/src/lifecycle.rs
@@ -699,6 +699,8 @@ mod tests {
 
         #[tokio::test]
         async fn restarts_unhealthy_stream() {
+            tokio::time::pause();
+
             let config = IndexerConfig::default();
             let mut state = IndexerState {
                 lifecycle_state: LifecycleState::Running,
@@ -953,6 +955,8 @@ mod tests {
 
         #[tokio::test]
         async fn restarts_unhealthy_executor() {
+            tokio::time::pause();
+
             let config = IndexerConfig::default();
             let mut state = IndexerState {
                 lifecycle_state: LifecycleState::Running,


### PR DESCRIPTION
On fresh startup, all provisioning requests will be sent simultaneously. This creates problems when multiple requests for the same account are actioned in quick succession - both will attempt to create a virtual DB at the same time causing only one to succeed. The main driver for this is to make local development, especially on fresh install, less problematic.

This PR contains a simple fix to rate limit the provisioning requests from Coordinator to reduce the overlap between provisioning attempts, avoiding the problem described above. This does also rate limit get requests but they are infrequent so this shouldn't pose a problem.
