### PR TITLE
fix: Increment S3 Request Count on Success

### DIFF
--- a/block-streamer/src/lake_s3_client.rs
+++ b/block-streamer/src/lake_s3_client.rs
@@ -144,11 +144,11 @@ impl LakeS3Client {
         let prefix = prefix.to_owned();
 
         async move {
-            metrics::LAKE_S3_GET_REQUEST_COUNT.inc();
-
             let object = s3_client.get_object(&bucket, &prefix).await?;
 
             let bytes = object.body.collect().await?.into_bytes().to_vec();
+
+            metrics::LAKE_S3_GET_REQUEST_COUNT.inc();
 
             Ok(bytes)
         }


### PR DESCRIPTION
We were previously incrementing S3 request count in all cases. However, this was misleading as the metrics indicated a significantly higher amount of requests than expected, and the metric was being used as a proxy for cost of the service. Research indicated that many requests were in fact failing due to a dispatch error, shown below. 

`GetObjectBytesError(DispatchFailure(DispatchFailure { source: ConnectorError { kind: Io, source: hyper::Error(Connect, ConnectError("dns error", Custom { kind: Uncategorized, error: "failed to lookup address information: nodename nor servname provided, or not known" })), connection: Unknown } }))`

In order to more accurately gauge actual S3 usage by the service, I've changed the increment counter to occur below the S3 get request, so that only successful requests get counted. However, it was observed that this metric is somehow still inaccurate, reporting an inconsistent number compared to the actual requests made, which were verified through cache size and logs. Regardless, this should still be an improvement to the metric. 